### PR TITLE
feat(scheduler): add trusted cross-channel recipients

### DIFF
--- a/agent/tools/scheduler/integration.py
+++ b/agent/tools/scheduler/integration.py
@@ -16,6 +16,7 @@ _scheduler_service = None
 _task_store = None
 _scheduler_services: Dict[str, object] = {}
 _task_stores: Dict[str, object] = {}
+_recipient_stores: Dict[str, object] = {}
 # Module-level lock to guard idempotent initialization across threads
 _init_lock = threading.RLock()
 
@@ -68,9 +69,10 @@ def init_scheduler(agent_bridge, workspace_root: str = None, agent_id: str = Non
 
         try:
             from agent.tools.scheduler.task_store import TaskStore
+            from agent.tools.scheduler.recipient_store import RecipientStore
             from agent.tools.scheduler.scheduler_service import SchedulerService
 
-            from common.state_dir import scheduler_file
+            from common.state_dir import scheduler_file, scheduler_recipients_file
 
             store_path = str(scheduler_file(base=workspace_root))
 
@@ -80,6 +82,13 @@ def init_scheduler(agent_bridge, workspace_root: str = None, agent_id: str = Non
                 task_store = TaskStore(store_path)
                 _task_stores[workspace_root] = task_store
                 logger.debug(f"[Scheduler] Task store initialized: {store_path}")
+
+            recipient_store = _recipient_stores.get(workspace_root)
+            if recipient_store is None:
+                recipient_store = RecipientStore(
+                    str(scheduler_recipients_file(base=workspace_root))
+                )
+                _recipient_stores[workspace_root] = recipient_store
 
             # Create execute callback. Returns True on success, False to ask
             # the scheduler to retry on the next tick (e.g. channel not yet
@@ -190,6 +199,12 @@ def get_scheduler_service(workspace_root: str = None, agent_id: str = None):
     return _scheduler_services.get(workspace_root)
 
 
+def get_recipient_store(workspace_root: str = None, agent_id: str = None):
+    """Get the trusted recipient directory owned by one agent workspace."""
+    workspace_root = _resolve_workspace(workspace_root, agent_id)
+    return _recipient_stores.get(workspace_root)
+
+
 def reset_scheduler_services(stop: bool = True) -> None:
     """Stop and forget all scheduler services, primarily for reloads/tests."""
     global _scheduler_service, _task_store
@@ -202,6 +217,7 @@ def reset_scheduler_services(stop: bool = True) -> None:
                     pass
         _scheduler_services.clear()
         _task_stores.clear()
+        _recipient_stores.clear()
         _scheduler_service = None
         _task_store = None
 
@@ -630,13 +646,28 @@ def attach_scheduler_to_tool(tool, context: Context = None):
         agent_id = context.get("agent_id")
         task_store = get_task_store(agent_id=agent_id)
         scheduler_service = get_scheduler_service(agent_id=agent_id)
+        recipient_store = get_recipient_store(agent_id=agent_id)
         if task_store:
             tool.task_store = task_store
         if scheduler_service:
             tool.scheduler_service = scheduler_service
+        if recipient_store:
+            tool.recipient_store = recipient_store
         tool.current_context = context
         
         channel_type = context.get("channel_type") or conf().get("channel_type", "unknown")
         if not tool.config:
             tool.config = {}
         tool.config["channel_type"] = channel_type
+
+        # Only accepted inbound contexts become cross-channel targets.  Do not
+        # persist ephemeral credentials; the channel keeps enforcing its own
+        # authentication and readiness rules at delivery time.
+        if recipient_store and channel_type != "web":
+            recipient_store.remember(
+                channel_type,
+                context.get("receiver"),
+                name=tool._get_receiver_name(context),
+                is_group=context.get("isgroup", False),
+                session_id=context.get("session_id"),
+            )

--- a/agent/tools/scheduler/recipient_store.py
+++ b/agent/tools/scheduler/recipient_store.py
@@ -1,0 +1,95 @@
+"""Persistent directory of trusted scheduler delivery targets."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+class RecipientStore:
+    """Remember recipient identities learned from accepted inbound messages.
+
+    The store deliberately contains no access tokens or channel credentials.
+    Channel implementations remain responsible for authentication and their
+    normal outbound readiness checks.
+    """
+
+    def __init__(self, store_path: str) -> None:
+        self.store_path = Path(store_path)
+        self._lock = threading.RLock()
+        self.store_path.parent.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _key(channel_type: str, receiver: str) -> str:
+        return f"{channel_type}\0{receiver}"
+
+    def _load_unlocked(self) -> Dict[str, dict]:
+        if not self.store_path.exists():
+            return {}
+        try:
+            with self.store_path.open("r", encoding="utf-8") as handle:
+                value = json.load(handle)
+            recipients = value.get("recipients", {})
+            return recipients if isinstance(recipients, dict) else {}
+        except (OSError, ValueError, TypeError):
+            return {}
+
+    def _save_unlocked(self, recipients: Dict[str, dict]) -> None:
+        payload = {"version": 1, "recipients": recipients}
+        temporary = self.store_path.with_suffix(self.store_path.suffix + ".tmp")
+        with temporary.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, self.store_path)
+
+    def remember(
+        self,
+        channel_type: str,
+        receiver: str,
+        *,
+        name: str = "",
+        is_group: bool = False,
+        session_id: str = "",
+    ) -> Optional[dict]:
+        channel_type = str(channel_type or "").strip()
+        receiver = str(receiver or "").strip()
+        if not channel_type or not receiver or channel_type in {"unknown", "web"}:
+            return None
+        entry = {
+            "channel_type": channel_type,
+            "receiver": receiver,
+            "name": str(name or receiver),
+            "is_group": bool(is_group),
+            "session_id": str(session_id or receiver),
+            "last_seen_at": datetime.now(timezone.utc).isoformat(),
+        }
+        with self._lock:
+            recipients = self._load_unlocked()
+            key = self._key(channel_type, receiver)
+            previous = recipients.get(key)
+            stable_fields = ("channel_type", "receiver", "name", "is_group", "session_id")
+            if previous and all(previous.get(field) == entry[field] for field in stable_fields):
+                try:
+                    last_seen = datetime.fromisoformat(previous["last_seen_at"])
+                    if datetime.now(timezone.utc) - last_seen < timedelta(hours=1):
+                        return dict(previous)
+                except (KeyError, TypeError, ValueError):
+                    pass
+            recipients[key] = entry
+            self._save_unlocked(recipients)
+        return dict(entry)
+
+    def get(self, channel_type: str, receiver: str) -> Optional[dict]:
+        with self._lock:
+            entry = self._load_unlocked().get(self._key(channel_type, receiver))
+        return dict(entry) if entry else None
+
+    def list(self) -> List[dict]:
+        with self._lock:
+            entries = [dict(item) for item in self._load_unlocked().values()]
+        return sorted(entries, key=lambda item: (item["channel_type"], item["name"], item["receiver"]))

--- a/agent/tools/scheduler/scheduler_tool.py
+++ b/agent/tools/scheduler/scheduler_tool.py
@@ -30,14 +30,16 @@ class SchedulerTool(BaseTool):
         "- once: 一次性任务，支持相对时间(+5s,+10m,+1h,+1d)或ISO时间\n"
         "- interval: 固定间隔(秒)，如3600表示每小时\n"
         "- cron: cron表达式，如'0 8 * * *'表示每天8点\n\n"
-        "注意：'X秒后'用once+相对时间，'每X秒'用interval"
+        "注意：'X秒后'用once+相对时间，'每X秒'用interval\n"
+        "For Web cross-channel delivery, call action='list_recipients' first, "
+        "then create a fixed-message task using the returned channel_type and receiver."
     )
     params: dict = {
         "type": "object",
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["create", "list", "get", "delete", "enable", "disable"],
+                "enum": ["create", "list", "list_recipients", "get", "delete", "enable", "disable"],
                 "description": "操作类型: create(创建), list(列表), get(查询), delete(删除), enable(启用), disable(禁用)"
             },
             "task_id": {
@@ -69,7 +71,15 @@ class SchedulerTool(BaseTool):
                 "type": "boolean",
                 "default": False,
                 "description": "Silent mode (default false): when true, the task runs normally but its result is not pushed. Set true only when the user explicitly says they don't need the result; reminder, notification and broadcast tasks must keep it false"
-            }
+            },
+            "channel_type": {
+                "type": "string",
+                "description": "Target channel for a Web-created fixed-message task. Use list_recipients first."
+            },
+            "receiver": {
+                "type": "string",
+                "description": "Trusted target receiver returned by list_recipients. It cannot be an arbitrary user ID."
+            },
         },
         "required": ["action"]
     }
@@ -80,6 +90,7 @@ class SchedulerTool(BaseTool):
         
         # Will be set by agent bridge
         self.task_store = None
+        self.recipient_store = None
         self.current_context = None
     
     def execute(self, params: dict) -> ToolResult:
@@ -107,6 +118,9 @@ class SchedulerTool(BaseTool):
                 return ToolResult.success(result)
             elif action == "list":
                 result = self._list_tasks(**kwargs)
+                return ToolResult.success(result)
+            elif action == "list_recipients":
+                result = self._list_recipients(**kwargs)
                 return ToolResult.success(result)
             elif action == "get":
                 result = self._get_task(**kwargs)
@@ -159,6 +173,22 @@ class SchedulerTool(BaseTool):
             return "错误: 无法获取当前对话上下文"
         
         context = self.current_context
+
+        target_channel = kwargs.get("channel_type")
+        target_receiver = kwargs.get("receiver")
+        target = None
+        if target_channel or target_receiver:
+            if context.get("channel_type") != "web":
+                return "Error: cross-channel recipients can only be selected from the Web console"
+            if not target_channel or not target_receiver:
+                return "Error: channel_type and receiver must be provided together"
+            if ai_task:
+                return "Error: cross-channel delivery currently supports fixed messages only"
+            if not self.recipient_store:
+                return "Error: trusted recipient directory is unavailable"
+            target = self.recipient_store.get(target_channel, target_receiver)
+            if not target:
+                return "Error: target is not in the trusted recipient directory; use list_recipients"
         
         # Create task
         task_id = str(uuid.uuid4())[:8]
@@ -166,27 +196,31 @@ class SchedulerTool(BaseTool):
         # Capture the real chat session_id at task creation time so that scheduler
         # can later inject the delivered output into the user's actual conversation
         # (in group chats, session_id != receiver, e.g. "user_id:group_id" on feishu).
-        notify_session_id = context.get("session_id")
+        notify_session_id = target["session_id"] if target else context.get("session_id")
+        receiver = target["receiver"] if target else context.get("receiver")
+        receiver_name = target["name"] if target else self._get_receiver_name(context)
+        is_group = target["is_group"] if target else context.get("isgroup", False)
+        channel_type = target["channel_type"] if target else self.config.get("channel_type", "unknown")
 
         # Build action based on message or ai_task
         if message:
             action = {
                 "type": "send_message",
                 "content": message,
-                "receiver": context.get("receiver"),
-                "receiver_name": self._get_receiver_name(context),
-                "is_group": context.get("isgroup", False),
-                "channel_type": self.config.get("channel_type", "unknown"),
+                "receiver": receiver,
+                "receiver_name": receiver_name,
+                "is_group": is_group,
+                "channel_type": channel_type,
                 "notify_session_id": notify_session_id,
             }
         else:  # ai_task
             action = {
                 "type": "agent_task",
                 "task_description": ai_task,
-                "receiver": context.get("receiver"),
-                "receiver_name": self._get_receiver_name(context),
-                "is_group": context.get("isgroup", False),
-                "channel_type": self.config.get("channel_type", "unknown"),
+                "receiver": receiver,
+                "receiver_name": receiver_name,
+                "is_group": is_group,
+                "channel_type": channel_type,
                 "notify_session_id": notify_session_id,
             }
             # silent only applies to ai_task; fixed messages always deliver
@@ -258,6 +292,24 @@ class SchedulerTool(BaseTool):
                 f"   ⏰ {schedule_desc} | 下次: {next_run_str}"
             )
         
+        return "\n".join(lines)
+
+    def _list_recipients(self, **kwargs) -> str:
+        """List trusted targets available to the Web scheduler."""
+        if not self.current_context or self.current_context.get("channel_type") != "web":
+            return "Error: trusted recipients can only be listed from the Web console"
+        if not self.recipient_store:
+            return "Error: trusted recipient directory is unavailable"
+        recipients = self.recipient_store.list()
+        if not recipients:
+            return "No trusted recipients yet. A recipient must contact CowAgent first."
+        lines = ["Trusted scheduler recipients:"]
+        for item in recipients:
+            kind = "group" if item["is_group"] else "user"
+            lines.append(
+                f"- {item['name']} ({kind}): channel_type={item['channel_type']}, "
+                f"receiver={item['receiver']}"
+            )
         return "\n".join(lines)
     
     def _get_task(self, **kwargs) -> str:

--- a/common/state_dir.py
+++ b/common/state_dir.py
@@ -177,6 +177,11 @@ def scheduler_file(identity=None, base=None) -> Path:
     return _agent_base(identity, base) / "scheduler" / "tasks.json"
 
 
+def scheduler_recipients_file(identity=None, base=None) -> Path:
+    """Trusted recipients observed on this Agent's inbound channels."""
+    return _agent_base(identity, base) / "scheduler" / "recipients.json"
+
+
 def tmp_dir(identity=None, ensure: bool = True, base=None) -> Path:
     """Transient downloads and synthesized media.
 

--- a/tests/test_scheduler_cross_channel_recipients.py
+++ b/tests/test_scheduler_cross_channel_recipients.py
@@ -1,0 +1,118 @@
+import json
+
+from agent.tools.scheduler.recipient_store import RecipientStore
+from agent.tools.scheduler.scheduler_tool import SchedulerTool
+from bridge.context import Context, ContextType
+
+
+class _TaskStore:
+    def __init__(self):
+        self.tasks = []
+
+    def add_task(self, task):
+        self.tasks.append(task)
+
+
+def _context(channel_type, receiver):
+    context = Context(ContextType.TEXT, "hello")
+    context["channel_type"] = channel_type
+    context["receiver"] = receiver
+    context["session_id"] = receiver
+    context["isgroup"] = False
+    return context
+
+
+def _create(tool, **overrides):
+    values = {
+        "name": "Reminder",
+        "message": "Stand up",
+        "schedule_type": "once",
+        "schedule_value": "+5m",
+    }
+    values.update(overrides)
+    return tool._create_task(**values)
+
+
+def test_recipient_store_persists_only_delivery_identity(tmp_path):
+    path = tmp_path / "recipients.json"
+    store = RecipientStore(str(path))
+    store.remember(
+        "wecom_bot",
+        "user-42",
+        name="Ada",
+        session_id="session-42",
+    )
+
+    reloaded = RecipientStore(str(path)).get("wecom_bot", "user-42")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert reloaded["name"] == "Ada"
+    assert reloaded["session_id"] == "session-42"
+    assert "token" not in json.dumps(payload).lower()
+
+
+def test_recipient_store_avoids_rewriting_an_unchanged_recent_entry(tmp_path):
+    path = tmp_path / "recipients.json"
+    store = RecipientStore(str(path))
+    store.remember("wecom_bot", "user-42", name="Ada")
+    original_mtime = path.stat().st_mtime_ns
+
+    store.remember("wecom_bot", "user-42", name="Ada")
+
+    assert path.stat().st_mtime_ns == original_mtime
+
+
+def test_web_can_create_message_for_trusted_cross_channel_recipient(tmp_path):
+    recipients = RecipientStore(str(tmp_path / "recipients.json"))
+    recipients.remember("wecom_bot", "user-42", name="Ada")
+    tasks = _TaskStore()
+    tool = SchedulerTool({"channel_type": "web"})
+    tool.current_context = _context("web", "web-session")
+    tool.recipient_store = recipients
+    tool.task_store = tasks
+
+    result = _create(tool, channel_type="wecom_bot", receiver="user-42")
+
+    assert "Error:" not in result
+    assert tasks.tasks[0]["action"]["channel_type"] == "wecom_bot"
+    assert tasks.tasks[0]["action"]["receiver"] == "user-42"
+    assert tasks.tasks[0]["action"]["receiver_name"] == "Ada"
+
+
+def test_cross_channel_target_must_be_trusted_and_selected_from_web(tmp_path):
+    recipients = RecipientStore(str(tmp_path / "recipients.json"))
+    tasks = _TaskStore()
+    tool = SchedulerTool({"channel_type": "web"})
+    tool.recipient_store = recipients
+    tool.task_store = tasks
+
+    tool.current_context = _context("web", "web-session")
+    assert "not in the trusted recipient directory" in _create(
+        tool, channel_type="wecom_bot", receiver="unknown"
+    )
+
+    recipients.remember("wecom_bot", "user-42")
+    tool.current_context = _context("feishu", "feishu-user")
+    assert "only be selected from the Web console" in _create(
+        tool, channel_type="wecom_bot", receiver="user-42"
+    )
+    assert tasks.tasks == []
+
+
+def test_cross_channel_phase_is_fixed_messages_only(tmp_path):
+    recipients = RecipientStore(str(tmp_path / "recipients.json"))
+    recipients.remember("wecom_bot", "user-42")
+    tool = SchedulerTool({"channel_type": "web"})
+    tool.current_context = _context("web", "web-session")
+    tool.recipient_store = recipients
+    tool.task_store = _TaskStore()
+
+    result = _create(
+        tool,
+        message=None,
+        ai_task="Prepare a report",
+        channel_type="wecom_bot",
+        receiver="user-42",
+    )
+
+    assert "fixed messages only" in result


### PR DESCRIPTION
## Summary

- persist a per-Agent directory of recipients observed through accepted inbound channel contexts
- let Web scheduler conversations list those trusted recipients and create fixed-message tasks for them
- reject arbitrary receiver IDs, non-Web cross-channel selection, and cross-channel AI tasks
- keep credentials and short-lived channel tokens out of persistent storage; existing channel readiness checks remain authoritative

This Draft starts with message delivery to recipients who have already contacted CowAgent. It does not introduce an arbitrary address book or file-delivery credential model.

## Context

Issue: #2839

## Tests

- `python -m pytest -q tests/test_scheduler_cross_channel_recipients.py tests/test_scheduler_run_now.py tests/test_scheduler_silent.py tests/test_scheduler_web_update.py` — 16 passed
- `python -m pytest -q` — 718 passed, 67 failed, 30 skipped
- clean `origin/master` baseline in the same Windows environment — 714 passed, 67 failed, 30 skipped

The 67 full-suite failures are unchanged from the clean baseline and are primarily existing Windows path/symlink and stale expectation failures.