### PR TITLE
feat(memory): add optional Milvus vector backend

### DIFF
--- a/agent/knowledge/service.py
+++ b/agent/knowledge/service.py
@@ -21,7 +21,7 @@ from urllib.parse import quote, unquote
 
 from common.log import logger
 from config import conf
-from agent.memory.config import MemoryConfig
+from agent.memory.config import create_memory_config
 from agent.memory.manager import MemoryManager
 
 
@@ -85,7 +85,7 @@ class KnowledgeService:
             from agent.memory.embedding import create_default_embedding_provider
             embedding_provider = create_default_embedding_provider()
             self._memory_manager = MemoryManager(
-                MemoryConfig(workspace_root=self.workspace_root),
+                create_memory_config(self.workspace_root),
                 embedding_provider=embedding_provider,
             )
         return self._memory_manager

--- a/agent/memory/__init__.py
+++ b/agent/memory/__init__.py
@@ -7,6 +7,7 @@ conversation history persistence (SQLite).
 
 from agent.memory.config import (
     MemoryConfig,
+    create_memory_config,
     get_default_memory_config,
     register_memory_config,
     reset_memory_configs,
@@ -33,6 +34,7 @@ from agent.memory.vector_backend import (
 __all__ = [
     'MemoryManager',
     'MemoryConfig',
+    'create_memory_config',
     'get_default_memory_config',
     'register_memory_config',
     'reset_memory_configs',

--- a/agent/memory/config.py
+++ b/agent/memory/config.py
@@ -33,6 +33,15 @@ class MemoryConfig:
     embedding_provider: str = "openai"  # "openai" | "local"
     embedding_model: str = "text-embedding-3-small"
     embedding_dim: int = 1536
+
+    # Vector backend config. SQLite remains the zero-dependency default.
+    vector_backend: str = "sqlite"
+    milvus_uri: str = ""
+    milvus_token: str = ""
+    milvus_db_name: str = "default"
+    milvus_collection: str = ""
+    milvus_timeout: float = 10.0
+    milvus_consistency_level: str = "Strong"
     
     # Chunking config
     chunk_max_tokens: int = 500
@@ -72,6 +81,25 @@ class MemoryConfig:
         """Get skills directory"""
         from common import state_dir
         return state_dir.skills_dir(base=self.workspace_root)
+
+
+def create_memory_config(workspace_root: str) -> MemoryConfig:
+    """Build a workspace-scoped memory config from the runtime config file."""
+    from config import conf
+
+    runtime = conf()
+    return MemoryConfig(
+        workspace_root=workspace_root,
+        vector_backend=str(runtime.get("vector_backend") or "sqlite"),
+        milvus_uri=str(runtime.get("milvus_uri") or ""),
+        milvus_token=str(runtime.get("milvus_token") or ""),
+        milvus_db_name=str(runtime.get("milvus_db_name") or "default"),
+        milvus_collection=str(runtime.get("milvus_collection") or ""),
+        milvus_timeout=float(runtime.get("milvus_timeout") or 10.0),
+        milvus_consistency_level=str(
+            runtime.get("milvus_consistency_level") or "Strong"
+        ),
+    )
 
 
 # One config per workspace, not one per process: several Agents share this

--- a/agent/memory/embedding/rebuild.py
+++ b/agent/memory/embedding/rebuild.py
@@ -61,10 +61,7 @@ def clear_index(db_path, storage=None) -> int:
     if owns_storage:
         storage = MemoryStorage(db_path)
     try:
-        before = storage.conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
-        storage.conn.execute("DELETE FROM chunks")
-        storage.conn.execute("DELETE FROM files")
-        storage.conn.commit()
+        before = storage.clear_memory_index()
         storage.reset_fts5()
     finally:
         if owns_storage:
@@ -100,6 +97,17 @@ def rebuild_in_process(memory_manager) -> RebuildResult:
     except Exception as e:
         logger.error(f"[RebuildIndex] embedding probe failed, aborting rebuild: {e}")
         return RebuildResult(ok=False, error=f"embedding endpoint not reachable: {e}")
+
+    configure_backend = getattr(memory_manager, "configure_vector_backend", None)
+    if configure_backend is not None:
+        try:
+            configure_backend()
+        except Exception as e:
+            logger.error("[RebuildIndex] vector backend preflight failed: %s", e)
+            return RebuildResult(
+                ok=False,
+                error=f"vector backend preflight failed: {e}",
+            )
 
     db_path = memory_manager.config.get_db_path()
     try:
@@ -150,15 +158,15 @@ def rebuild_in_process(memory_manager) -> RebuildResult:
 
 def main() -> int:
     """Standalone CLI entry. Must be run from project root (relative config path)."""
-    from config import conf, load_config
-    from agent.memory import MemoryConfig, MemoryManager
+    from config import load_config
+    from agent.memory import MemoryManager, create_memory_config
 
     load_config()
 
     from common.state_dir import state_root_str
 
     workspace_root = state_root_str()
-    memory_config = MemoryConfig(workspace_root=workspace_root)
+    memory_config = create_memory_config(workspace_root)
 
     logger.info(f"[RebuildIndex] Workspace: {workspace_root}")
     logger.info(f"[RebuildIndex] Index db:  {memory_config.get_db_path()}")

--- a/agent/memory/manager.py
+++ b/agent/memory/manager.py
@@ -15,6 +15,7 @@ from agent.memory.storage import MemoryStorage, MemoryChunk, SearchResult
 from agent.memory.chunker import TextChunker
 from agent.memory.embedding import EmbeddingProvider, EmbeddingCache
 from agent.memory.summarizer import MemoryFlushManager, create_memory_files_if_needed
+from agent.memory.vector_backend_factory import create_external_vector_backend
 
 
 class MemoryManager:
@@ -39,10 +40,16 @@ class MemoryManager:
             llm_model: LLM model for summarization (optional)
         """
         self.config = config or get_default_memory_config()
+
+        # Embedding provider is owned by the caller (agent_initializer is the
+        # canonical entry point and handles legacy/explicit + state validation).
+        self.embedding_provider = embedding_provider
         
         # Initialize storage
         db_path = self.config.get_db_path()
-        self.storage = MemoryStorage(db_path)
+        dimension = self._effective_embedding_dimension()
+        external_backend = create_external_vector_backend(self.config, dimension)
+        self.storage = MemoryStorage(db_path, vector_backend=external_backend)
         
         # Initialize chunker
         self.chunker = TextChunker(
@@ -50,12 +57,9 @@ class MemoryManager:
             overlap_tokens=self.config.chunk_overlap_tokens
         )
         
-        # Embedding provider is owned by the caller (agent_initializer is the
-        # canonical entry point and handles legacy/explicit + state validation).
         # When None is passed, memory degrades to keyword-only search instead
         # of silently re-initializing a vendor here, which would bypass the
         # caller's state checks and risk corrupting the index.
-        self.embedding_provider = embedding_provider
         if self.embedding_provider is None:
             from common.log import logger
             logger.info(
@@ -443,6 +447,7 @@ class MemoryManager:
     def get_status(self) -> Dict[str, Any]:
         """Get memory status"""
         stats = self.storage.get_stats()
+        vector_status = self.storage.get_vector_backend_status()
         return {
             'chunks': stats['chunks'],
             'files': stats['files'],
@@ -451,8 +456,22 @@ class MemoryManager:
             'embedding_enabled': self.embedding_provider is not None,
             'embedding_provider': self.config.embedding_provider if self.embedding_provider else 'disabled',
             'embedding_model': self.config.embedding_model if self.embedding_provider else 'N/A',
-            'search_mode': 'hybrid (vector + keyword)' if self.embedding_provider else 'keyword only (FTS5)'
+            'search_mode': 'hybrid (vector + keyword)' if self.embedding_provider else 'keyword only (FTS5)',
+            'vector_backend': vector_status['backend'],
+            'vector_backend_healthy': vector_status['healthy'],
+            'vector_sync_pending': vector_status['pending'],
         }
+
+    def configure_vector_backend(self) -> None:
+        """Recreate the optional backend after an embedding-provider change."""
+        backend = create_external_vector_backend(
+            self.config,
+            self._effective_embedding_dimension(),
+        )
+        self.storage.set_external_vector_backend(backend)
+        status = self.storage.get_vector_backend_status()
+        if backend is not None and not status["healthy"]:
+            raise RuntimeError(status["error"] or "Milvus backend is unavailable")
     
     def mark_dirty(self):
         """Mark memory as dirty (needs sync)"""
@@ -468,6 +487,15 @@ class MemoryManager:
         """Generate unique chunk ID"""
         content = f"{path}:{start_line}:{end_line}"
         return hashlib.md5(content.encode('utf-8')).hexdigest()
+
+    def _effective_embedding_dimension(self) -> Optional[int]:
+        if self.embedding_provider is None:
+            return None
+        dimension = getattr(self.embedding_provider, "dimensions", None)
+        if dimension:
+            return int(dimension)
+        configured = getattr(self.config, "embedding_dim", None)
+        return int(configured) if configured else None
     
     @staticmethod
     def _compute_temporal_decay(path: str, half_life_days: float = 30.0) -> float:

--- a/agent/memory/milvus_backend.py
+++ b/agent/memory/milvus_backend.py
@@ -1,0 +1,434 @@
+"""Optional Milvus implementation of the memory vector backend contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from agent.memory.vector_backend import VectorBackend, VectorMatch, VectorRecord
+
+
+class MilvusConfigurationError(ValueError):
+    """Raised when an existing collection is incompatible with CowAgent."""
+
+
+class MilvusVectorBackend(VectorBackend):
+    """Store and search memory vectors through ``pymilvus.MilvusClient``.
+
+    PyMilvus is imported lazily so the default SQLite backend stays completely
+    dependency-free.  A client factory and DataType object can be injected by
+    unit tests without importing the optional package.
+    """
+
+    _FILTER_COLUMNS = {"id", "user_id", "scope", "source", "path"}
+    _OUTPUT_FIELDS = [
+        "user_id",
+        "scope",
+        "source",
+        "path",
+        "start_line",
+        "end_line",
+        "text",
+        "metadata_json",
+    ]
+
+    def __init__(
+        self,
+        *,
+        uri: str,
+        collection_name: str,
+        dimension: int,
+        workspace_id: str,
+        token: str = "",
+        db_name: str = "default",
+        timeout: float = 10.0,
+        consistency_level: str = "Strong",
+        client_factory: Optional[Callable[..., Any]] = None,
+        data_type: Any = None,
+    ):
+        if dimension <= 1:
+            raise MilvusConfigurationError(
+                "Milvus requires an embedding dimension greater than 1"
+            )
+        if not uri:
+            raise MilvusConfigurationError("Milvus URI cannot be empty")
+        if not collection_name:
+            raise MilvusConfigurationError("Milvus collection name cannot be empty")
+
+        self.uri = uri
+        self.collection_name = collection_name
+        self.dimension = int(dimension)
+        self.workspace_id = workspace_id
+        self.token = token
+        self.db_name = db_name or "default"
+        self.timeout = float(timeout)
+        self.consistency_level = consistency_level or "Strong"
+        self._client_factory = client_factory
+        self._data_type = data_type
+        self._client = None
+        self._ready = False
+        self.collection_created = False
+
+    @property
+    def backend_name(self) -> str:
+        return "milvus"
+
+    @property
+    def sync_key(self) -> str:
+        raw = "{}:{}:{}".format(
+            self.collection_name,
+            self.workspace_id,
+            self.dimension,
+        )
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+    def prepare(self) -> bool:
+        """Ensure the collection is usable and report whether it was created."""
+        self._ensure_ready()
+        created = self.collection_created
+        self.collection_created = False
+        return created
+
+    def upsert(self, records: Sequence[VectorRecord]) -> None:
+        if not records:
+            return
+        self._ensure_ready()
+
+        rows = []
+        missing_ids = []
+        for record in records:
+            if record.embedding is None:
+                missing_ids.append(record.id)
+                continue
+            self._validate_dimension(record.embedding)
+            metadata = record.metadata
+            rows.append(
+                {
+                    "id": record.id,
+                    "embedding": list(record.embedding),
+                    "workspace_id": self.workspace_id,
+                    "user_id": metadata.get("user_id") or "",
+                    "scope": metadata.get("scope") or "shared",
+                    "source": metadata.get("source") or "memory",
+                    "path": metadata.get("path") or "",
+                    "start_line": int(metadata.get("start_line") or 0),
+                    "end_line": int(metadata.get("end_line") or 0),
+                    "text": metadata.get("text") or "",
+                    "metadata_json": json.dumps(
+                        metadata.get("metadata"),
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ),
+                }
+            )
+
+        if rows:
+            self._client.upsert(
+                collection_name=self.collection_name,
+                data=rows,
+                timeout=self.timeout,
+            )
+        if missing_ids:
+            self.delete(ids=missing_ids)
+
+    def delete(
+        self,
+        ids: Optional[Sequence[str]] = None,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        if ids is not None and not ids:
+            return
+        if ids is None and not metadata_filter:
+            raise ValueError("Vector deletion requires IDs or a metadata filter")
+
+        self._ensure_ready()
+        expression = self._build_filter(
+            metadata_filter,
+            ids=ids,
+            shared_visible_to_user=False,
+        )
+        self._client.delete(
+            collection_name=self.collection_name,
+            filter=expression,
+            timeout=self.timeout,
+        )
+
+    def search(
+        self,
+        query_embedding: Sequence[float],
+        limit: int = 10,
+        metadata_filter: Optional[Dict[str, Any]] = None,
+    ) -> List[VectorMatch]:
+        if limit <= 0 or not query_embedding:
+            return []
+        self._validate_dimension(query_embedding)
+        self._ensure_ready()
+
+        expression = self._build_filter(
+            metadata_filter,
+            shared_visible_to_user=True,
+        )
+        response = self._client.search(
+            collection_name=self.collection_name,
+            data=[list(query_embedding)],
+            anns_field="embedding",
+            filter=expression,
+            limit=limit,
+            output_fields=self._OUTPUT_FIELDS,
+            search_params={"metric_type": "COSINE", "params": {}},
+            consistency_level=self.consistency_level,
+            timeout=self.timeout,
+        )
+
+        hits = response[0] if response else []
+        matches = []
+        for hit in hits:
+            score = float(hit.get("distance", hit.get("score", 0.0)))
+            if score <= 0:
+                continue
+            entity = hit.get("entity") or {}
+            raw_metadata = entity.get("metadata_json")
+            try:
+                metadata = json.loads(raw_metadata) if raw_metadata else None
+            except (TypeError, ValueError):
+                metadata = None
+            matches.append(
+                VectorMatch(
+                    id=str(hit.get("id", entity.get("id", ""))),
+                    score=score,
+                    metadata={
+                        "user_id": entity.get("user_id") or None,
+                        "scope": entity.get("scope"),
+                        "source": entity.get("source"),
+                        "path": entity.get("path"),
+                        "start_line": entity.get("start_line"),
+                        "end_line": entity.get("end_line"),
+                        "text": entity.get("text") or "",
+                        "metadata": metadata,
+                    },
+                )
+            )
+        matches.sort(key=lambda item: item.score, reverse=True)
+        return matches[:limit]
+
+    def close(self) -> None:
+        client = self._client
+        self._client = None
+        self._ready = False
+        if client is not None:
+            client.close()
+
+    def _ensure_ready(self) -> None:
+        if self._ready:
+            return
+        if self._client is None:
+            self._client = self._create_client()
+
+        if self._client.has_collection(
+            collection_name=self.collection_name,
+            timeout=self.timeout,
+        ):
+            self.collection_created = False
+            self._validate_collection()
+        else:
+            self._create_collection()
+            self.collection_created = True
+
+        # Existing Lite collections are released after the previous client is
+        # closed. Loading is idempotent for server and cloud deployments.
+        self._client.load_collection(
+            collection_name=self.collection_name,
+            timeout=self.timeout,
+        )
+        self._ready = True
+
+    def _create_client(self):
+        factory = self._client_factory
+        if factory is None:
+            try:
+                from pymilvus import DataType, MilvusClient
+            except ImportError as exc:
+                raise RuntimeError(
+                    "Milvus backend requires the optional 'milvus' extra"
+                ) from exc
+            factory = MilvusClient
+            self._data_type = DataType
+
+        kwargs = {
+            "uri": self.uri,
+            "db_name": self.db_name,
+            "timeout": self.timeout,
+        }
+        if self.token:
+            kwargs["token"] = self.token
+        return factory(**kwargs)
+
+    def _create_collection(self) -> None:
+        data_type = self._data_type
+        if data_type is None:
+            raise RuntimeError("Milvus DataType is unavailable")
+
+        schema = self._client.create_schema(
+            auto_id=False,
+            enable_dynamic_field=False,
+        )
+        schema.add_field(
+            field_name="id",
+            datatype=data_type.VARCHAR,
+            is_primary=True,
+            max_length=64,
+        )
+        schema.add_field(
+            field_name="embedding",
+            datatype=data_type.FLOAT_VECTOR,
+            dim=self.dimension,
+        )
+        for name, max_length in (
+            ("workspace_id", 64),
+            ("user_id", 4096),
+            ("scope", 64),
+            ("source", 256),
+            ("path", 65535),
+            ("text", 65535),
+            ("metadata_json", 65535),
+        ):
+            schema.add_field(
+                field_name=name,
+                datatype=data_type.VARCHAR,
+                max_length=max_length,
+            )
+        schema.add_field(field_name="start_line", datatype=data_type.INT64)
+        schema.add_field(field_name="end_line", datatype=data_type.INT64)
+
+        index_params = self._client.prepare_index_params()
+        index_params.add_index(
+            field_name="embedding",
+            index_name="embedding",
+            index_type="AUTOINDEX",
+            metric_type="COSINE",
+        )
+        self._client.create_collection(
+            collection_name=self.collection_name,
+            schema=schema,
+            index_params=index_params,
+            consistency_level=self.consistency_level,
+            timeout=self.timeout,
+        )
+
+    def _validate_collection(self) -> None:
+        description = self._client.describe_collection(
+            collection_name=self.collection_name,
+            timeout=self.timeout,
+        )
+        fields = {
+            field.get("name"): field
+            for field in (description.get("fields") or [])
+        }
+        required = {
+            "id",
+            "embedding",
+            "workspace_id",
+            "user_id",
+            "scope",
+            "source",
+            "path",
+            "start_line",
+            "end_line",
+            "text",
+            "metadata_json",
+        }
+        missing = sorted(required.difference(fields))
+        if missing:
+            raise MilvusConfigurationError(
+                "Milvus collection '{}' is missing required fields: {}".format(
+                    self.collection_name,
+                    ", ".join(missing),
+                )
+            )
+
+        vector_params = fields["embedding"].get("params") or {}
+        actual_dimension = int(vector_params.get("dim") or 0)
+        if actual_dimension != self.dimension:
+            raise MilvusConfigurationError(
+                "Milvus collection '{}' dimension {} does not match embedding "
+                "dimension {}".format(
+                    self.collection_name,
+                    actual_dimension,
+                    self.dimension,
+                )
+            )
+
+        try:
+            index = self._client.describe_index(
+                collection_name=self.collection_name,
+                index_name="embedding",
+                timeout=self.timeout,
+            )
+        except Exception:
+            # Older compatible servers may not expose describe_index through
+            # MilvusClient. Search still supplies COSINE explicitly.
+            return
+        metric = str(index.get("metric_type") or "").upper()
+        if metric and metric != "COSINE":
+            raise MilvusConfigurationError(
+                "Milvus collection '{}' uses {} instead of COSINE".format(
+                    self.collection_name,
+                    metric,
+                )
+            )
+
+    def _validate_dimension(self, embedding: Sequence[float]) -> None:
+        if len(embedding) != self.dimension:
+            raise MilvusConfigurationError(
+                "Embedding dimension {} does not match Milvus dimension {}".format(
+                    len(embedding),
+                    self.dimension,
+                )
+            )
+
+    def _build_filter(
+        self,
+        metadata_filter: Optional[Dict[str, Any]],
+        *,
+        ids: Optional[Sequence[str]] = None,
+        shared_visible_to_user: bool,
+    ) -> str:
+        clauses = ["workspace_id == {}".format(self._literal(self.workspace_id))]
+        metadata_filter = metadata_filter or {}
+
+        scopes = metadata_filter.get("scopes")
+        if scopes is not None:
+            if not scopes:
+                clauses.append("id == {}".format(self._literal("__no_match__")))
+            else:
+                clauses.append("scope in {}".format(self._literal(list(scopes))))
+
+        user_id = metadata_filter.get("user_id")
+        if shared_visible_to_user and user_id:
+            clauses.append(
+                "(scope == {} or user_id == {})".format(
+                    self._literal("shared"),
+                    self._literal(user_id),
+                )
+            )
+
+        for key, value in metadata_filter.items():
+            if key == "scopes" or (
+                key == "user_id" and shared_visible_to_user
+            ) or value is None:
+                continue
+            if key not in self._FILTER_COLUMNS:
+                raise ValueError(
+                    "Unsupported vector metadata filter: {}".format(key)
+                )
+            clauses.append("{} == {}".format(key, self._literal(value)))
+
+        if ids is not None:
+            clauses.append("id in {}".format(self._literal(list(ids))))
+        return " and ".join(clauses)
+
+    @staticmethod
+    def _literal(value: Any) -> str:
+        """Encode values without interpolating raw user-controlled syntax."""
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))

--- a/agent/memory/storage.py
+++ b/agent/memory/storage.py
@@ -15,7 +15,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 from agent.memory.vector_backend import (
     SQLiteVectorBackend,
@@ -119,15 +119,21 @@ class MemoryStorage:
         self.db_path = db_path
         self.conn: Optional[sqlite3.Connection] = None
         self.vector_backend = vector_backend
+        self._external_vector_backend = vector_backend
+        self._local_vector_backend: Optional[SQLiteVectorBackend] = None
+        self._vector_backend_error: Optional[str] = None
         self.fts5_available = False  # Track FTS5 availability
         # RLock protects concurrent writes from the same process.
         # SQLite WAL mode handles read/write concurrency at the file level,
         # but same-process concurrent writes still need a Python-level lock.
         self._lock = threading.RLock()
         self._init_db()
+        assert self.conn is not None
+        self._local_vector_backend = SQLiteVectorBackend(self.conn)
         if self.vector_backend is None:
-            assert self.conn is not None
-            self.vector_backend = SQLiteVectorBackend(self.conn)
+            self.vector_backend = self._local_vector_backend
+        else:
+            self._init_vector_sync()
     
     def _check_fts5_support(self) -> bool:
         """Check if SQLite has FTS5 support"""
@@ -612,11 +618,14 @@ class MemoryStorage:
         with self._lock:
             try:
                 self.conn.execute(_SQL, params)
-                self.vector_backend.upsert([self._to_vector_record(chunk)])
+                record = self._to_vector_record(chunk)
+                self._local_vector_backend.upsert([record])
+                self._enqueue_vector_upserts([record])
                 self.conn.commit()
             except Exception:
                 self.conn.rollback()
                 raise
+        self._drain_vector_sync_queue()
 
     def save_chunks_batch(self, chunks: List[MemoryChunk]):
         """Save multiple chunks in a batch (insert or update by id).
@@ -662,13 +671,14 @@ class MemoryStorage:
         with self._lock:
             try:
                 self.conn.executemany(_SQL, params_list)
-                self.vector_backend.upsert([
-                    self._to_vector_record(chunk) for chunk in chunks
-                ])
+                records = [self._to_vector_record(chunk) for chunk in chunks]
+                self._local_vector_backend.upsert(records)
+                self._enqueue_vector_upserts(records)
                 self.conn.commit()
             except Exception:
                 self.conn.rollback()
                 raise
+        self._drain_vector_sync_queue()
     
     def get_chunk(self, chunk_id: str) -> Optional[MemoryChunk]:
         """Get a chunk by ID"""
@@ -696,11 +706,24 @@ class MemoryStorage:
         metadata_filter = {"scopes": scopes}
         if user_id:
             metadata_filter["user_id"] = user_id
-        matches = self.vector_backend.search(
-            query_embedding,
-            limit=limit,
-            metadata_filter=metadata_filter,
-        )
+        backend = self._select_search_backend()
+        try:
+            matches = backend.search(
+                query_embedding,
+                limit=limit,
+                metadata_filter=metadata_filter,
+            )
+            if backend is self._external_vector_backend:
+                self._vector_backend_error = None
+        except Exception as exc:
+            if backend is self._local_vector_backend:
+                raise
+            self._record_vector_backend_error(exc)
+            matches = self._local_vector_backend.search(
+                query_embedding,
+                limit=limit,
+                metadata_filter=metadata_filter,
+            )
         return [
             SearchResult(
                 path=match.metadata["path"],
@@ -906,15 +929,356 @@ class MemoryStorage:
 
     def delete_by_path(self, path: str):
         """Delete all chunks and file metadata for a path."""
+        deleted_ids = []
+        sync_entries = []
         with self._lock:
             try:
-                self.vector_backend.delete(metadata_filter={"path": path})
+                deleted_ids = [
+                    row["id"]
+                    for row in self.conn.execute(
+                        "SELECT id FROM chunks WHERE path = ?",
+                        (path,),
+                    ).fetchall()
+                ]
+                self._enqueue_vector_deletes(deleted_ids)
+                if self._external_vector_backend is not None:
+                    for item_id in deleted_ids:
+                        row = self.conn.execute(
+                            "SELECT operation, version FROM _vector_sync_queue "
+                            "WHERE id = ?",
+                            (item_id,),
+                        ).fetchone()
+                        if row is not None:
+                            sync_entries.append(
+                                (item_id, row["operation"], row["version"])
+                            )
                 self.conn.execute("DELETE FROM chunks WHERE path = ?", (path,))
                 self.conn.execute("DELETE FROM files WHERE path = ?", (path,))
                 self.conn.commit()
             except Exception:
                 self.conn.rollback()
                 raise
+
+        backend = self._external_vector_backend
+        if backend is not None:
+            if self._retry_vector_operation(
+                lambda: backend.delete(metadata_filter={"path": path})
+            ):
+                self._clear_vector_sync_entries(sync_entries)
+
+    def clear_memory_index(self) -> int:
+        """Clear derived memory rows while durably scheduling vector deletes."""
+        with self._lock:
+            rows = self.conn.execute("SELECT id FROM chunks").fetchall()
+            ids = [row["id"] for row in rows]
+            try:
+                self._enqueue_vector_deletes(ids)
+                self.conn.execute("DELETE FROM chunks")
+                self.conn.execute("DELETE FROM files")
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+        self._drain_vector_sync_queue()
+        return len(ids)
+
+    def set_external_vector_backend(
+        self,
+        backend: Optional[VectorBackend],
+    ) -> None:
+        """Replace the optional search backend without changing SQLite data."""
+        current = self._external_vector_backend
+        if current is backend:
+            return
+        if current is not None:
+            close = getattr(current, "close", None)
+            if close is not None:
+                try:
+                    close()
+                except Exception as exc:
+                    self._record_vector_backend_error(exc)
+        self._external_vector_backend = backend
+        self.vector_backend = backend or self._local_vector_backend
+        self._vector_backend_error = None
+        if backend is not None:
+            self._init_vector_sync()
+
+    def get_vector_backend_status(self) -> Dict[str, Any]:
+        backend = self._external_vector_backend
+        return {
+            "backend": "milvus" if backend is not None else "sqlite",
+            "healthy": self._vector_backend_error is None,
+            "pending": self._pending_vector_sync_count(),
+            "error": self._vector_backend_error,
+        }
+
+    def _init_vector_sync(self) -> None:
+        with self._lock:
+            self.conn.execute("""
+                CREATE TABLE IF NOT EXISTS _vector_sync_queue (
+                    id TEXT PRIMARY KEY,
+                    operation TEXT NOT NULL,
+                    version INTEGER NOT NULL DEFAULT 1,
+                    updated_at INTEGER DEFAULT (strftime('%s', 'now'))
+                )
+            """)
+            columns = {
+                row["name"]
+                for row in self.conn.execute(
+                    "PRAGMA table_info(_vector_sync_queue)"
+                ).fetchall()
+            }
+            if "version" not in columns:
+                self.conn.execute(
+                    "ALTER TABLE _vector_sync_queue "
+                    "ADD COLUMN version INTEGER NOT NULL DEFAULT 1"
+                )
+            self.conn.commit()
+
+        prepared, created = self._prepare_external_vector_backend()
+        meta_key = self._vector_sync_meta_key()
+        with self._lock:
+            backfill_done = self.conn.execute(
+                "SELECT 1 FROM _meta WHERE key = ?",
+                (meta_key,),
+            ).fetchone()
+            if created:
+                self.conn.execute("DELETE FROM _meta WHERE key = ?", (meta_key,))
+                backfill_done = None
+            if not backfill_done:
+                self.conn.execute("""
+                    INSERT INTO _vector_sync_queue(id, operation, updated_at)
+                    SELECT id, 'upsert', strftime('%s', 'now')
+                    FROM chunks
+                    WHERE embedding IS NOT NULL
+                    ON CONFLICT(id) DO UPDATE SET
+                        operation = 'upsert',
+                        version = _vector_sync_queue.version + 1,
+                        updated_at = strftime('%s', 'now')
+                """)
+            self.conn.commit()
+        if prepared:
+            self._drain_vector_sync_queue(prepared=True)
+
+    def _enqueue_vector_upserts(self, records: Sequence[VectorRecord]) -> None:
+        if self._external_vector_backend is None or not records:
+            return
+        self.conn.executemany(
+            """
+            INSERT INTO _vector_sync_queue(id, operation, updated_at)
+            VALUES (?, 'upsert', strftime('%s', 'now'))
+            ON CONFLICT(id) DO UPDATE SET
+                operation = 'upsert',
+                version = _vector_sync_queue.version + 1,
+                updated_at = strftime('%s', 'now')
+            """,
+            [(record.id,) for record in records],
+        )
+
+    def _enqueue_vector_deletes(self, ids: Sequence[str]) -> None:
+        if self._external_vector_backend is None or not ids:
+            return
+        self.conn.executemany(
+            """
+            INSERT INTO _vector_sync_queue(id, operation, updated_at)
+            VALUES (?, 'delete', strftime('%s', 'now'))
+            ON CONFLICT(id) DO UPDATE SET
+                operation = 'delete',
+                version = _vector_sync_queue.version + 1,
+                updated_at = strftime('%s', 'now')
+            """,
+            [(item,) for item in ids],
+        )
+
+    def _clear_vector_sync_entries(self, entries) -> None:
+        if not entries or not self._vector_sync_table_exists():
+            return
+        with self._lock:
+            self.conn.executemany(
+                "DELETE FROM _vector_sync_queue "
+                "WHERE id = ? AND operation = ? AND version = ?",
+                entries,
+            )
+            self.conn.commit()
+            self._mark_vector_sync_complete_if_idle()
+
+    def _drain_vector_sync_queue(self, prepared: bool = False) -> bool:
+        backend = self._external_vector_backend
+        if backend is None:
+            return True
+        if not self._vector_sync_table_exists():
+            return True
+        if not prepared:
+            prepared, _ = self._prepare_external_vector_backend()
+            if not prepared:
+                return False
+
+        while True:
+            with self._lock:
+                queued = self.conn.execute(
+                    "SELECT id, operation, version FROM _vector_sync_queue "
+                    "ORDER BY updated_at, id LIMIT 256"
+                ).fetchall()
+            if not queued:
+                with self._lock:
+                    self._mark_vector_sync_complete_if_idle()
+                self._vector_backend_error = None
+                return True
+
+            upsert_records = []
+            delete_ids = []
+            for item in queued:
+                if item["operation"] == "upsert":
+                    row = self.conn.execute(
+                        "SELECT * FROM chunks WHERE id = ?",
+                        (item["id"],),
+                    ).fetchone()
+                    if row is not None and row["embedding"] is not None:
+                        upsert_records.append(self._row_to_vector_record(row))
+                    else:
+                        delete_ids.append(item["id"])
+                else:
+                    delete_ids.append(item["id"])
+
+            def apply_batch():
+                if upsert_records:
+                    backend.upsert(upsert_records)
+                if delete_ids:
+                    backend.delete(ids=delete_ids)
+
+            if not self._retry_vector_operation(apply_batch):
+                return False
+
+            with self._lock:
+                self.conn.executemany(
+                    "DELETE FROM _vector_sync_queue "
+                    "WHERE id = ? AND operation = ? AND version = ?",
+                    [
+                        (item["id"], item["operation"], item["version"])
+                        for item in queued
+                    ],
+                )
+                self.conn.commit()
+
+    def _prepare_external_vector_backend(self):
+        backend = self._external_vector_backend
+        if backend is None:
+            return True, False
+        prepare = getattr(backend, "prepare", None)
+        if prepare is None:
+            return True, False
+        try:
+            created = bool(prepare())
+        except Exception as exc:
+            self._record_vector_backend_error(exc)
+            return False, False
+        if created and self._vector_sync_table_exists():
+            with self._lock:
+                self.conn.execute("DELETE FROM _meta WHERE key = ?", (
+                    self._vector_sync_meta_key(),
+                ))
+                self.conn.execute("""
+                    INSERT INTO _vector_sync_queue(id, operation, updated_at)
+                    SELECT id, 'upsert', strftime('%s', 'now')
+                    FROM chunks
+                    WHERE embedding IS NOT NULL
+                    ON CONFLICT(id) DO UPDATE SET
+                        operation = 'upsert',
+                        version = _vector_sync_queue.version + 1,
+                        updated_at = strftime('%s', 'now')
+                """)
+                self.conn.commit()
+        return True, created
+
+    def _retry_vector_operation(self, operation) -> bool:
+        last_error = None
+        for attempt in range(3):
+            try:
+                operation()
+                self._vector_backend_error = None
+                return True
+            except (ValueError, TypeError) as exc:
+                last_error = exc
+                break
+            except Exception as exc:
+                last_error = exc
+                if attempt < 2:
+                    time.sleep(0.1 * (2 ** attempt))
+        self._record_vector_backend_error(last_error)
+        return False
+
+    def _select_search_backend(self) -> VectorBackend:
+        backend = self._external_vector_backend
+        if backend is None:
+            return self._local_vector_backend
+        prepared, _ = self._prepare_external_vector_backend()
+        if not prepared or not self._drain_vector_sync_queue(prepared=True):
+            return self._local_vector_backend
+        if self._pending_vector_sync_count():
+            return self._local_vector_backend
+        return backend
+
+    def _record_vector_backend_error(self, error) -> None:
+        if error is None:
+            return
+        message = str(error)
+        backend = self._external_vector_backend
+        for secret in (
+            getattr(backend, "token", ""),
+            getattr(backend, "uri", ""),
+        ):
+            if secret:
+                message = message.replace(str(secret), "<redacted>")
+        message = re.sub(r"(https?://)([^/@\s]+)@", r"\1<redacted>@", message)
+        safe = "{}: {}".format(type(error).__name__, message)
+        if safe == self._vector_backend_error:
+            return
+        self._vector_backend_error = safe
+        from common.log import logger
+        logger.warning(
+            "[MemoryStorage] External vector backend unavailable; "
+            "using SQLite fallback: %s",
+            safe,
+        )
+
+    def _pending_vector_sync_count(self) -> int:
+        if not self._vector_sync_table_exists():
+            return 0
+        row = self.conn.execute(
+            "SELECT COUNT(*) AS cnt FROM _vector_sync_queue"
+        ).fetchone()
+        return int(row["cnt"] if row else 0)
+
+    def _vector_sync_table_exists(self) -> bool:
+        if self.conn is None:
+            return False
+        row = self.conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' "
+            "AND name='_vector_sync_queue'"
+        ).fetchone()
+        return row is not None
+
+    def _vector_sync_meta_key(self) -> str:
+        backend = self._external_vector_backend
+        sync_key = getattr(backend, "sync_key", None)
+        if not sync_key:
+            raw = "{}:{}".format(
+                type(backend).__module__,
+                type(backend).__name__,
+            )
+            sync_key = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+        return "vector_sync:{}".format(sync_key)
+
+    def _mark_vector_sync_complete_if_idle(self) -> None:
+        if self._external_vector_backend is None:
+            return
+        if self._pending_vector_sync_count():
+            return
+        self.conn.execute(
+            "INSERT OR REPLACE INTO _meta(key, value) VALUES (?, '1')",
+            (self._vector_sync_meta_key(),),
+        )
+        self.conn.commit()
 
     def get_file_hash(self, path: str) -> Optional[str]:
         """Get stored file hash"""
@@ -950,10 +1314,19 @@ class MemoryStorage:
             'chunks': chunks_count,
             'files': files_count,
             'embedded': embedded_count,
+            'vector_sync_pending': self._pending_vector_sync_count(),
         }
     
     def close(self):
         """Close database connection"""
+        backend = self._external_vector_backend
+        if backend is not None:
+            close = getattr(backend, "close", None)
+            if close is not None:
+                try:
+                    close()
+                except Exception as e:
+                    self._record_vector_backend_error(e)
         if self.conn:
             try:
                 self.conn.commit()  # Ensure all changes are committed
@@ -986,6 +1359,24 @@ class MemoryStorage:
                 "end_line": chunk.end_line,
                 "text": chunk.text,
                 "metadata": chunk.metadata,
+            },
+        )
+
+    def _row_to_vector_record(self, row) -> VectorRecord:
+        return VectorRecord(
+            id=row["id"],
+            embedding=self._decode_embedding(row["embedding"]),
+            metadata={
+                "user_id": row["user_id"],
+                "scope": row["scope"],
+                "source": row["source"],
+                "path": row["path"],
+                "start_line": row["start_line"],
+                "end_line": row["end_line"],
+                "text": row["text"],
+                "metadata": (
+                    json.loads(row["metadata"]) if row["metadata"] else None
+                ),
             },
         )
 

--- a/agent/memory/vector_backend_factory.py
+++ b/agent/memory/vector_backend_factory.py
@@ -1,0 +1,51 @@
+"""Factory for optional memory vector backends."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+from typing import Optional
+
+from agent.memory.config import MemoryConfig
+from agent.memory.milvus_backend import MilvusVectorBackend
+from agent.memory.vector_backend import VectorBackend
+
+
+def create_external_vector_backend(
+    config: MemoryConfig,
+    dimension: Optional[int],
+) -> Optional[VectorBackend]:
+    """Create the configured external backend, or ``None`` for SQLite."""
+    backend_name = (config.vector_backend or "sqlite").strip().lower()
+    if backend_name == "sqlite":
+        return None
+    if backend_name != "milvus":
+        raise ValueError("Unknown memory vector backend: {}".format(backend_name))
+    if not dimension or dimension <= 1:
+        # Memory is keyword-only until an embedding provider becomes available.
+        return None
+
+    workspace = os.path.realpath(str(config.get_workspace()))
+    workspace_id = hashlib.sha256(workspace.encode("utf-8")).hexdigest()[:16]
+    collection = (config.milvus_collection or "").strip()
+    if not collection:
+        collection = "cowagent_memory_{}_d{}".format(workspace_id, dimension)
+
+    uri = (config.milvus_uri or "").strip()
+    if not uri:
+        uri = str(
+            Path(config.get_db_path()).with_name("milvus.db").resolve()
+        )
+
+    token = os.environ.get("MILVUS_TOKEN") or config.milvus_token or ""
+    return MilvusVectorBackend(
+        uri=uri,
+        collection_name=collection,
+        dimension=dimension,
+        workspace_id=workspace_id,
+        token=token,
+        db_name=config.milvus_db_name,
+        timeout=config.milvus_timeout,
+        consistency_level=config.milvus_consistency_level,
+    )

--- a/bridge/agent_initializer.py
+++ b/bridge/agent_initializer.py
@@ -289,11 +289,13 @@ class AgentInitializer:
         memory_tools = []
         
         try:
-            from agent.memory import MemoryManager, MemoryConfig, register_memory_config
+            from agent.memory import (
+                MemoryManager,
+                create_memory_config,
+                register_memory_config,
+            )
             from agent.tools import MemorySearchTool, MemoryGetTool
-            from config import conf
-
-            memory_config = MemoryConfig(workspace_root=workspace_root)
+            memory_config = create_memory_config(workspace_root)
             # Publish per workspace, not process-wide: this runs once per Agent,
             # and a single global slot would leave the last one to initialize
             # owning where every Agent's memory is written.

--- a/config-template.json
+++ b/config-template.json
@@ -45,6 +45,13 @@
   "enable_thinking": false,
   "reasoning_effort": "high",
   "knowledge": true,
+  "vector_backend": "sqlite",
+  "milvus_uri": "",
+  "milvus_token": "",
+  "milvus_db_name": "default",
+  "milvus_collection": "",
+  "milvus_timeout": 10.0,
+  "milvus_consistency_level": "Strong",
   "self_evolution_enabled": true,
   "mcp_tool_retrieval_enabled": false
 }

--- a/config.py
+++ b/config.py
@@ -117,6 +117,14 @@ available_setting = {
     "embedding_provider": "",  # explicitly set the provider: openai / linkai / dashscope / doubao / zhipu (aligned with bot_type naming)
     "embedding_model": "",     # leave empty to use the provider's default model
     "embedding_dimensions": 0, # leave empty/0 to use the provider's default dimension (1024 recommended for consistency)
+    # Memory vector backend. SQLite/FTS5 remains the zero-dependency default.
+    "vector_backend": "sqlite",  # sqlite | milvus
+    "milvus_uri": "",  # local .db path (Lite) or http(s) server/cloud endpoint
+    "milvus_token": "",  # prefer the MILVUS_TOKEN environment variable
+    "milvus_db_name": "default",
+    "milvus_collection": "",  # empty = workspace- and dimension-scoped name
+    "milvus_timeout": 10.0,
+    "milvus_consistency_level": "Strong",
     # voice config
     "speech_recognition": True,  # whether to enable speech recognition
     "group_speech_recognition": False,  # whether to enable group speech recognition
@@ -374,18 +382,25 @@ config = Config()
 
 
 def _mask_value(val):
-    """Mask a sensitive string value, keeping first 3 and last 3 chars."""
-    if not isinstance(val, str) or len(val) <= 8:
+    """Remove a sensitive string value from diagnostic output."""
+    if not isinstance(val, str) or not val:
         return val
-    return val[0:3] + "*" * 5 + val[-3:]
+    return "<redacted>"
 
 
 def _mask_sensitive_recursive(obj):
-    """Recursively mask values whose keys contain 'key' or 'secret'."""
+    """Recursively mask values stored under credential-like keys."""
     if isinstance(obj, dict):
         masked = {}
         for k, v in obj.items():
-            if ("key" in k or "secret" in k) and isinstance(v, str):
+            key = str(k).lower()
+            if (
+                key == "milvus_uri"
+                or any(
+                    marker in key
+                    for marker in ("key", "secret", "token", "password")
+                )
+            ) and isinstance(v, str):
                 masked[k] = _mask_value(v)
             else:
                 masked[k] = _mask_sensitive_recursive(v)
@@ -505,7 +520,13 @@ def load_config():
         if name.startswith("_"):
             continue
         if name in available_setting:
-            logger.info("[INIT] override config by environ args: {}={}".format(name, value))
+            safe_value = _mask_sensitive_recursive({name: value})[name]
+            logger.info(
+                "[INIT] override config by environ args: {}={}".format(
+                    name,
+                    safe_value,
+                )
+            )
             try:
                 # SECURITY: Use ast.literal_eval instead of eval().
                 # ast.literal_eval only parses Python literals (strings, numbers,

--- a/docs/ja/memory/index.mdx
+++ b/docs/ja/memory/index.mdx
@@ -32,6 +32,41 @@ Agent は以下のメカニズムにより、会話内容を長期記憶に自�
 
 すべての記憶書き込みはバックグラウンドスレッドで非同期に実行され（LLM の要約 + ファイル書き込み）、通常の会話応答をブロックしません。
 
+## メモリ検索
+
+メモリシステムは FTS5 によるキーワード検索と、embedding によるベクトル検索を組み合わせます。SQLite は追加依存関係のないデフォルトのベクトルバックエンドです。どのベクトルバックエンドを選んでも、FTS5 キーワード検索は引き続き SQLite を使用します。
+
+### オプションの Milvus ベクトルバックエンド
+
+Milvus Server または Zilliz Cloud を使う場合は、Python 3.9 以降で次をインストールします。
+
+```bash
+pip3 install -e ".[milvus]"
+```
+
+ローカルの組み込み Milvus Lite を使う場合は、Python 3.10 以降で次をインストールします。
+
+```bash
+pip3 install -e ".[milvus-lite]"
+```
+
+続いて `config.json` でバックエンドを選択します。`milvus_uri` には Milvus Lite のデータベースファイル、`http://localhost:19530` のような Milvus Server URI、または Zilliz Cloud の公開エンドポイントを指定できます。
+
+```json
+{
+  "vector_backend": "milvus",
+  "milvus_uri": "http://localhost:19530",
+  "milvus_db_name": "default",
+  "milvus_collection": "",
+  "milvus_timeout": 10.0,
+  "milvus_consistency_level": "Strong"
+}
+```
+
+Milvus Lite では `milvus_uri` に `/home/user/cow/memory/long-term/milvus.db` などのファイルを指定できます。空の場合は SQLite インデックスの隣に既定のファイルを作成します。認証が必要な Milvus または Zilliz Cloud では、資格情報をファイルに保存しないよう環境変数 `MILVUS_TOKEN` の使用を推奨します。`config.json` の `milvus_token` も利用できます。
+
+`milvus_collection` が空の場合、CowAgent はワークスペースと embedding 次元ごとに collection を作成します。既存 collection を明示する場合は、現在の次元と CowAgent schema が一致している必要があります。既存 SQLite ベクトルは自動的に backfill されます。SQLite は常に正本であり、Milvus への書き込み失敗は永続キューから再試行され、Milvus が利用不能または同期中なら検索は SQLite にフォールバックします。`/memory rebuild-index` はユーザー管理の collection を削除せず、両方のインデックスを再構築します。バックエンドのエラーログでは資格情報と接続 URI が伏せられます。
+
 ## 関連ファイル
 
 ワークスペース（デフォルト `~/cow`）内の記憶関連ファイル：
@@ -60,3 +95,9 @@ Web コンソールの記憶管理ページで、記憶ファイルと夢日記�
 | `agent_workspace` | ワークスペースパス、記憶ファイルはこのディレクトリ配下に保存されます | `~/cow` |
 | `agent_max_context_tokens` | 最大コンテキストトークン数。超過時にトリミングされ、記憶として要約されます | `50000` |
 | `agent_max_context_turns` | 最大コンテキストターン数。超過時にトリミングされ、記憶として要約されます | `20` |
+| `vector_backend` | ベクトルバックエンド：`sqlite` またはオプションの `milvus` | `sqlite` |
+| `milvus_uri` | Milvus Lite ファイル、Milvus Server URI、または Zilliz Cloud エンドポイント | ローカル `milvus.db` |
+| `milvus_db_name` | Milvus データベース名 | `default` |
+| `milvus_collection` | Collection 名。空ならワークスペースと次元から生成 | 空 |
+| `milvus_timeout` | Milvus 操作のタイムアウト（秒） | `10.0` |
+| `milvus_consistency_level` | Milvus の consistency level | `Strong` |

--- a/docs/memory/index.mdx
+++ b/docs/memory/index.mdx
@@ -41,6 +41,39 @@ The memory system supports hybrid retrieval modes:
 
 The Agent automatically triggers memory retrieval during conversation as needed, incorporating relevant historical information into context. Results are ranked by a combined score (default: 0.7 vector weight + 0.3 keyword weight). Daily memory scores decay over time (30-day half-life), while core memory does not decay.
 
+### Optional Milvus vector backend
+
+SQLite remains the default vector backend and requires no additional service or package. FTS5 keyword retrieval also remains in SQLite regardless of which vector backend is selected.
+
+To use a Milvus server or Zilliz Cloud, install the server extra (Python 3.9 or later):
+
+```bash
+pip3 install -e ".[milvus]"
+```
+
+For an embedded local database, install Milvus Lite (Python 3.10 or later):
+
+```bash
+pip3 install -e ".[milvus-lite]"
+```
+
+Then select the backend in `config.json`. The URI may be a local Milvus Lite database file, a Milvus server endpoint such as `http://localhost:19530`, or a Zilliz Cloud public endpoint:
+
+```json
+{
+  "vector_backend": "milvus",
+  "milvus_uri": "http://localhost:19530",
+  "milvus_db_name": "default",
+  "milvus_collection": "",
+  "milvus_timeout": 10.0,
+  "milvus_consistency_level": "Strong"
+}
+```
+
+For Milvus Lite, set `milvus_uri` to a database file such as `/home/user/cow/memory/long-term/milvus.db`, or leave it empty to use the default file next to the SQLite index. For authenticated Milvus or Zilliz Cloud, set the `MILVUS_TOKEN` environment variable; `milvus_token` is also accepted in `config.json`, but an environment variable avoids storing credentials in a file.
+
+CowAgent creates one dimension-specific collection per workspace when `milvus_collection` is empty. An explicitly named existing collection must use the same embedding dimension and CowAgent schema. Existing SQLite vectors are backfilled automatically. SQLite remains the authoritative copy: Milvus writes are retried from a durable queue, searches fall back to SQLite while Milvus is unavailable or behind, and `/memory rebuild-index` repopulates both indexes without dropping a user-managed collection. Credentials and connection URIs are redacted from backend error logs.
+
 ## Related Files
 
 Files related to memory in the workspace (default `~/cow`):
@@ -69,3 +102,9 @@ The memory management page in the Web console allows browsing memory files and d
 | `agent_workspace` | Workspace path, memory files stored under this directory | `~/cow` |
 | `agent_max_context_tokens` | Max context tokens; when exceeded, content is trimmed and summarized into memory | `50000` |
 | `agent_max_context_turns` | Max context turns; when exceeded, content is trimmed and summarized into memory | `20` |
+| `vector_backend` | Vector backend: `sqlite` or optional `milvus` | `sqlite` |
+| `milvus_uri` | Milvus Lite file, Milvus server URI, or Zilliz Cloud endpoint | local `milvus.db` |
+| `milvus_db_name` | Milvus database name | `default` |
+| `milvus_collection` | Collection name; empty creates a workspace/dimension-scoped name | empty |
+| `milvus_timeout` | Milvus operation timeout in seconds | `10.0` |
+| `milvus_consistency_level` | Milvus consistency level | `Strong` |

--- a/docs/zh/memory/index.mdx
+++ b/docs/zh/memory/index.mdx
@@ -41,6 +41,39 @@ Agent 通过以下机制自动将对话内容持久化为长期记忆：
 
 Agent 会在对话中根据需要自动触发记忆检索，将相关历史信息纳入上下文。检索结果按混合评分排序（默认向量权重 0.7、关键词权重 0.3），日级记忆会随时间衰减（半衰期 30 天），核心记忆不衰减。
 
+### 可选 Milvus 向量后端
+
+SQLite 仍是零额外依赖的默认向量后端；无论选择哪个向量后端，FTS5 关键词检索都继续使用 SQLite。
+
+使用 Milvus Server 或 Zilliz Cloud 时，请在 Python 3.9 及以上环境安装：
+
+```bash
+pip3 install -e ".[milvus]"
+```
+
+使用本地嵌入式 Milvus Lite 时，请在 Python 3.10 及以上环境安装：
+
+```bash
+pip3 install -e ".[milvus-lite]"
+```
+
+然后在 `config.json` 中启用后端。`milvus_uri` 可填写 Milvus Lite 数据库文件、`http://localhost:19530` 形式的 Milvus Server 地址，或 Zilliz Cloud 公网地址：
+
+```json
+{
+  "vector_backend": "milvus",
+  "milvus_uri": "http://localhost:19530",
+  "milvus_db_name": "default",
+  "milvus_collection": "",
+  "milvus_timeout": 10.0,
+  "milvus_consistency_level": "Strong"
+}
+```
+
+Milvus Lite 可将 `milvus_uri` 设为 `/home/user/cow/memory/long-term/milvus.db` 等文件路径；留空时使用 SQLite 索引旁的默认文件。Milvus Server 或 Zilliz Cloud 需要认证时，建议通过环境变量 `MILVUS_TOKEN` 提供令牌；也支持配置项 `milvus_token`，但环境变量可避免凭据落盘。
+
+`milvus_collection` 留空时，CowAgent 会按工作区和 embedding 维度创建独立 collection。手动指定的现有 collection 必须匹配当前维度和 CowAgent schema。已有 SQLite 向量会自动回填；SQLite 始终是权威副本，Milvus 写入失败会进入持久队列重试，远端不可用或未同步完成时搜索自动回退 SQLite。`/memory rebuild-index` 会重新填充两侧索引，但不会删除用户管理的 collection。后端错误日志会脱敏凭据与连接地址。
+
 ## 相关文件
 
 工作空间（默认 `~/cow`）中与记忆相关的文件：
@@ -69,3 +102,9 @@ Agent 会在对话中根据需要自动触发记忆检索，将相关历史信�
 | `agent_workspace` | 工作空间路径，记忆文件存储在此目录下 | `~/cow` |
 | `agent_max_context_tokens` | 最大上下文 token 数，超出时裁剪并总结写入记忆 | `50000` |
 | `agent_max_context_turns` | 最大上下文轮次，超出时裁剪并总结写入记忆 | `20` |
+| `vector_backend` | 向量后端：`sqlite` 或可选的 `milvus` | `sqlite` |
+| `milvus_uri` | Milvus Lite 文件、Milvus Server 地址或 Zilliz Cloud 地址 | 本地 `milvus.db` |
+| `milvus_db_name` | Milvus 数据库名 | `default` |
+| `milvus_collection` | Collection 名；留空时按工作区和维度生成 | 空 |
+| `milvus_timeout` | Milvus 操作超时（秒） | `10.0` |
+| `milvus_consistency_level` | Milvus 一致性级别 | `Strong` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,17 @@ dependencies = [
     "requests>=2.28.2",
 ]
 
+[project.optional-dependencies]
+# PyMilvus 2.6.x requires Python >3.8. CowAgent's core Python >=3.7 support is
+# unchanged because these dependencies are installed only when requested.
+milvus = [
+    "pymilvus>=2.6.14,<2.7",
+]
+milvus-lite = [
+    "pymilvus>=2.6.14,<2.7",
+    "milvus-lite>=3,<4",
+]
+
 [project.scripts]
 cow = "cli.cli:main"
 

--- a/tests/test_memory_rebuild_vector_backend.py
+++ b/tests/test_memory_rebuild_vector_backend.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+from agent.memory.embedding.rebuild import rebuild_in_process
+
+
+class ProbeEmbeddingProvider:
+    def embed_query(self, _text):
+        return [1.0, 0.0]
+
+
+def test_rebuild_aborts_before_clearing_when_vector_preflight_fails():
+    def fail_preflight():
+        raise ConnectionError("Milvus is unavailable")
+
+    manager = SimpleNamespace(
+        embedding_provider=ProbeEmbeddingProvider(),
+        configure_vector_backend=fail_preflight,
+    )
+
+    result = rebuild_in_process(manager)
+
+    assert result.ok is False
+    assert result.removed == 0
+    assert result.error == "vector backend preflight failed: Milvus is unavailable"

--- a/tests/test_milvus_backend.py
+++ b/tests/test_milvus_backend.py
@@ -1,0 +1,315 @@
+import pytest
+
+from agent.memory.config import MemoryConfig, create_memory_config
+from agent.memory.milvus_backend import (
+    MilvusConfigurationError,
+    MilvusVectorBackend,
+)
+from agent.memory.vector_backend import VectorRecord
+from agent.memory.vector_backend_factory import create_external_vector_backend
+
+
+class FakeDataType:
+    VARCHAR = "VARCHAR"
+    FLOAT_VECTOR = "FLOAT_VECTOR"
+    INT64 = "INT64"
+
+
+class FakeSchema:
+    def __init__(self):
+        self.fields = []
+
+    def add_field(self, **kwargs):
+        field = {"name": kwargs["field_name"], "params": {}}
+        if "dim" in kwargs:
+            field["params"]["dim"] = kwargs["dim"]
+        self.fields.append(field)
+
+
+class FakeIndexParams:
+    def __init__(self):
+        self.indexes = []
+
+    def add_index(self, **kwargs):
+        self.indexes.append(kwargs)
+
+
+class FakeMilvusClient:
+    def __init__(self, *, existing=False, dimension=2, **kwargs):
+        self.kwargs = kwargs
+        self.existing = existing
+        self.dimension = dimension
+        self.schema = None
+        self.index_params = None
+        self.loaded = []
+        self.upserts = []
+        self.deletes = []
+        self.search_kwargs = None
+        self.search_response = [[]]
+        self.closed = False
+
+    def has_collection(self, **kwargs):
+        return self.existing
+
+    def create_schema(self, **kwargs):
+        return FakeSchema()
+
+    def prepare_index_params(self):
+        return FakeIndexParams()
+
+    def create_collection(self, **kwargs):
+        self.existing = True
+        self.schema = kwargs["schema"]
+        self.index_params = kwargs["index_params"]
+
+    def describe_collection(self, **kwargs):
+        names = [
+            "id",
+            "embedding",
+            "workspace_id",
+            "user_id",
+            "scope",
+            "source",
+            "path",
+            "start_line",
+            "end_line",
+            "text",
+            "metadata_json",
+        ]
+        return {
+            "fields": [
+                {
+                    "name": name,
+                    "params": {"dim": self.dimension}
+                    if name == "embedding"
+                    else {},
+                }
+                for name in names
+            ]
+        }
+
+    def describe_index(self, **kwargs):
+        return {"metric_type": "COSINE"}
+
+    def load_collection(self, **kwargs):
+        self.loaded.append(kwargs["collection_name"])
+
+    def upsert(self, **kwargs):
+        self.upserts.append(kwargs)
+
+    def delete(self, **kwargs):
+        self.deletes.append(kwargs)
+
+    def search(self, **kwargs):
+        self.search_kwargs = kwargs
+        return self.search_response
+
+    def close(self):
+        self.closed = True
+
+
+def backend_with(client):
+    return MilvusVectorBackend(
+        uri="http://milvus.invalid:19530",
+        collection_name="cowagent_test",
+        dimension=2,
+        workspace_id="workspace-a",
+        token="secret-token",
+        client_factory=lambda **kwargs: client,
+        data_type=FakeDataType,
+    )
+
+
+def record(record_id="chunk-1", embedding=None, **metadata):
+    values = {
+        "user_id": None,
+        "scope": "shared",
+        "source": "memory",
+        "path": "memory/test.md",
+        "start_line": 1,
+        "end_line": 2,
+        "text": "hello",
+        "metadata": {"kind": "note"},
+    }
+    values.update(metadata)
+    return VectorRecord(
+        id=record_id,
+        embedding=embedding if embedding is not None else [1.0, 0.0],
+        metadata=values,
+    )
+
+
+def test_milvus_backend_creates_schema_upserts_and_loads_collection():
+    client = FakeMilvusClient()
+    backend = backend_with(client)
+
+    backend.upsert([record()])
+
+    assert client.loaded == ["cowagent_test"]
+    assert {field["name"] for field in client.schema.fields} >= {
+        "id",
+        "embedding",
+        "workspace_id",
+        "scope",
+        "path",
+        "text",
+    }
+    assert client.index_params.indexes == [
+        {
+            "field_name": "embedding",
+            "index_name": "embedding",
+            "index_type": "AUTOINDEX",
+            "metric_type": "COSINE",
+        }
+    ]
+    assert client.upserts[0]["data"][0]["workspace_id"] == "workspace-a"
+    assert client.upserts[0]["data"][0]["metadata_json"] == '{"kind":"note"}'
+
+
+def test_milvus_backend_preserves_visibility_filters_and_score_order():
+    client = FakeMilvusClient(existing=True)
+    client.search_response = [[
+        {
+            "id": "second",
+            "distance": 0.5,
+            "entity": {
+                "user_id": "",
+                "scope": "shared",
+                "source": "memory",
+                "path": "second.md",
+                "start_line": 1,
+                "end_line": 1,
+                "text": "second",
+                "metadata_json": "null",
+            },
+        },
+        {
+            "id": "best",
+            "distance": 0.9,
+            "entity": {
+                "user_id": "current",
+                "scope": "user",
+                "source": "knowledge",
+                "path": "best.md",
+                "start_line": 2,
+                "end_line": 3,
+                "text": "best",
+                "metadata_json": '{"kind":"doc"}',
+            },
+        },
+        {"id": "negative", "distance": -0.1, "entity": {}},
+    ]]
+    backend = backend_with(client)
+
+    matches = backend.search(
+        [1.0, 0.0],
+        metadata_filter={
+            "scopes": ["shared", "user"],
+            "user_id": "current",
+            "source": "memory",
+        },
+    )
+
+    expression = client.search_kwargs["filter"]
+    assert 'workspace_id == "workspace-a"' in expression
+    assert 'scope in ["shared","user"]' in expression
+    assert '(scope == "shared" or user_id == "current")' in expression
+    assert 'source == "memory"' in expression
+    assert [match.id for match in matches] == ["best", "second"]
+    assert matches[0].metadata["metadata"] == {"kind": "doc"}
+
+
+def test_milvus_filter_literals_escape_untrusted_values():
+    client = FakeMilvusClient(existing=True)
+    backend = backend_with(client)
+
+    backend.delete(metadata_filter={"path": 'a" or workspace_id != "x\\y'})
+
+    expression = client.deletes[0]["filter"]
+    assert expression.startswith('workspace_id == "workspace-a" and path == ')
+    assert '\\" or workspace_id != \\"x\\\\y' in expression
+
+
+def test_milvus_backend_rejects_existing_dimension_mismatch():
+    client = FakeMilvusClient(existing=True, dimension=3)
+    backend = backend_with(client)
+
+    with pytest.raises(MilvusConfigurationError, match="dimension 3"):
+        backend.prepare()
+
+
+def test_milvus_none_embedding_deletes_stale_vector():
+    client = FakeMilvusClient(existing=True)
+    backend = backend_with(client)
+    item = record(embedding=[1.0, 0.0])
+    item.embedding = None
+
+    backend.upsert([item])
+
+    assert client.upserts == []
+    assert 'id in ["chunk-1"]' in client.deletes[0]["filter"]
+
+
+def test_vector_backend_factory_keeps_sqlite_default_and_scopes_milvus(tmp_path):
+    sqlite_config = MemoryConfig(workspace_root=str(tmp_path))
+    assert create_external_vector_backend(sqlite_config, 2) is None
+
+    milvus_config = MemoryConfig(
+        workspace_root=str(tmp_path),
+        vector_backend="milvus",
+    )
+    backend = create_external_vector_backend(milvus_config, 2)
+    assert isinstance(backend, MilvusVectorBackend)
+    assert backend.collection_name.startswith("cowagent_memory_")
+    assert backend.collection_name.endswith("_d2")
+    assert backend.uri.endswith("milvus.db")
+
+
+def test_vector_backend_factory_prefers_environment_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("MILVUS_TOKEN", "environment-token")
+    config = MemoryConfig(
+        workspace_root=str(tmp_path),
+        vector_backend="milvus",
+        milvus_token="file-token",
+    )
+
+    backend = create_external_vector_backend(config, 2)
+
+    assert backend.token == "environment-token"
+
+
+def test_create_memory_config_reads_optional_backend_settings(tmp_path, monkeypatch):
+    runtime = {
+        "vector_backend": "milvus",
+        "milvus_uri": "http://localhost:19530",
+        "milvus_token": "configured-token",
+        "milvus_db_name": "cowagent",
+        "milvus_collection": "memory_vectors",
+        "milvus_timeout": 3.5,
+        "milvus_consistency_level": "Bounded",
+    }
+    monkeypatch.setattr("config.conf", lambda: runtime)
+
+    config = create_memory_config(str(tmp_path))
+
+    assert config.vector_backend == "milvus"
+    assert config.milvus_uri == "http://localhost:19530"
+    assert config.milvus_token == "configured-token"
+    assert config.milvus_db_name == "cowagent"
+    assert config.milvus_collection == "memory_vectors"
+    assert config.milvus_timeout == 3.5
+    assert config.milvus_consistency_level == "Bounded"
+
+
+def test_config_diagnostics_redact_milvus_credentials():
+    from config import drag_sensitive
+
+    masked = drag_sensitive({
+        "milvus_token": "short",
+        "web_password": "also-secret",
+        "milvus_uri": "https://milvus.example.com",
+    })
+
+    assert masked["milvus_token"] == "<redacted>"
+    assert masked["web_password"] == "<redacted>"
+    assert masked["milvus_uri"] == "<redacted>"

--- a/tests/test_milvus_lite_integration.py
+++ b/tests/test_milvus_lite_integration.py
@@ -1,0 +1,81 @@
+"""Optional real-backend tests; install ``.[milvus-lite]`` to run them."""
+
+import pytest
+
+pytest.importorskip("milvus_lite")
+pytest.importorskip("pymilvus")
+
+from agent.memory.milvus_backend import MilvusVectorBackend
+from agent.memory.vector_backend import VectorRecord
+
+
+def item(item_id, embedding, *, scope="shared", user_id=None, path=None):
+    return VectorRecord(
+        id=item_id,
+        embedding=embedding,
+        metadata={
+            "user_id": user_id,
+            "scope": scope,
+            "source": "memory",
+            "path": path or "memory/{}.md".format(item_id),
+            "start_line": 1,
+            "end_line": 1,
+            "text": "text for {}".format(item_id),
+            "metadata": {"kind": "integration"},
+        },
+    )
+
+
+def test_milvus_lite_crud_filter_score_and_reopen(tmp_path):
+    uri = str(tmp_path / "milvus.db")
+    kwargs = {
+        "uri": uri,
+        "collection_name": "cowagent_integration",
+        "dimension": 2,
+        "workspace_id": "workspace-integration",
+    }
+    backend = MilvusVectorBackend(**kwargs)
+    backend.upsert([
+        item("shared-best", [1.0, 0.0]),
+        item("shared-second", [0.8, 0.2]),
+        item(
+            "current-user",
+            [0.9, 0.1],
+            scope="user",
+            user_id="current",
+        ),
+        item(
+            "other-user",
+            [1.0, 0.0],
+            scope="user",
+            user_id="other",
+        ),
+    ])
+
+    matches = backend.search(
+        [1.0, 0.0],
+        metadata_filter={
+            "scopes": ["shared", "user"],
+            "user_id": "current",
+        },
+        limit=10,
+    )
+    assert [match.id for match in matches] == [
+        "shared-best",
+        "current-user",
+        "shared-second",
+    ]
+    assert all(match.score > 0 for match in matches)
+    assert matches[0].metadata["metadata"] == {"kind": "integration"}
+
+    backend.delete(metadata_filter={"path": "memory/shared-second.md"})
+    backend.close()
+
+    reopened = MilvusVectorBackend(**kwargs)
+    remaining = reopened.search(
+        [1.0, 0.0],
+        metadata_filter={"scopes": ["shared"]},
+        limit=10,
+    )
+    assert [match.id for match in remaining] == ["shared-best"]
+    reopened.close()

--- a/tests/test_vector_backend.py
+++ b/tests/test_vector_backend.py
@@ -131,3 +131,112 @@ def test_memory_storage_routes_vector_operations_through_backend(tmp_path):
     assert results[0].path == "memory/shared/custom.md"
     assert results[0].score == 0.75
     storage.close()
+
+
+class FailingVectorBackend(RecordingVectorBackend):
+    def __init__(self):
+        super().__init__()
+        self.fail_writes = True
+        self.fail_deletes = False
+        self.token = "top-secret-token"
+        self.uri = "https://user:password@milvus.example.com"
+
+    def upsert(self, records):
+        if self.fail_writes:
+            raise ConnectionError(
+                "{} at {} is unavailable".format(self.token, self.uri)
+            )
+        super().upsert(records)
+
+    def delete(self, ids=None, metadata_filter=None):
+        if self.fail_deletes:
+            raise ConnectionError("delete failed at {}".format(self.uri))
+        super().delete(ids=ids, metadata_filter=metadata_filter)
+
+
+def test_external_failure_keeps_sqlite_vectors_and_pending_retry(tmp_path, monkeypatch):
+    monkeypatch.setattr("agent.memory.storage.time.sleep", lambda _seconds: None)
+    backend = FailingVectorBackend()
+    storage = MemoryStorage(tmp_path / "index.db", vector_backend=backend)
+    chunk = _chunk("durable", [1.0, 0.0])
+
+    storage.save_chunk(chunk)
+
+    assert storage.get_chunk("durable").embedding == [1.0, 0.0]
+    assert storage.get_stats()["vector_sync_pending"] == 1
+    results = storage.search_vector([1.0, 0.0])
+    assert [result.path for result in results] == [chunk.path]
+    status = storage.get_vector_backend_status()
+    assert status["healthy"] is False
+    assert "top-secret-token" not in status["error"]
+    assert "password" not in status["error"]
+
+    backend.fail_writes = False
+    results = storage.search_vector([1.0, 0.0])
+    assert storage.get_stats()["vector_sync_pending"] == 0
+    assert backend.upserted[0].id == "durable"
+    assert results[0].score == 0.75
+    storage.close()
+
+
+def test_external_delete_failure_is_durable_and_retried(tmp_path, monkeypatch):
+    monkeypatch.setattr("agent.memory.storage.time.sleep", lambda _seconds: None)
+    backend = FailingVectorBackend()
+    backend.fail_writes = False
+    storage = MemoryStorage(tmp_path / "index.db", vector_backend=backend)
+    chunk = _chunk("delete-me", [1.0, 0.0])
+    storage.save_chunk(chunk)
+
+    backend.fail_deletes = True
+    storage.delete_by_path(chunk.path)
+
+    assert storage.get_chunk(chunk.id) is None
+    assert storage.get_stats()["vector_sync_pending"] == 1
+    backend.fail_deletes = False
+    storage.search_vector([1.0, 0.0])
+    assert storage.get_stats()["vector_sync_pending"] == 0
+    assert backend.deleted[-1] == ([chunk.id], None)
+    storage.close()
+
+
+def test_existing_sqlite_vectors_are_backfilled_once(tmp_path):
+    db_path = tmp_path / "index.db"
+    sqlite_storage = MemoryStorage(db_path)
+    sqlite_storage.save_chunk(_chunk("legacy", [0.5, 0.5]))
+    sqlite_storage.close()
+
+    first_backend = RecordingVectorBackend()
+    storage = MemoryStorage(db_path, vector_backend=first_backend)
+    assert [record.id for record in first_backend.upserted] == ["legacy"]
+    storage.close()
+
+    second_backend = RecordingVectorBackend()
+    storage = MemoryStorage(db_path, vector_backend=second_backend)
+    assert second_backend.upserted == []
+    storage.close()
+
+
+class ConcurrentUpdateBackend(RecordingVectorBackend):
+    def __init__(self):
+        super().__init__()
+        self.storage = None
+        self.calls = 0
+
+    def upsert(self, records):
+        self.calls += 1
+        super().upsert(records)
+        if self.calls == 1:
+            self.storage._enqueue_vector_upserts(records)
+            self.storage.conn.commit()
+
+
+def test_vector_queue_does_not_lose_update_during_remote_call(tmp_path):
+    backend = ConcurrentUpdateBackend()
+    storage = MemoryStorage(tmp_path / "index.db", vector_backend=backend)
+    backend.storage = storage
+
+    storage.save_chunk(_chunk("concurrent", [1.0, 0.0]))
+
+    assert backend.calls == 2
+    assert storage.get_stats()["vector_sync_pending"] == 0
+    storage.close()


### PR DESCRIPTION
## What does this PR do?

Adds the optional Milvus follow-up requested in #2956 after the VectorBackend abstraction landed in #3021.

- Adds a lazy-imported `MilvusVectorBackend` for Milvus Lite, Milvus Server, and Zilliz Cloud, with an explicit schema, COSINE/AUTOINDEX search, workspace isolation, metadata filters, collection validation, and embedding-dimension checks.
- Keeps SQLite as the zero-dependency authoritative store and keeps FTS5 unchanged. A versioned durable outbox backfills existing SQLite vectors, retries idempotent writes/deletes, avoids losing concurrent updates, and falls back to SQLite until Milvus is healthy and fully synchronized.
- Adds `milvus` and `milvus-lite` optional extras plus runtime configuration, token/URI log redaction, rebuild preflight/repopulation, backend health status, and English/Chinese/Japanese documentation.
- Preserves CowAgent's core `requires-python >=3.7`; the optional server extra requires Python 3.9+, while current Milvus Lite requires Python 3.10+.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Refactor / chore

## Testing

- `pip install -e .[milvus-lite]` in an isolated environment, followed by the focused backend, real Milvus Lite, and rebuild suites: **17 passed**.
- Focused unit/config/security suite: **35 passed**.
- Memory/knowledge/search regression matrix: **139 passed, 1 skipped, 14 failed**. The same command on a clean `origin/master` worktree produced **127 passed, 14 failed**; all 14 failures are pre-existing Windows/environment issues (symlink privileges, path separators, ripgrep CJK output, missing `web.py`) or existing workspace/recovery failures.
- `python -m compileall -q agent bridge tests`
- Ruff on the changed memory/backend/test modules
- `git diff --check origin/master...HEAD`

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): closes #2956

Closes #2956