### PR TITLE
feat(agent): add guarded cross-agent delegation

### DIFF
--- a/agent/chat/service.py
+++ b/agent/chat/service.py
@@ -406,9 +406,8 @@ class ChatService:
         ctx["agent_id"] = agent_id
         return ctx
 
-    @staticmethod
-    def _attach_context_aware_tools(agent, context):
-        """Attach the current context to tools that need it (scheduler)."""
+    def _attach_context_aware_tools(self, agent, context):
+        """Attach the current context to tools that need turn metadata."""
         try:
             if not (context and getattr(agent, "tools", None)):
                 return
@@ -416,7 +415,9 @@ class ChatService:
                 if tool.name == "scheduler":
                     from agent.tools.scheduler.integration import attach_scheduler_to_tool
                     attach_scheduler_to_tool(tool, context)
-                    break
+                elif tool.name == "agent_delegate":
+                    from agent.tools.agent_delegate.agent_delegate import attach_agent_delegate_to_tool
+                    attach_agent_delegate_to_tool(tool, self.agent_bridge, context)
         except Exception as e:
             logger.warning(f"[ChatService] Failed to attach context to scheduler: {e}")
 

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -17,6 +17,7 @@ from agent.tools.memory.memory_get import MemoryGetTool
 
 # Import self-evolution tools
 from agent.tools.evolution_undo.evolution_undo import EvolutionUndoTool
+from agent.tools.agent_delegate.agent_delegate import AgentDelegateTool
 
 # Import sub agent tools
 from agent.tools.subagent.subagent import SubagentTool
