### PR TITLE
feat(curiosity): add thread-safe v3 foundation

### DIFF
--- a/agent/curiosity/__init__.py
+++ b/agent/curiosity/__init__.py
@@ -1,0 +1,16 @@
+"""Thread-safe building blocks for the curiosity engine."""
+
+from .fatigue import FatigueGuard
+from .feedback import Feedback, FeedbackEngine
+from .interests import InterestGraph
+from .orchestrator import PushOrchestrator
+from .state import CuriosityState
+
+__all__ = [
+    "CuriosityState",
+    "FatigueGuard",
+    "Feedback",
+    "FeedbackEngine",
+    "InterestGraph",
+    "PushOrchestrator",
+]

--- a/agent/curiosity/fatigue.py
+++ b/agent/curiosity/fatigue.py
@@ -1,0 +1,36 @@
+"""Feedback-window based push fatigue protection."""
+
+from __future__ import annotations
+
+from .state import CuriosityState
+
+
+class FatigueGuard:
+    def __init__(
+        self,
+        state: CuriosityState,
+        window_size: int = 100,
+        negative_threshold: float = 0.6,
+    ) -> None:
+        if window_size <= 0:
+            raise ValueError("window_size must be positive")
+        if not 0 <= negative_threshold <= 1:
+            raise ValueError("negative_threshold must be between 0 and 1")
+        self.state = state
+        self.window_size = window_size
+        self.negative_threshold = negative_threshold
+
+    def record_feedback(self, accepted: bool) -> None:
+        """Record one result without exposing a read/modify/write race."""
+        with self.state._lock:
+            window = list(self.state.data.get("feedback_window", ()))
+            window.append(1 if accepted else 0)
+            self.state.data["feedback_window"] = window[-self.window_size :]
+
+    def is_fatigued(self) -> bool:
+        with self.state._lock:
+            window = list(self.state.data.get("feedback_window", ()))
+        if not window:
+            return False
+        negative_ratio = window.count(0) / len(window)
+        return negative_ratio >= self.negative_threshold

