### PR TITLE
fix(bash): guide Windows shell command recovery

### DIFF
--- a/agent/tools/bash/bash.py
+++ b/agent/tools/bash/bash.py
@@ -40,9 +40,9 @@ class Bash(BaseTool):
     MAX_TIMEOUT = 600
 
     name: str = "bash"
-    description: str = f"""Execute a bash command in the current working directory. Returns stdout and stderr. Output is truncated to last {DEFAULT_MAX_LINES} lines or {DEFAULT_MAX_BYTES // 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file.
+    description: str = f"""Execute a command in the current working directory using the platform shell. Returns stdout and stderr. Output is truncated to last {DEFAULT_MAX_LINES} lines or {DEFAULT_MAX_BYTES // 1024}KB (whichever is hit first). If truncated, full output is saved to a temp file.
 {'''
-PLATFORM: Windows (cmd.exe). Do NOT use Unix-only commands like head, tail, sed, awk. To search file contents or find files by name, use the search_files tool instead of this command.
+PLATFORM: Windows (cmd.exe), not Bash, WSL, PowerShell, or Windows Terminal. Use cmd.exe syntax: double quotes (single quotes are literal), `>nul 2>&1` instead of `/dev/null`, `&&` instead of `;`, and `findstr /I "pattern"` without grep-style `-i`/`-e` flags. Do not invoke `bash script.sh` or use Unix-only commands such as grep, head, tail, sed, or awk. Use the search_files tool for file/content search and Python for portable scripting.
 ''' if _IS_WIN else ''}
 ENVIRONMENT: All API keys from env_config are auto-injected. Use $VAR_NAME directly.
 
@@ -336,6 +336,9 @@ SAFETY:
             is_error, note = exit_codes.interpret(command, result.returncode)
             if is_error:
                 output_text += f"\n\nCommand exited with code {result.returncode}"
+                hint = self._windows_failure_hint(command)
+                if hint:
+                    output_text += f"\n\n{hint}"
                 return ToolResult.fail({
                     "output": output_text,
                     "exit_code": result.returncode,
@@ -540,6 +543,38 @@ SAFETY:
             return "This command will shut down or restart the system"
 
         return ""
+
+    @classmethod
+    def _windows_failure_hint(cls, command: str) -> str:
+        """Return focused cmd.exe corrections for detected Unix syntax.
+
+        The hint is intentionally absent for ordinary command failures: only a
+        recognized shell mismatch should add another instruction to the model.
+        """
+        if not cls._IS_WIN:
+            return ""
+
+        lower = command.lower()
+        corrections = []
+        if re.search(r"\bfindstr\b[^\r\n]*(?:^|\s)-[a-z]", lower):
+            corrections.append(
+                'findstr uses /I and a quoted search string, for example '
+                'findstr /I "cow agent"; it does not accept grep-style -i/-e flags'
+            )
+        if "/dev/null" in lower:
+            corrections.append("redirect to nul, for example >nul 2>&1, not /dev/null")
+        if re.search(r"(?:^|[&|()]\s*|\s)(?:bash|sh)\s+\S", lower):
+            corrections.append("do not invoke bash/sh; use a cmd.exe command or a Python script")
+        if re.search(r"'[^'\r\n]*'", command):
+            corrections.append("use double quotes because cmd.exe treats single quotes literally")
+        if re.search(r"(?:^|[&|()]\s*|\s)(?:grep|head|tail|sed|awk)\b", lower):
+            corrections.append("use search_files for file/content search instead of Unix text tools")
+        if ";" in command:
+            corrections.append("chain commands with && instead of ;")
+
+        if not corrections:
+            return ""
+        return "[Windows cmd.exe hint: " + "; ".join(corrections) + ".]"
 
     @staticmethod
     def _convert_env_vars_for_windows(command: str, dotenv_vars: dict) -> str:

--- a/tests/test_bash_windows_guidance.py
+++ b/tests/test_bash_windows_guidance.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent.tools.bash.bash import Bash
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("findstr -i -e cow -e agent", "findstr uses /I"),
+        ("python task.py 2>/dev/null", "redirect to nul"),
+        ("bash script.sh", "do not invoke bash/sh"),
+        ("echo 'hello'", "single quotes literally"),
+        ("grep needle file.txt", "use search_files"),
+        ("echo one; echo two", "chain commands with &&"),
+    ],
+)
+def test_windows_failure_hint_corrects_detected_shell_mismatches(monkeypatch, command, expected):
+    monkeypatch.setattr(Bash, "_IS_WIN", True)
+
+    assert expected in Bash._windows_failure_hint(command)
+
+
+def test_windows_failure_hint_is_absent_for_an_ordinary_failure(monkeypatch):
+    monkeypatch.setattr(Bash, "_IS_WIN", True)
+
+    assert Bash._windows_failure_hint("python missing.py") == ""
+
+
+def test_failed_windows_command_returns_the_corrective_hint(monkeypatch, tmp_path):
+    tool = Bash({"cwd": str(tmp_path)})
+    monkeypatch.setattr(tool, "_IS_WIN", True)
+    monkeypatch.setattr(
+        tool,
+        "_run_streaming",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="FINDSTR: Cannot open -e",
+        ),
+    )
+
+    result = tool.execute(
+        {"command": "pip list 2>nul | findstr -i -e cow -e agent"}
+    )
+
+    assert result.status == "error"
+    assert "FINDSTR: Cannot open -e" in result.result["output"]
+    assert "Windows cmd.exe hint" in result.result["output"]
+    assert "findstr /I" in result.result["output"]


### PR DESCRIPTION
## What does this PR do?

Windows desktop runs the bash tool through cmd.exe, but the model can still emit Bash/Unix syntax and retry the same category of failure until the consecutive-failure guard stops the run.

This change:

- describes the tool as using the platform shell and gives concise cmd.exe-specific syntax guidance on Windows;
- detects recognized shell mismatches after a failed command and appends a focused correction for findstr flags, /dev/null redirects, bash/sh invocation, single quotes, Unix text tools, or semicolon chaining;
- leaves ordinary command failures unchanged, so unrelated errors do not gain generic prompt noise.

This intentionally does not add a configurable PowerShell backend or another dependency.

Related issue: #3060

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Validation

- Reproduced the report with: pip list 2>nul | findstr -i -e cow -e agent
- Verified the same failure now includes a findstr /I corrective hint.
- python -m pytest -q tests/test_bash_windows_guidance.py tests/test_bash_exit_codes.py tests/test_bash_streaming.py tests/test_bash_output_encoding.py tests/test_bash_background.py tests/test_bash_config_propagation.py — 36 passed, 22 skipped
- Full suite on this branch — 740 passed, 67 failed, 30 skipped
- Clean origin/master baseline in the same environment — 732 passed, the same 67 failed, 30 skipped
- python -m compileall -q agent/tools/bash tests/test_bash_windows_guidance.py
- git diff --check

The 67 full-suite failures are unchanged from the clean baseline and are existing Windows path/symlink, environment, and stale-expectation failures.

## Checklist

- [x] I have read the Contributing Guide
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue: #3060