@@ -139,6 +140,7 @@ __all__ = [
     'MemoryGetTool',
     'EvolutionUndoTool',
     'SubagentTool',
+    'AgentDelegateTool',
     'EnvConfig',
     'SchedulerTool',
     'WebSearch',

--- a/agent/tools/agent_delegate/__init__.py
+++ b/agent/tools/agent_delegate/__init__.py
@@ -1,0 +1,5 @@
+"""Agent-to-agent delegation tool."""
+
+from .agent_delegate import AgentDelegateTool, DelegationPolicy
+
+__all__ = ["AgentDelegateTool", "DelegationPolicy"]

--- a/agent/tools/agent_delegate/agent_delegate.py
+++ b/agent/tools/agent_delegate/agent_delegate.py
@@ -1,0 +1,288 @@
+"""Guarded delegation between independently configured agent workspaces."""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+import uuid
+from dataclasses import dataclass
+from queue import Empty, Queue
+from typing import Mapping, Optional, Tuple
+
+from agent.tools.base_tool import BaseTool, ToolResult
+from bridge.context import Context, ContextType
+from bridge.reply import ReplyType
+from common.log import logger
+
+
+@dataclass(frozen=True)
+class DelegationPolicy:
+    enabled: bool = True
+    allowed_targets: Optional[Mapping[str, Tuple[str, ...]]] = None
+    max_depth: int = 3
+    timeout_seconds: float = 120.0
+    max_message_chars: int = 8000
+
+    @classmethod
+    def from_config(cls, raw) -> "DelegationPolicy":
+        if raw is False:
+            return cls(enabled=False)
+        if raw is None or raw is True:
+            raw = {}
+        if not isinstance(raw, Mapping):
+            raise ValueError("agent_delegation must be an object or boolean")
+
+        allow = raw.get("allowed_targets")
+        normalized = None
+        if allow is not None:
+            if not isinstance(allow, Mapping):
+                raise ValueError("allowed_targets must map source Agent IDs to lists")
+            normalized = {}
+            for source, targets in allow.items():
+                if not isinstance(source, str) or not isinstance(targets, (list, tuple)):
+                    raise ValueError("allowed_targets entries must contain lists")
+                if not all(isinstance(target, str) for target in targets):
+                    raise ValueError("allowed target IDs must be strings")
+                normalized[source] = tuple(targets)
+
+        max_depth = int(raw.get("max_depth", 3))
+        timeout_seconds = float(raw.get("timeout_seconds", 120))
+        max_message_chars = int(raw.get("max_message_chars", 8000))
+        if not 1 <= max_depth <= 8:
+            raise ValueError("max_depth must be between 1 and 8")
+        if not 0.01 <= timeout_seconds <= 600:
+            raise ValueError("timeout_seconds must be between 0.01 and 600")
+        if not 1 <= max_message_chars <= 100000:
+            raise ValueError("max_message_chars must be between 1 and 100000")
+        return cls(
+            enabled=bool(raw.get("enabled", True)),
+            allowed_targets=normalized,
+            max_depth=max_depth,
+            timeout_seconds=timeout_seconds,
+            max_message_chars=max_message_chars,
+        )
+
+    def allows(self, source_agent_id: str, target_agent_id: str) -> bool:
+        if not self.enabled:
+            return False
+        if self.allowed_targets is None:
+            return source_agent_id != target_agent_id
+        targets = self.allowed_targets.get(source_agent_id, ())
+        return "*" in targets or target_agent_id in targets
+
+
+_relay_locks = {}
+_relay_locks_guard = threading.Lock()
+
+
+def _relay_lock(session_id: str) -> threading.Lock:
+    with _relay_locks_guard:
+        return _relay_locks.setdefault(session_id, threading.Lock())
+
+
+class AgentDelegateTool(BaseTool):
+    """Ask another registered Agent to complete a bounded subtask."""
+
+    name = "agent_delegate"
+    description = (
+        "List available peer Agents or delegate a concrete subtask to one. Use "
+        "action='list' to discover targets. A delegated target runs in its own "
+        "workspace with its own memory, skills, sessions, and scheduler. Its "
+        "result is returned to you and is not sent directly to the user."
+    )
+    params = {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["list", "delegate"],
+                "description": "List available targets or delegate a task",
+                "default": "delegate",
+            },
+            "agent_id": {
+                "type": "string",
+                "description": "Target Agent ID for action='delegate'",
+            },
+            "task": {
+                "type": "string",
+                "description": "A self-contained task for the target Agent",
+            },
+        },
+        "required": [],
+    }
+
+    def __init__(self, config: dict = None):
+        self.config = config or {}
+        self.agent_bridge = None
+        self.current_context = None
+
+    def _policy(self) -> DelegationPolicy:
+        if self.config:
+            return DelegationPolicy.from_config(self.config)
+        from config import conf
+
+        return DelegationPolicy.from_config(conf().get("agent_delegation", {}))
+
+    @staticmethod
+    def _session_id(
+        source_agent_id: str, target_agent_id: str, root_session_id: str
+    ) -> str:
+        digest = hashlib.sha256(root_session_id.encode("utf-8")).hexdigest()[:16]
+        return f"delegate_{source_agent_id}_{target_agent_id}_{digest}"
+
+    def execute(self, params: dict) -> ToolResult:
+        if self.agent_bridge is None or self.current_context is None:
+            return ToolResult.fail("Agent delegation is not attached to this turn")
+
+        try:
+            policy = self._policy()
+        except (TypeError, ValueError) as exc:
+            return ToolResult.fail(f"Invalid delegation policy: {exc}")
+        if not policy.enabled:
+            return ToolResult.fail("Agent delegation is disabled")
+        context_values = dict(self.current_context.kwargs)
+        source_agent_id = context_values.get("agent_id")
+        if not source_agent_id:
+            return ToolResult.fail("Source Agent could not be resolved")
+        try:
+            source = self.agent_bridge.agent_registry.get(source_agent_id)
+        except (KeyError, ValueError):
+            return ToolResult.fail(f"Source Agent '{source_agent_id}' is not available")
+
+        action = params.get("action", "delegate")
+        if action == "list":
+            available = [
+                {"id": profile.id, "name": profile.name}
+                for profile in self.agent_bridge.agent_registry.list(
+                    include_disabled=False
+                )
+                if policy.allows(source.id, profile.id)
+            ]
+            return ToolResult.success({"source_agent_id": source.id, "agents": available})
+        if action != "delegate":
+            return ToolResult.fail(f"Unsupported delegation action: {action}")
+
+        target_agent_id = (params.get("agent_id") or "").strip()
+        task = (params.get("task") or "").strip()
+        if not target_agent_id or not task:
+            return ToolResult.fail("agent_id and task are required for delegation")
+        if len(task) > policy.max_message_chars:
+            return ToolResult.fail(
+                f"Delegated task exceeds {policy.max_message_chars} characters"
+            )
+        try:
+            target = self.agent_bridge.agent_registry.get(target_agent_id)
+        except (KeyError, ValueError):
+            return ToolResult.fail(f"Target Agent '{target_agent_id}' is not available")
+
+        raw_trace = context_values.get("delegation_trace") or (source.id,)
+        if not isinstance(raw_trace, (list, tuple)) or not all(
+            isinstance(item, str) for item in raw_trace
+        ):
+            return ToolResult.fail("Delegation trace is invalid")
+        trace = tuple(raw_trace)
+        if not trace or trace[-1] != source.id:
+            return ToolResult.fail("Delegation trace does not match the source Agent")
+        if target.id in trace:
+            return ToolResult.fail(
+                f"Delegation cycle rejected: {' -> '.join((*trace, target.id))}"
+            )
+        if not policy.allows(source.id, target.id):
+            return ToolResult.fail(
+                f"Agent '{source.id}' is not allowed to delegate to '{target.id}'"
+            )
+
+        depth = int(context_values.get("delegation_depth", len(trace) - 1)) + 1
+        if depth > policy.max_depth:
+            return ToolResult.fail(
+                f"Delegation depth {depth} exceeds the maximum {policy.max_depth}"
+            )
+
+        root_session_id = str(
+            context_values.get("delegation_root_session")
+            or context_values.get("session_id")
+            or uuid.uuid4()
+        )
+        session_id = self._session_id(source.id, target.id, root_session_id)
+        request_id = f"delegate_{uuid.uuid4().hex}"
+        delegated_context = Context(ContextType.TEXT, task, kwargs={})
+        delegated_context["session_id"] = session_id
+        delegated_context["request_id"] = request_id
+        delegated_context["receiver"] = target.id
+        delegated_context["isgroup"] = False
+        delegated_context["channel_type"] = "agent"
+        delegated_context["agent_id"] = target.id
+        delegated_context["is_delegated_task"] = True
+        delegated_context["delegated_by"] = source.id
+        delegated_context["delegation_depth"] = depth
+        delegated_context["delegation_trace"] = [*trace, target.id]
+        delegated_context["delegation_root_session"] = root_session_id
+
+        prompt = (
+            f"Delegated by Agent '{source.name}' ({source.id}).\n\n"
+            f"Task:\n{task}\n\n"
+            "Return a concise result to the delegating Agent. Do not address the user directly."
+        )
+        result_queue = Queue(maxsize=1)
+        lock = _relay_lock(session_id)
+
+        def run_target():
+            acquired = lock.acquire(timeout=policy.timeout_seconds)
+            if not acquired:
+                result_queue.put((False, "Target delegation session is busy"))
+                return
+            try:
+                reply = self.agent_bridge.agent_reply(
+                    prompt, context=delegated_context, on_event=None
+                )
+                result_queue.put((True, reply))
+            except Exception as exc:
+                result_queue.put((False, str(exc)))
+            finally:
+                lock.release()
+
+        threading.Thread(
+            target=run_target,
+            daemon=True,
+            name=f"agent-delegate-{source.id}-{target.id}",
+        ).start()
+        try:
+            ok, value = result_queue.get(timeout=policy.timeout_seconds)
+        except Empty:
+            from agent.protocol import get_cancel_registry
+
+            cancel_key = self.agent_bridge._cancel_key(
+                target.id,
+                request_id,
+                self.agent_bridge.agent_registry.default_agent_id,
+            )
+            get_cancel_registry().cancel_request(cancel_key)
+            logger.warning(
+                f"[AgentDelegate] Timed out source={source.id} target={target.id}"
+            )
+            return ToolResult.fail(
+                f"Delegation to '{target.id}' timed out after "
+                f"{policy.timeout_seconds:g} seconds"
+            )
+
+        if not ok:
+            return ToolResult.fail(f"Delegation to '{target.id}' failed: {value}")
+        if value.type == ReplyType.ERROR:
+            return ToolResult.fail(str(value.content))
+        return ToolResult.success(
+            {
+                "agent_id": target.id,
+                "agent_name": target.name,
+                "delegated_by": source.id,
+                "depth": depth,
+                "session_id": session_id,
+                "content": value.content,
+            }
+        )
+
+
+def attach_agent_delegate_to_tool(tool, agent_bridge, context: Context) -> None:
+    """Bind the current source turn and bridge to a delegation tool instance."""
+
+    tool.agent_bridge = agent_bridge
+    tool.current_context = context