--- a/agent/curiosity/feedback.py
+++ b/agent/curiosity/feedback.py
@@ -1,0 +1,105 @@
+"""Conservative feedback classification with a safe LLM fallback."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Iterable, Optional, Union
+
+
+@dataclass(frozen=True)
+class Feedback:
+    type: str
+    weight: int
+
+
+Analyzer = Callable[[str], Union[Any, Awaitable[Any]]]
+
+
+class FeedbackEngine:
+    """Classify explicit feedback and optionally defer to an LLM.
+
+    Keyword matching is deliberately conservative for unsegmented CJK text:
+    a term must end at punctuation, whitespace, the end of the message, or a
+    contrast conjunction.  This avoids treating ``真好`` inside ``真好看`` as
+    an exact feedback token without adding a mandatory tokenizer dependency.
+    """
+
+    DEFAULT_POSITIVE = ("真好", "喜欢", "满意", "有趣")
+    DEFAULT_NEGATIVE = ("无聊", "讨厌", "失望", "不好")
+    _CJK = re.compile(r"[\u3400-\u9fff]")
+    _RIGHT_BOUNDARIES = frozenset("但却可而和也呢啊呀哦嘛吧，。！？；：,.!?;:\t\r\n ")
+
+    def __init__(
+        self,
+        positive_keywords: Iterable[str] = DEFAULT_POSITIVE,
+        negative_keywords: Iterable[str] = DEFAULT_NEGATIVE,
+        llm_analyzer: Optional[Analyzer] = None,
+    ) -> None:
+        self.positive_keywords = tuple(filter(None, positive_keywords))
+        self.negative_keywords = tuple(filter(None, negative_keywords))
+        self.llm_analyzer = llm_analyzer
+
+    @classmethod
+    def _contains_exact(cls, message: str, keyword: str) -> bool:
+        start = 0
+        while True:
+            index = message.find(keyword, start)
+            if index < 0:
+                return False
+            end = index + len(keyword)
+            if cls._CJK.search(keyword):
+                right_ok = end == len(message) or message[end] in cls._RIGHT_BOUNDARIES
+                if right_ok:
+                    return True
+            else:
+                left_ok = index == 0 or not message[index - 1].isalnum()
+                right_ok = end == len(message) or not message[end].isalnum()
+                if left_ok and right_ok:
+                    return True
+            start = index + 1
+
+    def _keyword_feedback(self, message: str) -> Optional[Feedback]:
+        positive = sum(self._contains_exact(message, word) for word in self.positive_keywords)
+        negative = sum(self._contains_exact(message, word) for word in self.negative_keywords)
+        if not positive and not negative:
+            return None
+        weight = positive - negative
+        if weight > 0:
+            return Feedback("positive", weight)
+        if weight < 0:
+            return Feedback("negative", weight)
+        return Feedback("neutral", 0)
+
+    @staticmethod
+    def _coerce_llm_result(value: Any) -> Feedback:
+        if isinstance(value, str):
+            value = json.loads(value)
+        if not isinstance(value, dict):
+            raise ValueError("sentiment result must be an object")
+        feedback_type = value.get("type")
+        weight = value.get("weight")
+        if feedback_type not in {"positive", "negative", "neutral"}:
+            raise ValueError("invalid feedback type")
+        if not isinstance(weight, int) or isinstance(weight, bool):
+            raise ValueError("invalid feedback weight")
+        return Feedback(feedback_type, weight)
+
+    async def _llm_analyze_sentiment(self, message: str) -> Feedback:
+        if self.llm_analyzer is None:
+            return Feedback("neutral", 0)
+        try:
+            value = self.llm_analyzer(message)
+            if inspect.isawaitable(value):
+                value = await value
+            return self._coerce_llm_result(value)
+        except Exception:
+            return Feedback("neutral", 0)
+
+    async def analyze(self, message: str) -> Feedback:
+        keyword_result = self._keyword_feedback(message)
+        if keyword_result is not None:
+            return keyword_result
+        return await self._llm_analyze_sentiment(message)

--- a/agent/curiosity/interests.py
+++ b/agent/curiosity/interests.py
@@ -1,0 +1,42 @@
+"""Concurrent interest-node creation."""
+
+from __future__ import annotations
+
+import copy
+import time
+from typing import Any, Callable, Dict, Optional
+
+from .state import CuriosityState
+
+
+class InterestGraph:
+    def __init__(
+        self,
+        state: CuriosityState,
+        save: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> None:
+        self.state = state
+        self._save = save
+
+    def get_or_create(self, topic: str, **attributes: Any) -> Dict[str, Any]:
+        """Atomically return the single node for ``topic``."""
+        normalized = topic.strip()
+        if not normalized:
+            raise ValueError("topic must not be empty")
+        with self.state._lock:
+            graph = self.state.data.setdefault("interest_graph", {})
+            node = graph.get(normalized)
+            if node is None:
+                node = {
+                    "topic": normalized,
+                    "created_at": time.time(),
+                    **attributes,
+                }
+                graph[normalized] = node
+                if self._save is not None:
+                    self._save(copy.deepcopy(self.state.data))
+            return copy.deepcopy(node)
+
+    def snapshot(self) -> Dict[str, Dict[str, Any]]:
+        with self.state._lock:
+            return copy.deepcopy(self.state.data.get("interest_graph", {}))

--- a/agent/curiosity/orchestrator.py
+++ b/agent/curiosity/orchestrator.py
@@ -1,0 +1,31 @@
+"""Failure-isolated curiosity push orchestration."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class PushOrchestrator:
+    def __init__(
+        self,
+        get_recent_messages: Callable[[], Any],
+        fatigue_guard: Any,
+        build_push: Callable[[Any], Any],
+    ) -> None:
+        self._get_recent_messages = get_recent_messages
+        self.fatigue_guard = fatigue_guard
+        self._build_push = build_push
+
+    def orchestrate(self) -> Optional[Any]:
+        """Return no push when any pipeline stage fails."""
+        try:
+            messages = self._get_recent_messages()
+            if self.fatigue_guard.is_fatigued():
+                return None
+            return self._build_push(messages)
+        except Exception:
+            logger.exception("Curiosity push orchestration failed")
+            return None

