### PR TITLE
fix(scheduler): prevent concurrent task updates from being lost

### DIFF
--- a/agent/tools/scheduler/task_store.py
+++ b/agent/tools/scheduler/task_store.py
@@ -11,6 +11,16 @@ from pathlib import Path
 from common.utils import expand_path
 
 
+_store_locks = {}
+_store_locks_guard = threading.Lock()
+
+
+def _lock_for_path(store_path: str):
+    normalized_path = os.path.normcase(os.path.realpath(store_path))
+    with _store_locks_guard:
+        return _store_locks.setdefault(normalized_path, threading.RLock())
+
+
 class TaskStore:
     """
     Manages persistent storage of scheduled tasks
@@ -29,7 +39,7 @@ class TaskStore:
             store_path = os.path.join(home, "cow", "scheduler", "tasks.json")
         
         self.store_path = store_path
-        self.lock = threading.Lock()
+        self.lock = _lock_for_path(store_path)
         self._ensure_store_dir()
     
     def _ensure_store_dir(self):
@@ -98,17 +108,18 @@ class TaskStore:
         Returns:
             True if successful
         """
-        tasks = self.load_tasks()
-        task_id = task.get("id")
-        
-        if not task_id:
-            raise ValueError("Task must have an 'id' field")
-        
-        if task_id in tasks:
-            raise ValueError(f"Task with id '{task_id}' already exists")
-        
-        tasks[task_id] = task
-        self.save_tasks(tasks)
+        with self.lock:
+            tasks = self.load_tasks()
+            task_id = task.get("id")
+
+            if not task_id:
+                raise ValueError("Task must have an 'id' field")
+
+            if task_id in tasks:
+                raise ValueError(f"Task with id '{task_id}' already exists")
+
+            tasks[task_id] = task
+            self.save_tasks(tasks)
         return True
     
     def update_task(self, task_id: str, updates: dict) -> bool:
@@ -122,16 +133,16 @@ class TaskStore:
         Returns:
             True if successful
         """
-        tasks = self.load_tasks()
-        
-        if task_id not in tasks:
-            raise ValueError(f"Task '{task_id}' not found")
-        
-        # Update fields
-        tasks[task_id].update(updates)
-        tasks[task_id]["updated_at"] = datetime.now().isoformat()
-        
-        self.save_tasks(tasks)
+        with self.lock:
+            tasks = self.load_tasks()
+
+            if task_id not in tasks:
+                raise ValueError(f"Task '{task_id}' not found")
+
+            tasks[task_id].update(updates)
+            tasks[task_id]["updated_at"] = datetime.now().isoformat()
+
+            self.save_tasks(tasks)
         return True
     
     def delete_task(self, task_id: str) -> bool:
@@ -144,13 +155,14 @@ class TaskStore:
         Returns:
             True if successful
         """
-        tasks = self.load_tasks()
-        
-        if task_id not in tasks:
-            raise ValueError(f"Task '{task_id}' not found")
-        
-        del tasks[task_id]
-        self.save_tasks(tasks)
+        with self.lock:
+            tasks = self.load_tasks()
+
+            if task_id not in tasks:
+                raise ValueError(f"Task '{task_id}' not found")
+
+            del tasks[task_id]
+            self.save_tasks(tasks)
         return True
     
     def get_task(self, task_id: str) -> Optional[dict]:

