### PR TITLE
feat(desktop): keep chat input draft when navigating away from chat page

### DIFF
--- a/desktop/src/renderer/src/components/ChatInput.tsx
+++ b/desktop/src/renderer/src/components/ChatInput.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import { t } from '../i18n'
 import type { Attachment, WorkspaceEntry } from '../types'
+import { chatDraft } from '../store/draftStore'
 import apiClient from '../api/client'
 import { PaperPlaneIcon } from './icons'
 import { WORKSPACE_DRAG_TYPE } from './FileTree'
@@ -40,8 +41,11 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   { onSend, onNewChat, onStop, onClearContext, isStreaming, sessionId },
   ref
 ) {
-  const [text, setText] = useState('')
-  const [attachments, setAttachments] = useState<Attachment[]>([])
+  // Restore the draft saved in `chatDraft` on mount (lazy init: the very first
+  // render must already show it, otherwise the write-through effect below would
+  // overwrite the saved draft with the initial empty state).
+  const [text, setText] = useState(() => chatDraft.text)
+  const [attachments, setAttachments] = useState(() => chatDraft.attachments)
   const [uploading, setUploading] = useState(false)
   const [uploadError, setUploadError] = useState('')
   const [dragOver, setDragOver] = useState(false)
@@ -104,6 +108,15 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
     autoSize(textareaRef.current)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Write the input through to `chatDraft` on every change so it survives this
+  // component unmounting when the user navigates to another page (chat route
+  // unmounts ChatPage; see store/draftStore.ts). Sending clears the input, which
+  // therefore also clears the saved draft.
+  useEffect(() => {
+    chatDraft.text = text
+    chatDraft.attachments = attachments
+  }, [text, attachments])
 
   // Allow the parent to load a draft (e.g. when editing a past user message).
   useImperativeHandle(ref, () => (draft: string, atts: Attachment[]) => {

--- a/desktop/src/renderer/src/store/draftStore.ts
+++ b/desktop/src/renderer/src/store/draftStore.ts
@@ -1,0 +1,11 @@
+import type { Attachment } from '../types'
+
+// Draft of the chat input (text + attachments). The input lives in local
+// component state and the chat route unmounts ChatPage when the user navigates
+// to another page, which would otherwise destroy what was typed. This module-
+// scoped variable survives the unmount and is restored on the next mount.
+// Lives for the renderer process only — no persistence across app restarts.
+export const chatDraft: { text: string; attachments: Attachment[] } = {
+  text: '',
+  attachments: [],
+}


### PR DESCRIPTION
Closes #3038

## Summary

The chat input in the desktop app loses its unsent content (text + attachments) when the user navigates to another page (e.g. Knowledge, Settings) and comes back. Leaving the chat route unmounts `ChatPage`, and the input value lives in `ChatInput`'s local state, so it is destroyed together with the component.

## Changes

- **`store/draftStore.ts`** (new): a module-scope `chatDraft` variable (renderer memory only, no persistence across app restarts) that survives component unmounting.
- **`ChatInput.tsx`**: restore the draft on mount via lazy `useState` initializers, and write the input through to `chatDraft` on every change.

## Behavior

- Navigating away from the chat page and back now restores what was typed.
- Sending still clears the draft (the input is emptied as before).
- Switching sessions, `/clear` and `/new` behave exactly as before (the draft stays shared across sessions — out of scope per the issue).
- The web console (`channel/web`) is unaffected: it is a separate single-page frontend whose input element never unmounts.

## Verification

- `npx tsc --noEmit -p tsconfig.json` — no errors in the changed files (pre-existing `ChannelsPage.tsx` lucide icon type errors are unrelated).
- `npm run build:renderer` — passes.
- Manual: type text → navigate to Knowledge → back → text restored; send → navigate away/back → input empty.