--- a/bridge/agent_bridge.py
+++ b/bridge/agent_bridge.py
@@ -652,17 +652,21 @@ class AgentBridge:
                 filtered_tools = [tool for tool in agent.tools if tool.name != "scheduler"]
                 agent.tools = filtered_tools
                 logger.info(f"[AgentBridge] Scheduled task execution: excluded scheduler tool ({len(filtered_tools)}/{len(original_tools)} tools)")
-            else:
-                # Attach context to scheduler tool if present
-                if context and agent.tools:
-                    for tool in agent.tools:
-                        if tool.name == "scheduler":
-                            try:
-                                from agent.tools.scheduler.integration import attach_scheduler_to_tool
-                                attach_scheduler_to_tool(tool, context)
-                            except Exception as e:
-                                logger.warning(f"[AgentBridge] Failed to attach context to scheduler: {e}")
-                            break
+
+            if context and agent.tools:
+                for tool in agent.tools:
+                    if tool.name == "scheduler" and not context.get("is_scheduled_task"):
+                        try:
+                            from agent.tools.scheduler.integration import attach_scheduler_to_tool
+                            attach_scheduler_to_tool(tool, context)
+                        except Exception as e:
+                            logger.warning(f"[AgentBridge] Failed to attach context to scheduler: {e}")
+                    elif tool.name == "agent_delegate":
+                        try:
+                            from agent.tools.agent_delegate.agent_delegate import attach_agent_delegate_to_tool
+                            attach_agent_delegate_to_tool(tool, self, context)
+                        except Exception as e:
+                            logger.warning(f"[AgentBridge] Failed to attach delegation context: {e}")
             
             # Pass context metadata to model for downstream API requests
             if context and hasattr(agent, 'model'):