--- a/agent/curiosity/state.py
+++ b/agent/curiosity/state.py
@@ -1,0 +1,25 @@
+"""Shared state for curiosity-engine components."""
+
+from __future__ import annotations
+
+import copy
+import threading
+from typing import Any, Dict, Optional
+
+
+class CuriosityState:
+    """Small thread-safe state container shared by v3 components.
+
+    The lock is intentionally exposed to sibling components.  A component can
+    therefore protect an entire read/modify/write operation instead of locking
+    individual dictionary accesses and still losing updates between them.
+    """
+
+    def __init__(self, data: Optional[Dict[str, Any]] = None) -> None:
+        self.data: Dict[str, Any] = copy.deepcopy(data or {})
+        self._lock = threading.RLock()
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return an isolated copy suitable for persistence or inspection."""
+        with self._lock:
+            return copy.deepcopy(self.data)

--- a/tests/test_curiosity_v3.py
+++ b/tests/test_curiosity_v3.py
@@ -1,0 +1,79 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+from agent.curiosity import (
+    CuriosityState,
+    FatigueGuard,
+    FeedbackEngine,
+    InterestGraph,
+    PushOrchestrator,
+)
+
+
+def test_fatigue_guard_keeps_all_concurrent_feedback():
+    state = CuriosityState()
+    guard = FatigueGuard(state, window_size=100)
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(guard.record_feedback, (index % 2 == 0 for index in range(100))))
+
+    window = state.snapshot()["feedback_window"]
+    assert len(window) == 100
+    assert window.count(1) == 50
+    assert window.count(0) == 50
+
+
+def test_feedback_keywords_do_not_match_substrings_and_balance_mixed_feedback():
+    engine = FeedbackEngine()
+
+    false_positive = asyncio.run(engine.analyze("这个电影真好看"))
+    mixed = asyncio.run(engine.analyze("真好但无聊"))
+
+    assert false_positive.type == "neutral"
+    assert false_positive.weight == 0
+    assert mixed.type == "neutral"
+    assert mixed.weight == 0
+
+
+def test_feedback_engine_falls_back_to_neutral_on_llm_failure_or_invalid_json():
+    async def timeout(_message):
+        raise TimeoutError
+
+    timeout_result = asyncio.run(FeedbackEngine(llm_analyzer=timeout).analyze("unclear"))
+    invalid_result = asyncio.run(
+        FeedbackEngine(llm_analyzer=lambda _message: "not json").analyze("unclear")
+    )
+
+    assert (timeout_result.type, timeout_result.weight) == ("neutral", 0)
+    assert (invalid_result.type, invalid_result.weight) == ("neutral", 0)
+
+
+def test_interest_graph_concurrent_get_or_create_preserves_one_node():
+    graph = InterestGraph(CuriosityState())
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        nodes = list(pool.map(lambda _: graph.get_or_create("python"), range(100)))
+
+    assert len(graph.snapshot()) == 1
+    assert len({node["created_at"] for node in nodes}) == 1
+
+
+class _Guard:
+    def __init__(self, error=False):
+        self.error = error
+
+    def is_fatigued(self):
+        if self.error:
+            raise RuntimeError("guard failed")
+        return False
+
+
+def test_orchestrator_isolates_message_and_guard_failures():
+    def fail_messages():
+        raise TimeoutError
+
+    messages_failure = PushOrchestrator(fail_messages, _Guard(), lambda messages: messages)
+    guard_failure = PushOrchestrator(lambda: ["hello"], _Guard(error=True), lambda messages: messages)
+
+    assert messages_failure.orchestrate() is None
+    assert guard_failure.orchestrate() is None


### PR DESCRIPTION
## Summary

- add a shared, thread-safe CuriosityState for proposed curiosity components
- make fatigue feedback updates atomic across the complete read/modify/write cycle
- add conservative feedback matching with neutral LLM failure fallback
- make interest-node creation atomic and isolate push-pipeline failures

## Design status

This is an early new-feature proposal, not a fix for code currently present in CowAgent. In the discussion on #3030, the maintainer confirmed that CuriosityState, FatigueGuard, FeedbackEngine, InterestGraph, and PushOrchestrator do not exist on master. The Draft therefore keeps these contracts isolated and does not wire a new product flow into the Agent runtime.

The unresolved review question is whether this component model fits CowAgent's architecture at all. The Draft is intended as a concrete, tested design artifact and does not claim to close #3030 or its related reports.

## Tests

- python -m pytest -q tests/test_curiosity_v3.py — 5 passed
- python -m pytest -q — 719 passed, 67 failed, 30 skipped
- clean origin/master baseline in the same Windows environment — 714 passed, 67 failed, 30 skipped

The 67 full-suite failures were unchanged from the clean baseline and were primarily existing Windows path/symlink and stale expectation failures.