### PR TITLE
feat(backup): include all agent workspaces

### DIFF
--- a/cli/commands/backup.py
+++ b/cli/commands/backup.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import re
 import shutil
 import stat
 import tempfile
@@ -16,7 +17,9 @@ from cli.utils import get_project_root
 
 
 BACKUP_FORMAT = "cowagent-backup"
-BACKUP_VERSION = 1
+BACKUP_VERSION = 2
+_SUPPORTED_BACKUP_VERSIONS = {1, BACKUP_VERSION}
+_AGENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 _SKIP_DIRS = {".git", "__pycache__", "tmp"}
 _SKIP_FILES = {".DS_Store"}
 
@@ -40,6 +43,20 @@ def _read_config(data_root: Path) -> dict:
 
 def _workspace_from_config(config: dict) -> Path:
     return Path(config.get("agent_workspace") or "~/cow").expanduser().resolve()
+
+
+def _configured_workspaces(config: dict, fallback: Path):
+    """Return archive profiles and whether config uses the explicit registry."""
+    if config.get("agents"):
+        from agent.registry import AgentRegistry
+
+        registry = AgentRegistry.from_config(config)
+        return registry.list(), True
+    from agent.registry import AgentProfile
+
+    return [
+        AgentProfile("default", "Default", str(Path(fallback).resolve()))
+    ], False
 
 
 def _legacy_user_data_path(data_root: Path, config: dict) -> Path:
@@ -79,7 +96,7 @@ def create_backup_archive(
     workspace: Path,
     excluded_paths: Optional[Iterable[Path]] = None,
 ) -> dict:
-    """Create a portable archive containing config and the agent workspace."""
+    """Create a portable archive containing config and every agent workspace."""
     output = Path(output).expanduser().resolve()
     data_root = Path(data_root).expanduser().resolve()
     workspace = Path(workspace).expanduser().resolve()