@@ -765,7 +769,10 @@ class AgentBridge:
             # scheduler-injected / scheduled-task sessions so internal runs do
             # not count as user activity.
             if session_id and not session_id.startswith("scheduler_") and not (
-                context and context.get("is_scheduled_task")
+                context and (
+                    context.get("is_scheduled_task")
+                    or context.get("is_delegated_task")
+                )
             ):
                 try:
                     from agent.evolution.trigger import note_user_turn

--- a/bridge/agent_initializer.py
+++ b/bridge/agent_initializer.py
@@ -379,6 +379,22 @@ class AgentInitializer:
                         logger.debug("[AgentInitializer] evolution_undo skipped - self-evolution disabled")
                         continue
 
+                if tool_name == "agent_delegate":
+                    delegation = conf().get("agent_delegation", {})
+                    enabled = delegation is not False and (
+                        not isinstance(delegation, dict)
+                        or delegation.get("enabled", True)
+                    )
+                    enabled_agents = self.agent_bridge.agent_registry.list(
+                        include_disabled=False
+                    )
+                    if not enabled or len(enabled_agents) < 2:
+                        logger.debug(
+                            "[AgentInitializer] agent_delegate skipped - "
+                            "requires at least two enabled Agents"
+                        )
+                        continue
+
                 # Special handling for EnvConfig tool
                 if tool_name == "env_config":
                     from agent.tools import EnvConfig

