### PR TITLE
fix: keep nightly Deep Dream on schedule after a midnight-crossing failure

### DIFF
--- a/agent/memory/summarizer.py
+++ b/agent/memory/summarizer.py
@@ -480,7 +480,6 @@ class MemoryFlushManager:
         if not force and dedup_key == self._last_dream_input_hash:
             logger.info("[DeepDream] Already dreamed today with same daily content, skipping")
             return False
-        self._last_dream_input_hash = dedup_key
 
         logger.info(
             f"[DeepDream] Materials collected: "
@@ -488,35 +487,59 @@ class MemoryFlushManager:
             f"daily={len(daily_content)} chars"
         )
 
-        # Call LLM for distillation
+        # Call LLM for distillation, retrying transient errors (timeout /
+        # connection / rate limit / 5xx) and empty responses so a single
+        # hiccup doesn't lose the night's dream.
         import time as _time
-        t0 = _time.monotonic()
-        try:
-            user_msg = _dream_user_prompt().format(
-                memory_content=memory_content or "(empty)",
-                days=lookback_days,
-                daily_content=daily_content or "(no recent daily records)",
-            )
-            from agent.protocol.models import LLMRequest
-            # No output cap: the prompt already keeps MEMORY.md concise (~50
-            # items), so a hard max_tokens would only risk truncating a large
-            # rewrite. Let the model use its default output budget.
-            request = LLMRequest(
-                messages=[{"role": "user", "content": user_msg}],
-                temperature=0.3,
-                stream=False,
-                system=_dream_system_prompt(),
-            )
-            response = self.llm_model.call(request)
-            raw = self._extract_response_text(response)
-            elapsed = _time.monotonic() - t0
-            if not raw or not raw.strip():
-                logger.warning(f"[DeepDream] LLM returned empty response ({elapsed:.1f}s)")
-                return False
-            logger.info(f"[DeepDream] LLM distillation completed ({elapsed:.1f}s, {len(raw)} chars)")
-        except Exception as e:
-            elapsed = _time.monotonic() - t0
-            logger.warning(f"[DeepDream] LLM call failed ({elapsed:.1f}s): {e}")
+
+        max_attempts = 3
+        retryable_errors = (
+            "timeout", "timed out", "connection", "network", "rate limit",
+            "overloaded", "unavailable", "busy", "retry",
+            "429", "500", "502", "503", "504", "512",
+        )
+        raw = ""
+        for attempt in range(1, max_attempts + 1):
+            t0 = _time.monotonic()
+            try:
+                user_msg = _dream_user_prompt().format(
+                    memory_content=memory_content or "(empty)",
+                    days=lookback_days,
+                    daily_content=daily_content or "(no recent daily records)",
+                )
+                from agent.protocol.models import LLMRequest
+                # No output cap: the prompt already keeps MEMORY.md concise (~50
+                # items), so a hard max_tokens would only risk truncating a
+                # large rewrite. Let the model use its default output budget.
+                request = LLMRequest(
+                    messages=[{"role": "user", "content": user_msg}],
+                    temperature=0.3,
+                    stream=False,
+                    system=_dream_system_prompt(),
+                )
+                raw = self._extract_response_text(self.llm_model.call(request)) or ""
+                elapsed = _time.monotonic() - t0
+                if raw.strip():
+                    logger.info(
+                        f"[DeepDream] LLM distillation completed "
+                        f"(attempt {attempt}/{max_attempts}, {elapsed:.1f}s, {len(raw)} chars)"
+                    )
+                    break
+                logger.warning(
+                    f"[DeepDream] LLM returned empty response "
+                    f"(attempt {attempt}/{max_attempts}, {elapsed:.1f}s)"
+                )
+            except Exception as e:
+                elapsed = _time.monotonic() - t0
+                logger.warning(
+                    f"[DeepDream] LLM call failed "
+                    f"(attempt {attempt}/{max_attempts}, {elapsed:.1f}s): {e}"
+                )
+                if not any(k in str(e).lower() for k in retryable_errors):
+                    break
+            if attempt < max_attempts:
+                _time.sleep(60)
+        if not raw.strip():
             return False
 
         # Parse [MEMORY] and [DREAM] sections
@@ -547,6 +570,9 @@ class MemoryFlushManager:
                 logger.warning(f"[DeepDream] Failed to write dream diary: {e}")
 
         logger.info("[DeepDream] ✅ Deep Dream completed successfully")
+        # Mark as dreamed only after a fully successful run, so a failed
+        # attempt remains retryable the same day.
+        self._last_dream_input_hash = dedup_key
         return True
 
     def _read_main_memory(self, user_id: Optional[str] = None) -> str:

--- a/bridge/agent_initializer.py
+++ b/bridge/agent_initializer.py
@@ -657,7 +657,9 @@ class AgentInitializer:
                     time.sleep(wait_seconds)
 
                     self._flush_all_agents()
-                    last_run_date = datetime.datetime.now().date()
+                    # Record the scheduled date: a run that crosses midnight must
+                    # not mark the new day as already done.
+                    last_run_date = target.date()
                 except Exception as e:
                     logger.warning(f"[DailyFlush] Error in daily flush loop: {e}")
                     time.sleep(3600)


### PR DESCRIPTION
Fixes #3053

## Problem

A timed-out Deep Dream LLM call finishing after midnight made `_daily_flush_loop` mark the **new** day as already run, so the next scheduled flush was pushed two days out — one failed night plus one silently skipped night.

## Changes

1. `bridge/agent_initializer.py`: `last_run_date` now records the **scheduled** date (`target.date()`), not the completion-time date. A run that crosses midnight no longer marks the new day as done, so the loop re-arms to the same evening.
2. `agent/memory/summarizer.py`: the dedup hash is written only after a fully successful run, so a failed attempt can be retried the same day instead of being blocked by dedup.
3. `agent/memory/summarizer.py`: the Deep Dream LLM call retries up to 3 attempts (60s apart) on transient errors (timeout / connection / rate limit / 5xx, mirroring the retry keywords in `agent/protocol/agent_stream.py`) and on empty responses; other errors fail fast.

## Testing

- Verified the scheduler loop re-arms to the same evening when a run crosses midnight (old logic reproduces the skip-a-day behavior, fixed logic does not).
- Verified a failed LLM attempt no longer blocks a same-day retry via dedup, while a successful run still dedups same-day repeats.
- Verified retry behavior end-to-end with a stubbed LLM: timeout → timeout → success completes the dream; non-retryable errors fail after one attempt; empty responses are retried.
- Import/smoke checks pass.
