### PR TITLE
fix(skill): harden tar archive extraction

### DIFF
--- a/cli/commands/skill.py
+++ b/cli/commands/skill.py
@@ -475,10 +475,21 @@ def _install_targz_bytes(content: bytes, name: str, skills_dir: str, result: Ins
         extract_dir = os.path.join(tmp_dir, "extracted")
         os.makedirs(extract_dir)
         with tarfile.open(tar_path, "r:gz") as tf:
+            extraction_root = os.path.realpath(extract_dir)
             for member in tf.getmembers():
                 resolved = os.path.realpath(os.path.join(extract_dir, member.name))
-                if not resolved.startswith(os.path.realpath(extract_dir)):
+                try:
+                    inside_root = (
+                        os.path.commonpath((extraction_root, resolved)) == extraction_root
+                    )
+                except ValueError:
+                    inside_root = False
+                if not inside_root:
                     raise SkillInstallError("Archive contains path traversal, aborting.")
+                if member.issym() or member.islnk():
+                    raise SkillInstallError("Archive contains a link, aborting.")
+                if not (member.isfile() or member.isdir()):
+                    raise SkillInstallError("Archive contains a special file, aborting.")
             tf.extractall(extract_dir)
 
         top_items = [d for d in os.listdir(extract_dir) if not d.startswith(".")]

--- a/tests/test_skill_tar_security.py
+++ b/tests/test_skill_tar_security.py
@@ -1,0 +1,86 @@
+"""Security regression tests for installing skills from tar archives."""
+
+import io
+import tarfile
+from unittest.mock import patch
+
+import pytest
+
+from cli.commands.skill import InstallResult, SkillInstallError, _install_targz_bytes
+
+
+def _tar_bytes(*members):
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as archive:
+        for info, content in members:
+            if content is not None:
+                info.size = len(content)
+            archive.addfile(info, io.BytesIO(content) if content is not None else None)
+    return payload.getvalue()
+
+
+def test_tar_rejects_path_with_matching_directory_prefix(tmp_path):
+    entry = tarfile.TarInfo("../extracted-evil/pwned.txt")
+    content = _tar_bytes((entry, b"outside extraction root"))
+
+    with pytest.raises(SkillInstallError, match="path traversal"):
+        _install_targz_bytes(
+            content, "unsafe-skill", str(tmp_path / "skills"), InstallResult()
+        )
+
+
+def test_tar_rejects_symbolic_links(tmp_path):
+    skill_file = tarfile.TarInfo("unsafe-skill/SKILL.md")
+    link = tarfile.TarInfo("unsafe-skill/host-file")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "/etc/passwd"
+    content = _tar_bytes((skill_file, b"---\nname: unsafe-skill\n---\n"), (link, None))
+
+    with pytest.raises(SkillInstallError, match="link"):
+        _install_targz_bytes(
+            content, "unsafe-skill", str(tmp_path / "skills"), InstallResult()
+        )
+
+
+def test_tar_rejects_hard_links(tmp_path):
+    skill_file = tarfile.TarInfo("unsafe-skill/SKILL.md")
+    link = tarfile.TarInfo("unsafe-skill/duplicate")
+    link.type = tarfile.LNKTYPE
+    link.linkname = "unsafe-skill/SKILL.md"
+    content = _tar_bytes((skill_file, b"---\nname: unsafe-skill\n---\n"), (link, None))
+
+    with pytest.raises(SkillInstallError, match="link"):
+        _install_targz_bytes(
+            content, "unsafe-skill", str(tmp_path / "skills"), InstallResult()
+        )
+
+
+def test_tar_rejects_special_files(tmp_path):
+    fifo = tarfile.TarInfo("unsafe-skill/input")
+    fifo.type = tarfile.FIFOTYPE
+    content = _tar_bytes((fifo, None))
+
+    with pytest.raises(SkillInstallError, match="special file"):
+        _install_targz_bytes(
+            content, "unsafe-skill", str(tmp_path / "skills"), InstallResult()
+        )
+
+
+def test_tar_installs_regular_directory_and_file(tmp_path):
+    directory = tarfile.TarInfo("safe-skill")
+    directory.type = tarfile.DIRTYPE
+    directory.mode = 0o755
+    skill_file = tarfile.TarInfo("safe-skill/SKILL.md")
+    skill_file.mode = 0o644
+    content = _tar_bytes(
+        (directory, None),
+        (skill_file, b"---\nname: safe-skill\ndescription: Safe fixture\n---\n"),
+    )
+    skills_dir = tmp_path / "skills"
+    result = InstallResult()
+
+    with patch("cli.commands.skill.get_skills_dir", return_value=str(skills_dir)):
+        _install_targz_bytes(content, "safe-skill", str(skills_dir), result)
+
+    assert result.installed == ["safe-skill"]
+    assert (skills_dir / "safe-skill" / "SKILL.md").is_file()


### PR DESCRIPTION
<!--
Thanks for your contribution! Please write this PR in English.
推荐使用英文填写，感谢 ❤️
-->

## What does this PR do?

Hardens remote `tar.gz` skill installation against archive entries that can escape or abuse the extraction directory.

The previous path check used a string prefix comparison, so an entry such as `../extracted-evil/pwned.txt` could pass when the extraction directory was named `extracted`. This change:

- uses `os.path.commonpath` to enforce the extraction boundary
- rejects symbolic links, hard links, and special files
- keeps regular directories and files installable
- adds regression coverage for the bypass and supported archive shape

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): N/A

## Validation

- `python -m pytest -q tests/test_skill_tar_security.py` (`5 passed`)
- `python -m compileall -q cli/commands/skill.py tests/test_skill_tar_security.py`
- `git diff --check origin/master...HEAD`

The full suite reports the same 49 pre-existing failures as `master` in this environment; the failed test IDs are unchanged.