@@ -90,18 +107,53 @@ def create_backup_archive(
     config_path = data_root / "config.json"
     config = _read_config(data_root)
     legacy_path = _legacy_user_data_path(data_root, config)
-    workspace_files = list(_iter_workspace_files(workspace, excluded))
-    total_bytes = sum(path.stat().st_size for path in workspace_files)
+    profiles, explicit_registry = _configured_workspaces(config, workspace)
+    workspace_entries = []
+    total_files = 0
+    total_bytes = 0
+    for profile in profiles:
+        source = Path(profile.workspace).expanduser().resolve()
+        files = list(_iter_workspace_files(source, excluded))
+        size = sum(path.stat().st_size for path in files)
+        archive_root = (
+            f"agents/{profile.id}/workspace"
+            if explicit_registry
+            else "workspace"
+        )
+        workspace_entries.append((profile, source, archive_root, files, size))
+        total_files += len(files)
+        total_bytes += size
 
     manifest = {
         "format": BACKUP_FORMAT,
         "version": BACKUP_VERSION,
         "created_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
-        "workspace_source": str(workspace),
+        "layout": "agents" if explicit_registry else "workspace",
+        "workspace_source": str(
+            next(
+                source
+                for profile, source, _, _, _ in workspace_entries
+                if profile.id
+                == (config.get("default_agent_id") if explicit_registry else "default")
+            )
+        ),
+        "agents": [
+            {
+                "id": profile.id,
+                "name": profile.name,
+                "enabled": profile.enabled,
+                "workspace_source": str(source),
+                "archive_root": archive_root,
+                "workspace_files": len(files),
+                "workspace_bytes": size,
+            }
+            for profile, source, archive_root, files, size in workspace_entries
+        ],
         "contents": {
             "config": config_path.is_file(),
             "legacy_user_data": legacy_path.is_file(),
-            "workspace_files": len(workspace_files),
+            "agent_workspaces": len(workspace_entries),
+            "workspace_files": total_files,
             "workspace_bytes": total_bytes,
         },
     }
@@ -120,9 +172,10 @@ def create_backup_archive(
                 archive.write(str(config_path), "data/config.json")
             if legacy_path.is_file():
                 archive.write(str(legacy_path), "data/user_datas.pkl")
-            for path in workspace_files:
-                relative = path.relative_to(workspace).as_posix()
-                archive.write(str(path), "workspace/" + relative)
+            for _, source, archive_root, files, _ in workspace_entries:
+                for path in files:
+                    relative = path.relative_to(source).as_posix()
+                    archive.write(str(path), f"{archive_root}/{relative}")
         os.replace(str(temp_archive), str(output))
         try:
             os.chmod(str(output), stat.S_IRUSR | stat.S_IWUSR)
@@ -143,8 +196,30 @@ def _validate_archive(archive: zipfile.ZipFile) -> dict:
         manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
     except (ValueError, UnicodeDecodeError) as exc:
         raise ValueError("archive manifest is invalid") from exc
-    if manifest.get("format") != BACKUP_FORMAT or manifest.get("version") != BACKUP_VERSION:
+    version = manifest.get("version")
+    if (
+        manifest.get("format") != BACKUP_FORMAT
+        or version not in _SUPPORTED_BACKUP_VERSIONS
+    ):
         raise ValueError("unsupported CowAgent backup format or version")
+
+    allowed_agent_roots = set()
+    if version >= 2 and manifest.get("layout") == "agents":
+        agents = manifest.get("agents")
+        if not isinstance(agents, list) or not agents:
+            raise ValueError("multi-agent archive manifest is missing agents")
+        seen_ids = set()
+        for item in agents:
+            if not isinstance(item, dict):
+                raise ValueError("multi-agent archive manifest is invalid")
+            agent_id = item.get("id")
+            root = item.get("archive_root")
+            if not isinstance(agent_id, str) or not _AGENT_ID_RE.fullmatch(agent_id):
+                raise ValueError("multi-agent archive contains an invalid Agent ID")
+            if agent_id in seen_ids or root != f"agents/{agent_id}/workspace":
+                raise ValueError("multi-agent archive contains duplicate or invalid roots")
+            seen_ids.add(agent_id)
+            allowed_agent_roots.add(root + "/")
 
     for info in archive.infolist():
         name = info.filename
@@ -154,7 +229,13 @@ def _validate_archive(archive: zipfile.ZipFile) -> dict:
         mode = (info.external_attr >> 16) & 0o170000
         if mode == stat.S_IFLNK:
             raise ValueError(f"symbolic links are not allowed in backups: {name!r}")
-        if name != "manifest.json" and not name.startswith(("data/", "workspace/")):
+        if allowed_agent_roots:
+            allowed = name.startswith("data/") or any(
+                name.startswith(root) for root in allowed_agent_roots
+            )
+        else:
+            allowed = name.startswith(("data/", "workspace/"))
+        if name != "manifest.json" and not allowed:
             raise ValueError(f"unexpected archive entry: {name!r}")
     return manifest
 
@@ -187,6 +268,50 @@ def _atomic_copy(source: Path, destination: Path, private: bool = False) -> None
             os.remove(temp_name)
 
 
+def _multi_agent_destinations(
+    manifest: dict,
+    archived_config: dict,
+    current_config: dict,
+    workspace_root: Optional[Path],
+):
+    """Resolve safe restore destinations without trusting archived paths."""
+    from agent.registry import AgentRegistry
+
+    archived_registry = AgentRegistry.from_config(archived_config)
+    manifest_ids = [item["id"] for item in manifest.get("agents", [])]
+    configured_ids = [profile.id for profile in archived_registry.list()]
+    if sorted(manifest_ids) != sorted(configured_ids):
+        raise ValueError("archive Agent registry does not match its workspace manifest")
+
+    current_registry = None
+    if current_config.get("agents"):
+        try:
+            current_registry = AgentRegistry.from_config(current_config)
+        except ValueError:
+            current_registry = None
+
+    base = (
+        Path(workspace_root).expanduser().resolve()
+        if workspace_root is not None
+        else Path("~/cow-agents").expanduser().resolve()
+    )
+    destinations = {}
+    for agent_id in manifest_ids:
+        current = None
+        if workspace_root is None and current_registry is not None:
+            try:
+                current = current_registry.get(agent_id, require_enabled=False)
+            except KeyError:
+                pass
+        destination = current.workspace_path.resolve() if current else (base / agent_id)
+        if current is None and not _is_within(destination, base):
+            raise ValueError(f"unsafe Agent workspace destination: {agent_id}")
+        destinations[agent_id] = destination
+    if len({str(path) for path in destinations.values()}) != len(destinations):
+        raise ValueError("multiple Agents resolve to the same workspace destination")
+    return archived_registry, destinations
+
+
 def restore_backup_archive(
     archive_path: Path,
     data_root: Path,
@@ -212,19 +337,47 @@ def restore_backup_archive(
                 raise ValueError("archived config.json must contain an object")
             archived_config = value
 
-        if workspace is not None:
-            target_workspace = Path(workspace).expanduser().resolve()
-        elif current_config.get("agent_workspace"):
-            target_workspace = _workspace_from_config(current_config)
-        else:
-            # Do not trust an archive-controlled absolute destination on a
-            # fresh machine. Portable restores default to the standard local
-            # workspace unless the operator supplies --workspace.
-            target_workspace = Path("~/cow").expanduser().resolve()
-
         restored_config = dict(archived_config)
-        if restored_config:
+        multi_agent = (
+            manifest.get("version", 1) >= 2
+            and manifest.get("layout") == "agents"
+        )
+        destinations = {}
+        if multi_agent:
+            if not restored_config.get("agents"):
+                raise ValueError("multi-agent archive is missing its Agent registry")
+            archived_registry, destinations = _multi_agent_destinations(
+                manifest, restored_config, current_config, workspace
+            )
+            restored_agents = []
+            for raw in restored_config["agents"]:
+                item = dict(raw)
+                item["workspace"] = str(destinations[item["id"]])
+                restored_agents.append(item)
+            restored_config["agents"] = restored_agents
+            default_agent_id = archived_registry.default_agent_id
+            restored_config["default_agent_id"] = default_agent_id
+            target_workspace = destinations[default_agent_id]
+            # Keep the singular key aligned for older extensions that still
+            # inspect it even when an explicit registry is configured.
             restored_config["agent_workspace"] = str(target_workspace)
+            from agent.registry import AgentRegistry
+
+            AgentRegistry.from_config(restored_config)
+        else:
+            if workspace is not None:
+                target_workspace = Path(workspace).expanduser().resolve()
+            elif current_config.get("agent_workspace"):
+                target_workspace = _workspace_from_config(current_config)
+            else:
+                # Do not trust an archive-controlled absolute destination on a
+                # fresh machine. Portable restores default to ~/cow unless the
+                # operator supplies --workspace.
+                target_workspace = Path("~/cow").expanduser().resolve()
+            if restored_config:
+                restored_config["agent_workspace"] = str(target_workspace)
+
+        if restored_config:
             appdata_dir = restored_config.get("appdata_dir") or ""
             if appdata_dir:
                 archived_appdata = (data_root / appdata_dir).resolve()
@@ -232,22 +385,48 @@ def restore_backup_archive(
                     # Keep legacy user data under the selected data root
                     # instead of writing to an archive-controlled path.
                     restored_config["appdata_dir"] = ""
+        restored_files = 0
+        restored_agents = []
+        if multi_agent:
+            manifest_agents = {item["id"]: item for item in manifest["agents"]}
+            for agent_id, target in destinations.items():
+                archive_root = manifest_agents[agent_id]["archive_root"]
+                source_root = temp_dir.joinpath(*PurePosixPath(archive_root).parts)
+                agent_files = 0
+                if source_root.is_dir():
+                    for source in _iter_workspace_files(source_root, set()):
+                        relative = source.relative_to(source_root)
+                        destination = target / relative
+                        if not _is_within(destination, target):
+                            raise ValueError(
+                                f"unsafe Agent workspace destination: {agent_id}/{relative}"
+                            )
+                        _atomic_copy(source, destination)
+                        restored_files += 1
+                        agent_files += 1
+                restored_agents.append(
+                    {"id": agent_id, "workspace": str(target), "files": agent_files}
+                )
+        else:
+            source_root = temp_dir / "workspace"
+            if source_root.is_dir():
+                for source in _iter_workspace_files(source_root, set()):
+                    relative = source.relative_to(source_root)
+                    destination = target_workspace / relative
+                    if not _is_within(destination, target_workspace):
+                        raise ValueError(f"unsafe workspace destination: {relative}")
+                    _atomic_copy(source, destination)
+                    restored_files += 1
+
+        # Publish config only after every workspace file has been validated
+        # and copied. A copy failure cannot leave config pointing at a partial
+        # multi-agent restore.
+        if restored_config:
             config_temp = temp_dir / "restored-config.json"
             with config_temp.open("w", encoding="utf-8") as handle:
                 json.dump(restored_config, handle, ensure_ascii=False, indent=2)
                 handle.write("\n")
             _atomic_copy(config_temp, data_root / "config.json", private=True)
-
-        workspace_root = temp_dir / "workspace"
-        restored_files = 0
-        if workspace_root.is_dir():
-            for source in _iter_workspace_files(workspace_root, set()):
-                relative = source.relative_to(workspace_root)
-                destination = target_workspace / relative
-                if not _is_within(destination, target_workspace):
-                    raise ValueError(f"unsafe workspace destination: {relative}")
-                _atomic_copy(source, destination)
-                restored_files += 1
 
         legacy_source = temp_dir / "data" / "user_datas.pkl"
         if legacy_source.is_file():
@@ -259,6 +438,7 @@ def restore_backup_archive(
             "manifest": manifest,
             "workspace": str(target_workspace),
             "workspace_files": restored_files,
+            "agents": restored_agents,
             "config_restored": bool(restored_config),
             "legacy_user_data_restored": legacy_source.is_file(),
         }
@@ -284,6 +464,7 @@ def backup_command(output: Optional[Path]):
     result = create_backup_archive(output, data_root, workspace)
     click.echo(click.style("✓ Backup created", fg="green"))
     click.echo(f"  Archive: {result['archive']}")
+    click.echo(f"  Agent workspaces: {result['contents']['agent_workspaces']}")
     click.echo(f"  Workspace files: {result['contents']['workspace_files']}")
     click.echo("  Keep this archive private: it may contain API keys and personal data.")
 
@@ -293,7 +474,7 @@ def backup_command(output: Optional[Path]):
 @click.option(
     "--workspace",
     type=click.Path(file_okay=False, path_type=Path),
-    help="Restore workspace files to this directory.",
+    help="Restore a single workspace here, or use this as the root for Agent subdirectories.",
 )
 @click.option("--yes", is_flag=True, help="Confirm overwriting matching files.")
 def restore_command(archive: Path, workspace: Optional[Path], yes: bool):
@@ -329,4 +510,6 @@ def restore_command(archive: Path, workspace: Optional[Path], yes: bool):
     result = restore_backup_archive(archive, data_root, workspace)
     click.echo(click.style("✓ Backup restored", fg="green"))
     click.echo(f"  Workspace: {result['workspace']}")
+    if result["agents"]:
+        click.echo(f"  Agent workspaces: {len(result['agents'])}")
     click.echo(f"  Restored files: {result['workspace_files']}")

--- a/docs/cli/backup.mdx
+++ b/docs/cli/backup.mdx
@@ -17,6 +17,7 @@ The archive contains:
 - `config.json`
 - Agent persona and user files such as `AGENT.md`, `USER.md`, and `MEMORY.md`
 - Daily memory, session history, knowledge, custom skills, and scheduled tasks in the configured workspace
+- The Agent registry, channel bindings, and every configured Agent workspace when multi-Agent mode is configured
 - Legacy `user_datas.pkl`, when present
 
 Transient `tmp/` data, caches, Git metadata, and symbolic links are skipped. The
@@ -42,6 +43,10 @@ Use `--workspace` to migrate workspace files to a different location:
 ```bash
 cow restore cow-backup.zip --workspace ~/cow-restored
 ```
+
+For a multi-Agent archive, `--workspace` is a root directory. CowAgent restores
+each workspace under `<root>/<agent-id>`. Without the option, existing Agent IDs
+reuse their current local workspace; new Agents use `~/cow-agents/<agent-id>`.
 
 Restore validates the archive format and paths before writing anything. It
 overwrites matching files but does not delete unrelated files already present

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,7 @@
                 "group": "Installation",
                 "pages": [
                   "guide/quick-start",
+                  "guide/multi-agent",
                   "guide/desktop",
                   "guide/manual-install",
                   "guide/upgrade"
@@ -337,6 +338,7 @@
                 "group": "安装部署",
                 "pages": [
                   "zh/guide/quick-start",
+                  "zh/guide/multi-agent",
                   "zh/guide/desktop",
                   "zh/guide/manual-install",
                   "zh/guide/upgrade"
@@ -580,6 +582,7 @@
                 "group": "インストール",
                 "pages": [
                   "ja/guide/quick-start",
+                  "ja/guide/multi-agent",
                   "ja/guide/desktop",
                   "ja/guide/manual-install",
                   "ja/guide/upgrade"

--- a/docs/zh/cli/backup.mdx
+++ b/docs/zh/cli/backup.mdx
@@ -17,6 +17,7 @@ cow backup --output /safe/location/cow-backup.zip
 - `config.json`
 - `AGENT.md`、`USER.md`、`MEMORY.md` 等 Agent 人格和用户文件
 - 工作区内的每日记忆、会话历史、知识库、自定义技能和定时任务
+- 配置多 Agent 后的 Agent registry、通道绑定和全部 Agent 工作区
 - 旧版 `user_datas.pkl`（如存在）
 
 临时 `tmp/` 数据、缓存、Git 元数据和符号链接不会写入归档。在操作系统支持的情况下，归档文件权限会限制为仅当前用户可读写。
@@ -39,6 +40,8 @@ cow restore /safe/location/cow-backup.zip
 ```bash
 cow restore cow-backup.zip --workspace ~/cow-restored
 ```
+
+恢复多 Agent 归档时，`--workspace` 表示统一根目录，各工作区会写入 `<根目录>/<agent-id>`。未传该参数时，本机已有的同名 Agent 沿用当前工作区，新 Agent 默认写入 `~/cow-agents/<agent-id>`。
 
 恢复命令会在写入前校验归档格式和所有路径。它会覆盖同名文件，但不会删除目标目录中无关的现有文件。如果检测到当前 CowAgent 数据，会先在所选归档旁创建 `cow-pre-restore-*.zip` 回滚备份。
 

--- a/tests/test_cli_backup.py
+++ b/tests/test_cli_backup.py
@@ -81,6 +81,26 @@ def test_restore_rejects_path_traversal(tmp_path):
         restore_backup_archive(archive, tmp_path / "data", tmp_path / "workspace")
 
 
+def test_restore_accepts_legacy_version_one_archive(tmp_path):
+    archive = tmp_path / "legacy.zip"
+    manifest = {"format": "cowagent-backup", "version": 1}
+    with zipfile.ZipFile(archive, "w") as output:
+        output.writestr("manifest.json", json.dumps(manifest))
+        output.writestr(
+            "data/config.json", json.dumps({"agent_workspace": "/old/path"})
+        )
+        output.writestr("workspace/MEMORY.md", "legacy memory")
+
+    target_data = tmp_path / "data"
+    target_workspace = tmp_path / "workspace"
+    result = restore_backup_archive(archive, target_data, target_workspace)
+
+    assert (target_workspace / "MEMORY.md").read_text() == "legacy memory"
+    assert result["agents"] == []
+    restored = json.loads((target_data / "config.json").read_text())
+    assert restored["agent_workspace"] == str(target_workspace.resolve())
+
+
 def test_fresh_restore_ignores_archive_controlled_destinations(tmp_path, monkeypatch):
     source_data = tmp_path / "source-data"
     source_workspace = tmp_path / "source-workspace"
@@ -108,3 +128,146 @@ def test_fresh_restore_ignores_archive_controlled_destinations(tmp_path, monkeyp
     assert (target_data / "user_datas.pkl").read_bytes() == b"legacy"
     restored_config = json.loads((target_data / "config.json").read_text(encoding="utf-8"))
     assert restored_config["appdata_dir"] == ""
+
+
+def test_multi_agent_backup_restore_preserves_all_isolated_workspaces(tmp_path):
+    source_data = tmp_path / "source-data"
+    primary = tmp_path / "source-primary"
+    research = tmp_path / "source-research"
+    _write_json(
+        source_data / "config.json",
+        {
+            "agent_workspace": str(primary),
+            "default_agent_id": "primary",
+            "agents": [
+                {
+                    "id": "primary",
+                    "name": "Primary",
+                    "workspace": str(primary),
+                    "enabled": True,
+                },
+                {
+                    "id": "research",
+                    "name": "Research",
+                    "workspace": str(research),
+                    "enabled": True,
+                },
+            ],
+            "agent_bindings": [
+                {"channel_type": "web", "agent_id": "research"}
+            ],
+        },
+    )
+    for workspace, marker in ((primary, "primary"), (research, "research")):
+        (workspace / "memory" / "long-term").mkdir(parents=True)
+        (workspace / "scheduler").mkdir()
+        (workspace / "MEMORY.md").write_text(marker, encoding="utf-8")
+        (workspace / "memory" / "long-term" / "index.db").write_bytes(
+            marker.encode("utf-8")
+        )
+        (workspace / "scheduler" / "tasks.json").write_text(
+            f'{{"owner":"{marker}"}}', encoding="utf-8"
+        )
+
+    archive = tmp_path / "multi.zip"
+    summary = create_backup_archive(archive, source_data, primary)
+
+    assert summary["layout"] == "agents"
+    assert summary["contents"]["agent_workspaces"] == 2
+    with zipfile.ZipFile(archive) as bundle:
+        names = set(bundle.namelist())
+    assert "agents/primary/workspace/memory/long-term/index.db" in names
+    assert "agents/research/workspace/memory/long-term/index.db" in names
+
+    target_data = tmp_path / "target-data"
+    target_root = tmp_path / "restored-agents"
+    result = restore_backup_archive(archive, target_data, target_root)
+    restored_config = json.loads(
+        (target_data / "config.json").read_text(encoding="utf-8")
+    )
+    destinations = {
+        item["id"]: Path(item["workspace"])
+        for item in restored_config["agents"]
+    }
+    assert destinations == {
+        "primary": (target_root / "primary").resolve(),
+        "research": (target_root / "research").resolve(),
+    }
+    assert restored_config["agent_workspace"] == str(destinations["primary"])
+    assert restored_config["agent_bindings"][0]["agent_id"] == "research"
+    assert (destinations["primary"] / "MEMORY.md").read_text() == "primary"
+    assert (destinations["research"] / "MEMORY.md").read_text() == "research"
+    assert (destinations["primary"] / "memory/long-term/index.db").read_bytes() == b"primary"
+    assert (destinations["research"] / "scheduler/tasks.json").exists()
+    assert result["workspace_files"] == 6
+    assert {item["id"] for item in result["agents"]} == {"primary", "research"}
+
+
+def test_multi_agent_restore_reuses_matching_local_destinations(tmp_path):
+    source_data = tmp_path / "source-data"
+    source_primary = tmp_path / "source-primary"
+    source_research = tmp_path / "source-research"
+    config = {
+        "default_agent_id": "primary",
+        "agents": [
+            {"id": "primary", "workspace": str(source_primary)},
+            {"id": "research", "workspace": str(source_research)},
+        ],
+    }
+    _write_json(source_data / "config.json", config)
+    source_primary.mkdir()
+    source_research.mkdir()
+    (source_primary / "AGENT.md").write_text("new primary", encoding="utf-8")
+    (source_research / "AGENT.md").write_text("new research", encoding="utf-8")
+    archive = tmp_path / "multi.zip"
+    create_backup_archive(archive, source_data, source_primary)
+
+    target_data = tmp_path / "target-data"
+    local_primary = tmp_path / "local-primary"
+    local_research = tmp_path / "local-research"
+    _write_json(
+        target_data / "config.json",
+        {
+            "default_agent_id": "primary",
+            "agents": [
+                {"id": "primary", "workspace": str(local_primary)},
+                {"id": "research", "workspace": str(local_research)},
+            ],
+        },
+    )
+
+    restore_backup_archive(archive, target_data)
+
+    assert (local_primary / "AGENT.md").read_text() == "new primary"
+    assert (local_research / "AGENT.md").read_text() == "new research"
+    restored = json.loads((target_data / "config.json").read_text())
+    assert {item["id"]: item["workspace"] for item in restored["agents"]} == {
+        "primary": str(local_primary.resolve()),
+        "research": str(local_research.resolve()),
+    }
+
+
+def test_multi_agent_restore_rejects_manifest_registry_mismatch(tmp_path):
+    archive = tmp_path / "mismatch.zip"
+    manifest = {
+        "format": "cowagent-backup",
+        "version": 2,
+        "layout": "agents",
+        "agents": [
+            {
+                "id": "research",
+                "archive_root": "agents/research/workspace",
+            }
+        ],
+    }
+    config = {
+        "default_agent_id": "primary",
+        "agents": [{"id": "primary", "workspace": "/untrusted/path"}],
+    }
+    with zipfile.ZipFile(archive, "w") as output:
+        output.writestr("manifest.json", json.dumps(manifest))
+        output.writestr("data/config.json", json.dumps(config))
+        output.writestr("agents/research/workspace/MEMORY.md", "nope")
+
+    with pytest.raises(ValueError, match="does not match"):
+        restore_backup_archive(archive, tmp_path / "data", tmp_path / "agents")


### PR DESCRIPTION
## Summary

- introduce backup format v2 containing every configured Agent workspace
- preserve v1 and single-workspace restore compatibility
- restore each Agent workspace to its configured destination without collapsing data into the default workspace
- document the multi-Agent backup behavior in English and Chinese CLI references

This PR previously bundled the remaining multi-Agent hardening work. It has been rebuilt on current `master` as a focused backup-only change; tool, scheduler, temporary-file, channel-attachment, and documentation hardening are being validated independently rather than carried as one 47-file diff.

## Validation

```bash
python -m pytest -q tests/test_cli_backup.py
# 8 passed
```