### PR TITLE
feat(provider): attribute OrcaRouter gateway requests

### DIFF
--- a/models/openai/openai_http_client.py
+++ b/models/openai/openai_http_client.py
@@ -58,6 +58,10 @@ _ATTRIBUTION_HEADERS_BY_HOST: Dict[str, Dict[str, str]] = {
         "HTTP-Referer": _APP_REFERER,
         "X-Title": _APP_TITLE,
     },
+    "orcarouter.ai": {
+        "HTTP-Referer": _APP_REFERER,
+        "X-Title": _APP_TITLE,
+    },
     "ai-gateway.vercel.sh": {
         "HTTP-Referer": _APP_REFERER,
         "X-Title": _APP_TITLE,

--- a/tests/test_openai_http_attribution.py
+++ b/tests/test_openai_http_attribution.py
@@ -1,0 +1,74 @@
+# encoding:utf-8
+"""
+Unit tests for per-gateway attribution headers in models/openai/openai_http_client.py.
+
+Covers _resolve_attribution_headers():
+  - OrcaRouter (api.orcarouter.ai) receives HTTP-Referer / X-Title, mirroring the
+    existing OpenRouter entry
+  - Bare / subdomain hosts of a documented gateway match
+  - Non-gateway (user-configured custom proxy) hosts get no attribution headers,
+    so app identity is not leaked to arbitrary endpoints
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from models.openai.openai_http_client import (  # noqa: E402
+    _APP_REFERER,
+    _APP_TITLE,
+    _resolve_attribution_headers,
+)
+
+
+class TestResolveAttributionHeaders(unittest.TestCase):
+    """_resolve_attribution_headers() host-suffix dispatch."""
+
+    def test_orcarouter_main_host(self):
+        headers = _resolve_attribution_headers(
+            "https://api.orcarouter.ai/v1/chat/completions"
+        )
+        self.assertEqual(
+            headers,
+            {"HTTP-Referer": _APP_REFERER, "X-Title": _APP_TITLE},
+        )
+
+    def test_orcarouter_bare_host(self):
+        self.assertEqual(
+            _resolve_attribution_headers("https://orcarouter.ai/v1"),
+            {"HTTP-Referer": _APP_REFERER, "X-Title": _APP_TITLE},
+        )
+
+    def test_orcarouter_subdomain(self):
+        self.assertEqual(
+            _resolve_attribution_headers("https://beta.orcarouter.ai/v1"),
+            {"HTTP-Referer": _APP_REFERER, "X-Title": _APP_TITLE},
+        )
+
+    def test_openrouter_still_matches(self):
+        """Guard the mirrored OpenRouter entry stays intact."""
+        self.assertEqual(
+            _resolve_attribution_headers("https://openrouter.ai/api/v1/chat/completions"),
+            {"HTTP-Referer": _APP_REFERER, "X-Title": _APP_TITLE},
+        )
+
+    def test_vercel_gateway_still_matches(self):
+        self.assertEqual(
+            _resolve_attribution_headers("https://ai-gateway.vercel.sh/v1"),
+            {"HTTP-Referer": _APP_REFERER, "X-Title": _APP_TITLE},
+        )
+
+    def test_non_gateway_host_gets_no_headers(self):
+        """Attribution must not leak to a user's own custom proxy."""
+        self.assertEqual(
+            _resolve_attribution_headers("https://api.example.com/v1/chat/completions"),
+            {},
+        )
+
+    def test_unparseable_url_safe(self):
+        self.assertEqual(_resolve_attribution_headers("not a url"), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Adds **[OrcaRouter](https://www.orcarouter.ai)** to the per-gateway attribution-header table in `models/openai/openai_http_client.py`, mirroring the existing `openrouter.ai` / `ai-gateway.vercel.sh` entries.

When a user configures OrcaRouter as a custom (OpenAI-compatible) provider — `api_base = https://api.orcarouter.ai/v1` — CowAgent now sends `HTTP-Referer` and `X-Title` attribution headers to the gateway, so traffic is attributable to the app. OrcaRouter is an AI gateway that serves OpenAI- (`/v1/chat/completions`) and Anthropic-compatible (`/v1/messages`) endpoints from one base URL with namespaced model ids (`anthropic/claude-sonnet-5`, …). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Changes

- `models/openai/openai_http_client.py` — add `"orcarouter.ai"` to `_ATTRIBUTION_HEADERS_BY_HOST` with the same `HTTP-Referer` / `X-Title` headers as the OpenRouter entry.
- `tests/test_openai_http_attribution.py` — focused unit tests: OrcaRouter main/bare/subdomain hosts resolve to the attribution headers; non-gateway hosts get none (no identity leak); existing gateway entries (OpenRouter, Vercel) stay intact.

### Verification

- `python -m pytest tests/test_openai_http_attribution.py` — 7 passed
- Full suite (`python -m pytest tests/`) — no new failures vs clean `master`; the only failing tests are pre-existing, environment-only (security SSRF / subagent / shared-db tests, unchanged by this PR)
- Live check against `https://api.orcarouter.ai/v1` through the repo's own `OpenAIHTTPClient` (`anthropic/claude-sonnet-5`) — returns `ORCA-OK`; attribution headers resolve correctly; a non-gateway host (`api.example.com`) resolves to no headers.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [ ] Linked related issue (if any): closes #

---

I'm an engineer on the OrcaRouter team.
