### PR TITLE
fix(web): prevent path traversal in /api/file endpoint

### DIFF
--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -897,7 +897,10 @@ class FileServeHandler:
             file_path = params.path
             if not file_path or not os.path.isabs(file_path):
                 raise web.notfound()
-            file_path = os.path.normpath(file_path)
+            file_path = os.path.realpath(file_path)
+            allowed_dir = os.path.realpath(_get_upload_dir())
+            if not file_path.startswith(allowed_dir + os.sep) and file_path != allowed_dir:
+                raise web.notfound()
             if not os.path.isfile(file_path):
                 raise web.notfound()
             content_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"


### PR DESCRIPTION
## Vulnerability: Path Traversal in `/api/file` (CWE-22)

The `FileServeHandler.GET` method in `channel/web/web_channel.py` (line 884) serves files based on a user-supplied `path` query parameter. The existing validation uses `os.path.normpath()`, which normalizes `..` sequences but does not prevent the resolved path from escaping the intended directory. An authenticated user (or any user when `web_password` is not configured) can read arbitrary files from the server filesystem.

For example, if the upload directory is `/root/cow/tmp`, a request like `/api/file?path=/root/cow/tmp/../../../etc/passwd` normalizes to `/etc/passwd` and is served directly.

### Data flow

1. `web.input(path="")` reads user-controlled `path` parameter
2. `os.path.normpath(file_path)` normalizes but doesn't confine the path
3. `open(file_path, 'rb')` reads and returns the file contents

### Severity

Medium. Exploitation requires either localhost access (when no password is set — which is also the default) or a valid auth cookie. However, the default configuration prior to this PR binds to `0.0.0.0`, exposing the endpoint to the network. In shared hosting or SSRF scenarios, localhost access is insufficient protection.

## Proof of Concept

```bash
# Start CowAgent with default config (channel_type: web, no password)
# The server binds to 0.0.0.0:9899 by default

# Read /etc/passwd via path traversal:
curl "http://localhost:9899/api/file?path=/root/cow/tmp/../../../etc/passwd"

# Or with an absolute path outside the upload directory:
curl "http://localhost:9899/api/file?path=/etc/passwd"

# Both return the contents of /etc/passwd because normpath
# does not enforce directory confinement.
```

If `web_password` is set, first obtain a session cookie via `/api/auth/login`, then include `-b "cow_auth_token=<token>"` in the curl commands above.

## Fix description

**Path confinement** (the key change): Replace `os.path.normpath()` with `os.path.realpath()` and add a directory prefix check against the resolved upload directory. After the fix, only files physically inside the upload workspace (`_get_upload_dir()`) can be served:

```python
file_path = os.path.realpath(file_path)
allowed_dir = os.path.realpath(_get_upload_dir())
if not file_path.startswith(allowed_dir + os.sep) and file_path != allowed_dir:
    raise web.notfound()
```

`realpath` resolves all symlinks and `..` components to a canonical absolute path, and the `startswith` check ensures the result stays within the allowed directory. This is the standard mitigation for CWE-22 in Python.

**Defense in depth** (accompanying commits): The PR also changes the default bind address from `0.0.0.0` to `127.0.0.1` when no password is configured, and adds a `web_host` configuration option so operators can explicitly choose. This reduces the attack surface for default deployments. Frontend assets are vendored locally to remove CDN dependencies (unrelated to the vulnerability but bundled in this branch for the web channel improvements).

## Testing

- Verified that after the fix, requests with traversal sequences (`../../../etc/passwd`) return 404
- Verified that requests for files within the upload directory continue to work normally
- Verified that `os.path.realpath` correctly resolves symlinks, preventing symlink-based bypasses
- Verified the new `web_host` default binds to `127.0.0.1` when no password is set

## Adversarial review

Before submitting, we considered whether the existing `_require_auth()` call on `FileServeHandler.GET` would prevent exploitation. It does not in practice: when `web_password` is empty (the default), `_require_auth()` is a no-op that always passes. Even when a password is set, authenticated users should not have arbitrary filesystem read — the endpoint is intended to serve uploaded files only, not act as a general file server. We also verified that `os.path.normpath` genuinely does not prevent this; `normpath("/upload/../../../etc/passwd")` returns `"/etc/passwd"`.