--- a/tests/test_agent_delegation.py
+++ b/tests/test_agent_delegation.py
@@ -1,0 +1,187 @@
+import threading
+import time
+
+from agent.protocol import get_cancel_registry
+from agent.registry import AgentProfile, AgentRegistry
+from agent.tools.agent_delegate.agent_delegate import (
+    AgentDelegateTool,
+    DelegationPolicy,
+    attach_agent_delegate_to_tool,
+)
+from bridge.context import Context, ContextType
+from bridge.reply import Reply, ReplyType
+
+
+def _registry(disable_research=False):
+    return AgentRegistry(
+        [
+            AgentProfile("primary", "Primary", "/tmp/delegate-primary"),
+            AgentProfile(
+                "research",
+                "Research",
+                "/tmp/delegate-research",
+                enabled=not disable_research,
+            ),
+        ],
+        "primary",
+    )
+
+
+def _context(agent_id="primary", session_id="user-session", **values):
+    context = Context(ContextType.TEXT, "source turn", kwargs={})
+    context["agent_id"] = agent_id
+    context["session_id"] = session_id
+    for key, value in values.items():
+        context[key] = value
+    return context
+
+
+class FakeBridge:
+    def __init__(self, registry=None):
+        self.agent_registry = registry or _registry()
+        self.calls = []
+
+    @staticmethod
+    def _cancel_key(agent_id, token, default_agent_id):
+        return token if agent_id == default_agent_id else f"{agent_id}::{token}"
+
+    def agent_reply(self, query, context=None, on_event=None):
+        self.calls.append((query, context, on_event))
+        return Reply(ReplyType.TEXT, "delegated result")
+
+
+def _tool(bridge=None, config=None, context=None):
+    tool = AgentDelegateTool(config=config)
+    attach_agent_delegate_to_tool(
+        tool,
+        bridge or FakeBridge(),
+        context or _context(),
+    )
+    return tool
+
+
+def test_policy_defaults_to_other_agents_and_honors_allowlist():
+    default = DelegationPolicy.from_config({})
+    assert default.allows("primary", "research") is True
+    assert default.allows("primary", "primary") is False
+
+    restricted = DelegationPolicy.from_config(
+        {"allowed_targets": {"primary": ["research"], "research": []}}
+    )
+    assert restricted.allows("primary", "research") is True
+    assert restricted.allows("research", "primary") is False
+
+
+def test_delegate_lists_only_enabled_allowed_targets():
+    tool = _tool(config={"allowed_targets": {"primary": ["research"]}})
+
+    result = tool.execute({"action": "list"})
+
+    assert result.status == "success"
+    assert result.result == {
+        "source_agent_id": "primary",
+        "agents": [{"id": "research", "name": "Research"}],
+    }
+
+
+def test_delegate_runs_target_with_source_attribution_and_private_relay_session():
+    bridge = FakeBridge()
+    tool = _tool(bridge=bridge)
+
+    result = tool.execute({"agent_id": "research", "task": "Check the evidence"})
+
+    assert result.status == "success"
+    assert result.result["agent_id"] == "research"
+    assert result.result["delegated_by"] == "primary"
+    assert result.result["content"] == "delegated result"
+    query, context, on_event = bridge.calls[0]
+    assert "Delegated by Agent 'Primary' (primary)" in query
+    assert context.get("agent_id") == "research"
+    assert context.get("channel_type") == "agent"
+    assert context.get("is_delegated_task") is True
+    assert context.get("delegation_trace") == ["primary", "research"]
+    assert context.get("session_id").startswith("delegate_primary_research_")
+    assert on_event is None
+
+
+def test_delegate_rejects_disabled_unknown_and_disallowed_targets():
+    disabled = _tool(bridge=FakeBridge(_registry(disable_research=True)))
+    result = disabled.execute({"agent_id": "research", "task": "Do work"})
+    assert result.status == "error"
+    assert "not available" in result.result
+
+    missing = _tool()
+    result = missing.execute({"agent_id": "missing", "task": "Do work"})
+    assert result.status == "error"
+    assert "not available" in result.result
+
+    denied = _tool(config={"allowed_targets": {"primary": []}})
+    result = denied.execute({"agent_id": "research", "task": "Do work"})
+    assert result.status == "error"
+    assert "not allowed" in result.result
+
+
+def test_delegate_rejects_cycles_and_depth_overflow():
+    cycle = _tool(
+        context=_context(
+            agent_id="research",
+            delegation_trace=["primary", "research"],
+            delegation_depth=1,
+        )
+    )
+    result = cycle.execute({"agent_id": "primary", "task": "Send it back"})
+    assert result.status == "error"
+    assert "cycle rejected" in result.result
+
+    too_deep = _tool(
+        config={"max_depth": 1},
+        context=_context(delegation_trace=["primary"], delegation_depth=1),
+    )
+    result = too_deep.execute({"agent_id": "research", "task": "Go deeper"})
+    assert result.status == "error"
+    assert "exceeds the maximum" in result.result
+
+
+def test_delegate_enforces_message_limit():
+    tool = _tool(config={"max_message_chars": 4})
+    result = tool.execute({"agent_id": "research", "task": "12345"})
+    assert result.status == "error"
+    assert "exceeds 4 characters" in result.result
+
+
+class BlockingBridge(FakeBridge):
+    def __init__(self):
+        super().__init__()
+        self.started = threading.Event()
+        self.cancelled = threading.Event()
+
+    def agent_reply(self, query, context=None, on_event=None):
+        request_id = context.get("request_id")
+        key = self._cancel_key(
+            context.get("agent_id"),
+            request_id,
+            self.agent_registry.default_agent_id,
+        )
+        registry = get_cancel_registry()
+        event = registry.register(key, session_id=context.get("session_id"))
+        self.started.set()
+        event.wait(0.5)
+        if event.is_set():
+            self.cancelled.set()
+        registry.unregister(key)
+        return Reply(ReplyType.TEXT, "late")
+
+
+def test_delegate_timeout_cancels_target_run_without_blocking_caller():
+    bridge = BlockingBridge()
+    tool = _tool(bridge=bridge, config={"timeout_seconds": 0.05})
+    started_at = time.monotonic()
+
+    result = tool.execute({"agent_id": "research", "task": "Wait"})
+
+    elapsed = time.monotonic() - started_at
+    assert result.status == "error"
+    assert "timed out" in result.result
+    assert elapsed < 0.3
+    assert bridge.started.is_set()
+    assert bridge.cancelled.wait(0.3)


### PR DESCRIPTION
## Summary

- add an `agent_delegate` tool for listing peers and assigning a bounded task to another Agent
- execute delegated work in the target Agent's own workspace and stable relay session
- return results to the caller without sending an unsolicited user-channel message
- enforce optional source-to-target allowlists, maximum depth, cycle checks, message limits, timeouts, cancellation, and per-route concurrency locks
- exclude delegated turns from user-memory evolution accounting

Delegation is available only when multiple Agents are enabled. A single-Agent installation does not gain an extra tool.

The multi-Agent prerequisites from #2969–#2972 are now merged. This branch was rebuilt on current `master` and contains only the delegation increment; it no longer carries #2973.

## Validation

```bash
python -m pytest -q tests/test_agent_delegation.py
# 7 passed
```