### PR TITLE
fix(keyword): detect attachment URLs by parsed path

### DIFF
--- a/plugins/keyword/keyword.py
+++ b/plugins/keyword/keyword.py
@@ -3,6 +3,7 @@
 import json
 import os
 import requests
+from urllib.parse import urlparse
 import plugins
 from bridge.context import ContextType
 from bridge.reply import Reply, ReplyType
@@ -53,20 +54,23 @@ class Keyword(Plugin):
         if content in self.keyword:
             logger.info(f"[keyword] 匹配到关键字【{content}】")
             reply_text = self.keyword[content]
+            parsed_url = urlparse(reply_text)
+            is_http_url = parsed_url.scheme in ("http", "https") and bool(parsed_url.netloc)
+            url_path = parsed_url.path.lower()
 
             # 判断匹配内容的类型
-            if (reply_text.startswith("http://") or reply_text.startswith("https://")) and any(reply_text.endswith(ext) for ext in [".jpg", ".webp", ".jpeg", ".png", ".gif", ".img"]):
+            if is_http_url and url_path.endswith((".jpg", ".webp", ".jpeg", ".png", ".gif", ".img")):
             # 如果是以 http:// 或 https:// 开头，且".jpg", ".jpeg", ".png", ".gif", ".img"结尾，则认为是图片 URL。
                 reply = Reply()
                 reply.type = ReplyType.IMAGE_URL
                 reply.content = reply_text
                 
-            elif (reply_text.startswith("http://") or reply_text.startswith("https://")) and any(reply_text.endswith(ext) for ext in [".pdf", ".doc", ".docx", ".xls", "xlsx",".zip", ".rar"]):
+            elif is_http_url and url_path.endswith((".pdf", ".doc", ".docx", ".xls", ".xlsx", ".zip", ".rar")):
             # 如果是以 http:// 或 https:// 开头，且".pdf", ".doc", ".docx", ".xls", "xlsx",".zip", ".rar"结尾，则下载文件到tmp目录并发送给用户
                 file_path = "tmp"
                 if not os.path.exists(file_path):
                     os.makedirs(file_path)
-                file_name = reply_text.split("/")[-1]  # 获取文件名
+                file_name = os.path.basename(parsed_url.path)
                 file_path = os.path.join(file_path, file_name)
                 response = requests.get(reply_text)
                 with open(file_path, "wb") as f:
@@ -75,7 +79,7 @@ class Keyword(Plugin):
                 reply.type = ReplyType.FILE
                 reply.content = file_path
             
-            elif (reply_text.startswith("http://") or reply_text.startswith("https://")) and any(reply_text.endswith(ext) for ext in [".mp4"]):
+            elif is_http_url and url_path.endswith(".mp4"):
             # 如果是以 http:// 或 https:// 开头，且".mp4"结尾，则下载视频到tmp目录并发送给用户
                 reply = Reply()
                 reply.type = ReplyType.VIDEO_URL

--- a/tests/test_keyword_attachment_urls.py
+++ b/tests/test_keyword_attachment_urls.py
@@ -1,0 +1,57 @@
+"""Regression tests for URL replies from the keyword plugin."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bridge.context import Context, ContextType
+from bridge.reply import ReplyType
+import plugins
+from plugins import Event, EventContext
+
+plugins.instance.current_plugin_path = "./plugins/keyword"
+import plugins.keyword.keyword  # noqa: F401
+plugins.instance.current_plugin_path = None
+
+Keyword = plugins.instance.plugins["KEYWORD"]
+
+
+def _handle(reply_text):
+    plugin = Keyword.__new__(Keyword)
+    plugin.keyword = {"download": reply_text}
+    event = EventContext(
+        Event.ON_HANDLE_CONTEXT,
+        {"context": Context(ContextType.TEXT, "download"), "reply": None},
+    )
+    plugin.on_handle_context(event)
+    return event["reply"]
+
+
+def test_image_url_with_query_string_is_detected():
+    reply = _handle("https://cdn.example.com/banner.PNG?version=2")
+
+    assert reply.type is ReplyType.IMAGE_URL
+    assert reply.content == "https://cdn.example.com/banner.PNG?version=2"
+
+
+def test_video_url_with_query_string_is_detected():
+    reply = _handle("https://cdn.example.com/demo.MP4?download=1")
+
+    assert reply.type is ReplyType.VIDEO_URL
+
+
+def test_http_scheme_without_host_remains_text():
+    reply = _handle("https:report.xlsx")
+
+    assert reply.type is ReplyType.TEXT
+
+
+def test_xlsx_url_uses_path_filename_without_query_string(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    response = SimpleNamespace(content=b"spreadsheet")
+
+    with patch("plugins.keyword.keyword.requests.get", return_value=response):
+        reply = _handle("https://cdn.example.com/report.XLSX?token=secret")
+
+    assert reply.type is ReplyType.FILE
+    assert reply.content == "tmp/report.XLSX"
+    assert (tmp_path / reply.content).read_bytes() == b"spreadsheet"


### PR DESCRIPTION
<!--
Thanks for your contribution! Please write this PR in English.
推荐使用英文填写，感谢 ❤️
-->

## What does this PR do?

Makes the keyword plugin classify attachment URLs from their parsed URL path instead of the complete raw string.

This fixes three small cases:

- image, video, and file URLs still work when they include query parameters
- extension matching is case-insensitive
- `.xlsx` is recognized correctly, and downloaded filenames exclude query strings

Malformed HTTP(S) values without a host continue to be treated as text.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): N/A

## Validation

- `python -m pytest -q tests/test_keyword_attachment_urls.py` (`4 passed`)
- `python -m compileall -q plugins/keyword/keyword.py tests/test_keyword_attachment_urls.py`
- `git diff --check origin/master...HEAD`

The full suite reports the same 49 pre-existing failures as `master` in this environment; the failed test IDs are unchanged.