--- a/tests/test_task_store_concurrency.py
+++ b/tests/test_task_store_concurrency.py
@@ -1,0 +1,176 @@
+"""Concurrency regression tests for scheduler task persistence."""
+
+import threading
+
+from agent.tools.scheduler.task_store import TaskStore
+
+
+def test_concurrent_adds_preserve_both_tasks(tmp_path):
+    store_path = str(tmp_path / "tasks.json")
+    first_store = TaskStore(store_path)
+    second_store = TaskStore(store_path)
+    first_load = first_store.load_tasks
+    second_load = second_store.load_tasks
+    first_save = first_store.save_tasks
+    second_save = second_store.save_tasks
+    first_loaded = threading.Event()
+    second_loaded = threading.Event()
+    second_saved = threading.Event()
+    calls_lock = threading.Lock()
+    load_calls = 0
+
+    def coordinated_load(real_load):
+        def load():
+            nonlocal load_calls
+            tasks = real_load()
+            with calls_lock:
+                load_calls += 1
+                call_number = load_calls
+            if call_number == 1:
+                first_loaded.set()
+                second_loaded.wait(timeout=0.5)
+            elif call_number == 2:
+                second_loaded.set()
+            return tasks
+        return load
+
+    first_store.load_tasks = coordinated_load(first_load)
+    second_store.load_tasks = coordinated_load(second_load)
+    first_store.save_tasks = lambda tasks: (
+        second_saved.wait(timeout=0.5), first_save(tasks)
+    )[-1]
+
+    def save_second(tasks):
+        second_save(tasks)
+        second_saved.set()
+
+    second_store.save_tasks = save_second
+    errors = []
+
+    def add(task_id):
+        try:
+            current_store = first_store if task_id == "first" else second_store
+            current_store.add_task({"id": task_id})
+        except Exception as exc:
+            errors.append(exc)
+
+    first = threading.Thread(target=add, args=("first",))
+    second = threading.Thread(target=add, args=("second",))
+    first.start()
+    assert first_loaded.wait(timeout=1)
+    second.start()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert set(first_load()) == {"first", "second"}
+
+
+def test_concurrent_updates_preserve_both_changes(tmp_path):
+    store_path = str(tmp_path / "tasks.json")
+    first_store = TaskStore(store_path)
+    second_store = TaskStore(store_path)
+    first_store.add_task({"id": "first", "name": "old"})
+    first_store.add_task({"id": "second", "name": "old"})
+    first_load = first_store.load_tasks
+    second_load = second_store.load_tasks
+    first_save = first_store.save_tasks
+    second_save = second_store.save_tasks
+    first_loaded = threading.Event()
+    second_loaded = threading.Event()
+    second_saved = threading.Event()
+    calls_lock = threading.Lock()
+    load_calls = 0
+
+    def coordinated_load(real_load):
+        def load():
+            nonlocal load_calls
+            tasks = real_load()
+            with calls_lock:
+                load_calls += 1
+                call_number = load_calls
+            if call_number == 1:
+                first_loaded.set()
+                second_loaded.wait(timeout=0.5)
+            elif call_number == 2:
+                second_loaded.set()
+            return tasks
+        return load
+
+    first_store.load_tasks = coordinated_load(first_load)
+    second_store.load_tasks = coordinated_load(second_load)
+    first_store.save_tasks = lambda tasks: (
+        second_saved.wait(timeout=0.5), first_save(tasks)
+    )[-1]
+
+    def save_second(tasks):
+        second_save(tasks)
+        second_saved.set()
+
+    second_store.save_tasks = save_second
+    first = threading.Thread(target=first_store.update_task, args=("first", {"name": "new"}))
+    second = threading.Thread(target=second_store.update_task, args=("second", {"name": "new"}))
+    first.start()
+    assert first_loaded.wait(timeout=1)
+    second.start()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    tasks = first_load()
+    assert tasks["first"]["name"] == "new"
+    assert tasks["second"]["name"] == "new"
+
+
+def test_concurrent_deletes_preserve_both_removals(tmp_path):
+    store_path = str(tmp_path / "tasks.json")
+    first_store = TaskStore(store_path)
+    second_store = TaskStore(store_path)
+    first_store.add_task({"id": "first"})
+    first_store.add_task({"id": "second"})
+    first_load = first_store.load_tasks
+    second_load = second_store.load_tasks
+    first_save = first_store.save_tasks
+    second_save = second_store.save_tasks
+    first_loaded = threading.Event()
+    second_loaded = threading.Event()
+    second_saved = threading.Event()
+    calls_lock = threading.Lock()
+    load_calls = 0
+
+    def coordinated_load(real_load):
+        def load():
+            nonlocal load_calls
+            tasks = real_load()
+            with calls_lock:
+                load_calls += 1
+                call_number = load_calls
+            if call_number == 1:
+                first_loaded.set()
+                second_loaded.wait(timeout=0.5)
+            elif call_number == 2:
+                second_loaded.set()
+            return tasks
+        return load
+
+    first_store.load_tasks = coordinated_load(first_load)
+    second_store.load_tasks = coordinated_load(second_load)
+    first_store.save_tasks = lambda tasks: (
+        second_saved.wait(timeout=0.5), first_save(tasks)
+    )[-1]
+
+    def save_second(tasks):
+        second_save(tasks)
+        second_saved.set()
+
+    second_store.save_tasks = save_second
+    first = threading.Thread(target=first_store.delete_task, args=("first",))
+    second = threading.Thread(target=second_store.delete_task, args=("second",))
+    first.start()
+    assert first_loaded.wait(timeout=1)
+    second.start()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert first_load() == {}


### PR DESCRIPTION
<!--
Thanks for your contribution! Please write this PR in English.
推荐使用英文填写，感谢 ❤️
-->

## What does this PR do?

Prevents scheduler task mutations from losing updates when the background scheduler, Web handlers, or channel callbacks modify the same `tasks.json` file concurrently.

Previously, each mutation locked `load_tasks` and `save_tasks` separately. Two callers could therefore read the same snapshot and overwrite one another. Separate `TaskStore` instances also had separate locks despite targeting the same file.

This change:

- shares a re-entrant lock by normalized store path
- holds that lock across each add, update, or delete read-modify-write transaction
- adds deterministic cross-instance concurrency tests for add, update, and delete

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): N/A

## Validation

- `python -m pytest -q tests/test_task_store_concurrency.py tests/test_scheduler_run_now.py tests/test_scheduler_web_update.py tests/test_cow_cli_tasks.py` (`15 passed`)
- `python -m compileall -q agent/tools/scheduler/task_store.py tests/test_task_store_concurrency.py`
- `git diff --check origin/master...HEAD`

The full suite reports the same 49 pre-existing failures as `master` in this environment; the failed test IDs are unchanged.
