### PR TITLE
Add Serply as a web_search provider

### DIFF
--- a/agent/tools/web_search/web_search.py
+++ b/agent/tools/web_search/web_search.py
@@ -1,15 +1,16 @@
-"""Web Search tool. Supports four backends with a unified response format:
+"""Web Search tool. Supports six backends with a unified response format:
   - bocha   (https://open.bochaai.com)
   - zhipu   (https://docs.bigmodel.cn/cn/guide/tools/web-search)
   - qianfan (https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy)
   - linkai  (https://link-ai.tech, fallback)
   - anysearch (https://anysearch.com)
+  - serply  (https://serply.io, Google/Bing SERP API)
 
 Provider selection
   - strategy 'auto' (default): pick the first configured provider in the
-    canonical order [bocha, zhipu, qianfan, linkai]. When the caller passes
-    an explicit `provider` it overrides the pick; an invalid/unconfigured
-    one silently falls back to the auto order.
+    canonical order [bocha, qianfan, zhipu, linkai, anysearch, serply]. When
+    the caller passes an explicit `provider` it overrides the pick; an
+    invalid/unconfigured one silently falls back to the auto order.
   - strategy 'fixed': use the configured provider; if its credential is
     missing at call time, silently fall back to auto order (no card hint).
 
@@ -19,11 +20,13 @@ Credentials
   - qianfan : conf.qianfan_api_key             ->  env QIANFAN_API_KEY
   - linkai  : conf.linkai_api_key              ->  env LINKAI_API_KEY
   - anysearch : tools.web_search.anysearch_api_key  -> env ANYSEARCH_API_KEY
+  - serply  : tools.web_search.serply_api_key  ->  env SERPLY_API_KEY
 """
 
 import json
 import os
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
 
 import requests
 
@@ -36,9 +39,10 @@ DEFAULT_TIMEOUT = 30
 
 # Canonical fallback order. Empirically ordered by Chinese real-time
 # quality + relevance: bocha (best overall), qianfan (best for hot news),
-# zhipu (strong on long-form articles), linkai (cloud aggregator, last
-# resort).
-PROVIDER_ORDER = ("bocha", "qianfan", "zhipu", "linkai", "anysearch")
+# zhipu (strong on long-form articles), linkai (cloud aggregator),
+# anysearch, serply (global Google/Bing SERP, last since it isn't
+# benchmarked against the Chinese-market providers above).
+PROVIDER_ORDER = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply")
 
 PROVIDER_LABELS = {
     "bocha":   "Bocha",
@@ -46,6 +50,7 @@ PROVIDER_LABELS = {
     "qianfan": "Baidu Qianfan",
     "linkai":  "LinkAI",
     "anysearch": "AnySearch",
+    "serply":  "Serply",
 }
 
 
@@ -75,6 +80,9 @@ def _get_api_key(provider: str) -> str:
     if provider == "anysearch":
         key = (_tools_web_search_conf().get("anysearch_api_key") or "").strip()
         return key or os.environ.get("ANYSEARCH_API_KEY", "").strip()
+    if provider == "serply":
+        key = (_tools_web_search_conf().get("serply_api_key") or "").strip()
+        return key or os.environ.get("SERPLY_API_KEY", "").strip()
     return ""
 
 
@@ -215,7 +223,8 @@ class WebSearch(BaseTool):
         if not provider:
             return ToolResult.fail(
                 "Error: No search provider configured. "
-                "Configure one of BOCHA_API_KEY / zhipu_ai_api_key / qianfan_api_key / linkai_api_key / anysearch_api_key."
+                "Configure one of BOCHA_API_KEY / zhipu_ai_api_key / qianfan_api_key / linkai_api_key / "
+                "anysearch_api_key / SERPLY_API_KEY."
             )
 
         # Always log the routing decision so multi-provider deployments can
@@ -239,6 +248,8 @@ class WebSearch(BaseTool):
                 return self._search_linkai(query, count, freshness)
             if provider == "anysearch":
                 return self._search_anysearch(query, count)
+            if provider == "serply":
+                return self._search_serply(query, count)
             return ToolResult.fail(f"Error: Unknown provider '{provider}'")
         except requests.Timeout:
             return ToolResult.fail(f"Error: Search request timed out after {DEFAULT_TIMEOUT}s")
@@ -537,4 +548,43 @@ class WebSearch(BaseTool):
         return ToolResult.success({
             "query": query, "backend": "anysearch",
             "total": total, "count": len(results), "results": results,
+        })
+
+    # ------------------------------------------------------------------
+    # Serply
+    # ------------------------------------------------------------------
+
+    def _search_serply(self, query: str, count: int) -> ToolResult:
+        api_key = _get_api_key("serply")
+        path = urlencode({"q": query, "num": max(1, min(int(count or 10), 50))})
+        headers = {
+            "X-Api-Key": api_key,
+            "Accept": "application/json",
+            # Serply sits behind Cloudflare, which rejects the default
+            # requests User-Agent, so send an explicit one.
+            "User-Agent": "CowAgent",
+        }
+
+        logger.debug(f"[WebSearch] serply: query='{query}', count={count}")
+        resp = requests.get(f"https://api.serply.io/v1/search/{path}", headers=headers, timeout=DEFAULT_TIMEOUT)
+
+        if resp.status_code == 401:
+            return ToolResult.fail("Error: Invalid Serply API key.")
+        if resp.status_code == 429:
+            return ToolResult.fail("Error: Serply API rate limit reached.")
+        if resp.status_code != 200:
+            return ToolResult.fail(f"Error: Serply API returned HTTP {resp.status_code}")
+
+        data = resp.json()
+        items = data.get("results") or []
+        results = []
+        for it in items:
+            results.append({
+                "title": it.get("title", ""),
+                "url": it.get("link", ""),
+                "snippet": it.get("description", ""),
+            })
+        return ToolResult.success({
+            "query": query, "backend": "serply",
+            "total": len(results), "count": len(results), "results": results,
         })

--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -133,6 +133,8 @@ const I18N = {
         models_search_bocha_desc: '前往博查开放平台创建 API Key',
         models_search_anysearch_title: '配置 AnySearch API Key',
         models_search_anysearch_desc: '前往 anysearch.com 控制台创建 API Key。',
+        models_search_serply_title: '配置 Serply API Key',
+        models_search_serply_desc: '前往 serply.io 控制台创建 API Key。',
         models_search_edit_hint: '点击修改配置',
         models_unavailable: '不可用',
         models_set_via_env: '通过环境变量启用',
@@ -538,6 +540,8 @@ const I18N = {
         models_search_bocha_desc: '前往博查開放平臺建立 API Key',
         models_search_anysearch_title: '設定 AnySearch API Key',
         models_search_anysearch_desc: '前往 anysearch.com 控制台建立 API Key',
+        models_search_serply_title: '設定 Serply API Key',
+        models_search_serply_desc: '前往 serply.io 控制台建立 API Key',
         models_search_edit_hint: '點選修改設定',
         models_unavailable: '不可用',
         models_set_via_env: '透過環境變數啟用',
@@ -938,6 +942,8 @@ const I18N = {
         models_search_bocha_desc: 'Create a key at the Bocha open platform.',
         models_search_anysearch_title: 'Configure AnySearch API Key',
         models_search_anysearch_desc: 'Create a key at the AnySearch console (anysearch.com).',
+        models_search_serply_title: 'Configure Serply API Key',
+        models_search_serply_desc: 'Create a key at the Serply console (serply.io).',
         models_search_edit_hint: 'Click to edit',
         models_unavailable: 'unavailable',
         models_set_via_env: 'enable via environment variable',
@@ -9830,7 +9836,7 @@ function openSearchAddProviderPicker(missingProviders) {
 }
 
 function _launchSearchProviderConfig(providerId, providerMeta) {
-    if (providerId === 'bocha' || providerId === 'anysearch') {
+    if (providerId === 'bocha' || providerId === 'anysearch' || providerId === 'serply') {
         openSearchKeyModal(providerId, providerMeta);
     } else {
         openVendorModal(providerId, () => loadModelsView({ preserveScroll: true }));

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -3992,7 +3992,7 @@ class ModelsHandler:
 
     # Canonical search provider order. Mirrors PROVIDER_ORDER in
     # agent/tools/web_search/web_search.py — keep them in sync.
-    _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai","anysearch")
+    _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply")
 
     _SEARCH_PROVIDER_LABELS = {
         "bocha":   {"zh": "博查", "en": "Bocha"},
@@ -4000,6 +4000,7 @@ class ModelsHandler:
         "qianfan": {"zh": "百度千帆", "en": "ERNIE"},
         "linkai":  {"zh": "LinkAI", "en": "LinkAI"},
         "anysearch": {"zh": "AnySearch", "en": "AnySearch"},
+        "serply":  {"zh": "Serply", "en": "Serply"},
     }
 
     @classmethod
@@ -4020,6 +4021,11 @@ class ModelsHandler:
             block = tools_cfg.get("web_search") or {} if isinstance(tools_cfg, dict) else {}
             return (block.get("anysearch_api_key") if isinstance(block, dict) else "") or os.environ.get(
                 "ANYSEARCH_API_KEY", "")
+        if provider == "serply":
+            tools_cfg = local_config.get("tools") or {}
+            block = tools_cfg.get("web_search") or {} if isinstance(tools_cfg, dict) else {}
+            return (block.get("serply_api_key") if isinstance(block, dict) else "") or os.environ.get(
+                "SERPLY_API_KEY", "")
         return ""
 
     @classmethod
@@ -4045,7 +4051,7 @@ class ModelsHandler:
                 # bocha owns its key under tools.web_search; the other three
                 # piggy-back on a model-vendor credential. Frontend uses
                 # this hint to decide which credential editor to surface.
-                "needs_dedicated_key": pid in ("bocha", "anysearch"),
+                "needs_dedicated_key": pid in ("bocha", "anysearch", "serply"),
                 "api_key_masked": ConfigHandler._mask_key(raw_key) if raw_key else "",
             })
             if ok:
@@ -4770,11 +4776,11 @@ class ModelsHandler:
     def _handle_set_search_credential(self, data: dict) -> str:
         """Persist a dedicated search-provider key under tools.web_search.
 
-        bocha and anysearch own their keys here; zhipu/qianfan/linkai reuse
-        model-vendor credentials and go through set_provider instead.
+        bocha, anysearch and serply own their keys here; zhipu/qianfan/linkai
+        reuse model-vendor credentials and go through set_provider instead.
         """
         provider = (data.get("provider") or "bocha").strip().lower()
-        if provider not in ("bocha", "anysearch"):
+        if provider not in ("bocha", "anysearch", "serply"):
             return json.dumps({"status": "error", "message": f"unsupported search provider: {provider!r}"})
         key_field = f"{provider}_api_key"
         api_key = (data.get("api_key") or "").strip() if isinstance(data.get("api_key"), str) else ""

--- a/docs/ja/tools/web-search.mdx
+++ b/docs/ja/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - Web 検索
 description: インターネットからリアルタイム情報を検索。複数の検索プロバイダーに対応
 ---
 
-インターネットからリアルタイム情報、ニュース、リサーチなどを検索します。Bocha、百度 Qianfan、智谱（Zhipu）、LinkAI、AnySearch の 5 つのバックエンドに対応しており、いずれか 1 社を設定すれば利用可能です。
+インターネットからリアルタイム情報、ニュース、リサーチなどを検索します。Bocha、百度 Qianfan、智谱（Zhipu）、LinkAI、AnySearch、Serply の 6 つのバックエンドに対応しており、いずれか 1 社を設定すれば利用可能です。
 
 <Tip>
   [Web コンソール](/ja/channels/web) の「モデル管理 → 検索」パネルから、プロバイダーと戦略を可視化して設定するのが推奨です。設定ファイルを手動で編集する必要はありません。
@@ -18,7 +18,9 @@ description: インターネットからリアルタイム情報を検索。複�
 | 智谱 Zhipu | `zhipu_ai_api_key` を再利用 | [Zhipu Open Platform](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | `linkai_api_key` を再利用 | [LinkAI コンソール](https://link-ai.tech/console/interface) |
 | AnySearch | `anysearch_api_key` を再利用 | [AnySearch Open Platform](https://anysearch.com/) |
-Bocha、AnySearch のみ独立した `api_key` が必要ですが、他の 3 社は対応するモデルの API Key をそのまま再利用するため、モデルを設定すれば検索機能も同時に利用可能になります。
+| Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[ドキュメント](https://serply.io/docs)） |
+
+Bocha、AnySearch、Serply のみ独立した `api_key` が必要ですが、他の 3 社は対応するモデルの API Key をそのまま再利用するため、モデルを設定すれば検索機能も同時に利用可能になります。
 
 ## ルーティング戦略
 
@@ -33,7 +35,7 @@ Bocha、AnySearch のみ独立した `api_key` が必要ですが、他の 3 社
 }
 ```
 
-- `auto`（デフォルト）：Agent が設定済みのプロバイダーから自動的に選択し、1 回のタスク内で複数回呼び出し、異なるプロバイダーを切り替えてより包括的な結果を取得できます。未指定の場合は `bocha → qianfan → zhipu → linkai` の順でフォールバックします。
+- `auto`（デフォルト）：Agent が設定済みのプロバイダーから自動的に選択し、1 回のタスク内で複数回呼び出し、異なるプロバイダーを切り替えてより包括的な結果を取得できます。未指定の場合は `bocha → qianfan → zhipu → linkai → anysearch → serply` の順でフォールバックします。
 - `fixed`：`provider` で指定したプロバイダーに固定。該当プロバイダーの認証情報が欠けている場合は自動的に auto の順序にフォールバックします。
 
 ## ツールパラメータ
@@ -47,5 +49,5 @@ Bocha、AnySearch のみ独立した `api_key` が必要ですが、他の 3 社
 | `provider` | string | いいえ | `auto` 戦略で複数プロバイダーを設定している場合に表示。単回のプロバイダー切り替えに使用 |
 
 <Note>
-  5 社の認証情報がいずれも未設定の場合、このツールは Agent に登録されません。
+  6 社の認証情報がいずれも未設定の場合、このツールは Agent に登録されません。
 </Note>

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - Web Search
 description: Search the internet for real-time information, with support for multiple search providers
 ---
 
-Search the internet for real-time information, news, research, and more. Supports five backends — Bocha, ERNIE, GLM, LinkAI, and AnySearch — and works once any one of them is configured.
+Search the internet for real-time information, news, research, and more. Supports six backends — Bocha, ERNIE, GLM, LinkAI, AnySearch, and Serply — and works once any one of them is configured.
 
 <Tip>
   It is recommended to configure providers and routing strategy visually from the "Model Management → Search" panel in the [Web console](/channels/web), without manually editing the configuration file.
@@ -18,8 +18,9 @@ Search the internet for real-time information, news, research, and more. Support
 | Zhipu | Reuses `zhipu_ai_api_key` | [Zhipu Open Platform](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | Reuses `linkai_api_key` | [LinkAI Console](https://link-ai.tech/console/interface) |
 | AnySearch | Reuses `anysearch_api_key` | [AnySearch Console](https://anysearch.com/) |
+| Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io) ([docs](https://serply.io/docs)) |
 
-Except for Bocha and AnySearch which require dedicated keys (bocha_api_key / anysearch_api_key), the other three reuse the corresponding model's API key — configuring the model automatically grants search capability.
+Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_key / anysearch_api_key / serply_api_key), the other three reuse the corresponding model's API key — configuring the model automatically grants search capability.
 
 ## Routing Strategy
 
@@ -34,7 +35,7 @@ Except for Bocha and AnySearch which require dedicated keys (bocha_api_key / any
 }
 ```
 
-- `auto` (default): the Agent intelligently picks among configured providers and may call multiple providers in a single task to gather more comprehensive results; when none is specified, falls back through `bocha → qianfan → zhipu → linkai`.
+- `auto` (default): the Agent intelligently picks among configured providers and may call multiple providers in a single task to gather more comprehensive results; when none is specified, falls back through `bocha → qianfan → zhipu → linkai → anysearch → serply`.
 - `fixed`: always use the provider specified in `provider`; falls back to the auto order if that provider's credentials are missing.
 
 ## Tool Parameters
@@ -48,5 +49,5 @@ Except for Bocha and AnySearch which require dedicated keys (bocha_api_key / any
 | `provider` | string | No | Available when multiple providers are configured under the `auto` strategy; used to switch provider for a single call |
 
 <Note>
-  If none of the five credentials are configured, this tool is not registered with the Agent.
+  If none of the six credentials are configured, this tool is not registered with the Agent.
 </Note>

--- a/docs/zh/tools/web-search.mdx
+++ b/docs/zh/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - 联网搜索
 description: 搜索互联网获取实时信息，支持多个搜索厂商
 ---
 
-搜索互联网获取实时信息、新闻、研究等内容。支持博查、百度千帆、智谱、LinkAI、AnySearch五个后端，配置任意一家即可使用。
+搜索互联网获取实时信息、新闻、研究等内容。支持博查、百度千帆、智谱、LinkAI、AnySearch、Serply 六个后端，配置任意一家即可使用。
 
 <Tip>
   推荐通过 [Web 控制台](/zh/channels/web) 的「模型管理 → 搜索」面板可视化配置厂商与策略，无需手动编辑配置文件。
@@ -18,8 +18,9 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | 智谱 Zhipu | 复用 `zhipu_ai_api_key` | [智谱开放平台](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | 复用 `linkai_api_key` | [LinkAI 控制台](https://link-ai.tech/console/interface) |
 | AnySearch | 复用 `anysearch_api_key` | [AnySearch 控制台](https://anysearch.com/) |
+| Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[文档](https://serply.io/docs)） |
 
-除博查、AnySearch需要单独配置专用密钥（bocha_api_key / anysearch_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
+除博查、AnySearch、Serply 需要单独配置专用密钥（bocha_api_key / anysearch_api_key / serply_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
 
 ## 路由策略
 
@@ -34,7 +35,7 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 }
 ```
 
-- `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai` 顺序兜底。
+- `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai → anysearch → serply` 顺序兜底。
 - `fixed`：固定使用 `provider` 指定的厂商；该厂商凭证缺失时自动回落到 auto 顺序。
 
 ## 工具参数
@@ -48,5 +49,5 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | `provider` | string | 否 | `auto` 策略下配置了多个厂商时可见，用于单次切换厂商 |
 
 <Note>
-  五家凭证均未配置时，该工具不会注册到 Agent。
+  六家凭证均未配置时，该工具不会注册到 Agent。
 </Note>

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -85,6 +85,24 @@ class TestProviderOrder(unittest.TestCase):
             ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply"),
         )
 
+    def test_web_console_provider_list_stays_in_sync(self):
+        """The web console keeps its own copy of the provider order plus the
+        set of providers that hold a dedicated key under tools.web_search.
+        Both must track the tool module so a new backend shows up in the
+        Search panel with the right credential editor."""
+        from channel.web.web_channel import ModelsHandler
+
+        self.assertEqual(ModelsHandler._SEARCH_PROVIDERS, web_search_module.PROVIDER_ORDER)
+        for pid in web_search_module.PROVIDER_ORDER:
+            self.assertIn(pid, ModelsHandler._SEARCH_PROVIDER_LABELS)
+
+        cfg = {"tools": {"web_search": {"serply_api_key": "console-key"}}}
+        self.assertEqual(ModelsHandler._search_provider_key("serply", cfg), "console-key")
+        with patch.dict(os.environ, {"SERPLY_API_KEY": "env-key"}):
+            self.assertEqual(ModelsHandler._search_provider_key("serply", {}), "env-key")
+        with patch.dict(os.environ, {"SERPLY_API_KEY": ""}):
+            self.assertEqual(ModelsHandler._search_provider_key("serply", {}), "")
+
 
 class TestAnySearchBackend(unittest.TestCase):
     """Behaviour of WebSearch._search_anysearch with a stubbed HTTP layer."""

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,6 +1,7 @@
 # encoding:utf-8
 """
-Unit tests for the web_search tool, focused on the AnySearch backend.
+Unit tests for the web_search tool, focused on the AnySearch and Serply
+backends.
 
 Covers key resolution (config file + environment fallback), the canonical
 provider fallback order, result normalization into the unified output shape,
@@ -8,7 +9,8 @@ the AnySearch-specific count clamp (the shared tool schema allows 1-50 while
 the API accepts 1-20), HTTP and business-level error mapping, and the
 anonymous mode contract (no Authorization header without a key).
 
-No real network is used: ``requests.post`` is stubbed throughout.
+No real network is used: ``requests.post`` / ``requests.get`` are stubbed
+throughout.
 """
 import json
 import os
@@ -74,13 +76,13 @@ class TestAnySearchKeyResolution(unittest.TestCase):
 
 
 class TestProviderOrder(unittest.TestCase):
-    """anysearch must be appended last, leaving existing routing untouched."""
+    """New providers are appended after the four originals, leaving existing
+    routing untouched: anysearch first, then serply."""
 
-    def test_provider_order_appends_anysearch_last(self):
-        self.assertEqual(web_search_module.PROVIDER_ORDER[-1], "anysearch")
+    def test_provider_order_appends_new_providers_last(self):
         self.assertEqual(
-            web_search_module.PROVIDER_ORDER[:4],
-            ("bocha", "qianfan", "zhipu", "linkai"),
+            web_search_module.PROVIDER_ORDER,
+            ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply"),
         )
 
 
@@ -172,6 +174,99 @@ class TestAnySearchBackend(unittest.TestCase):
         self.assertEqual(result.status, "success")
         headers = mock_post.call_args[1]["headers"]
         self.assertNotIn("Authorization", headers)
+
+
+def _serply_payload(results):
+    """Build a Serply /v1/search response body in the documented shape."""
+    return {"results": results, "ads": [], "related_questions": []}
+
+
+class TestSerplyKeyResolution(unittest.TestCase):
+    """The serply key lives under tools.web_search, falling back to env."""
+
+    def setUp(self):
+        self._prev_env = os.environ.get("SERPLY_API_KEY")
+        os.environ.pop("SERPLY_API_KEY", None)
+
+    def tearDown(self):
+        if self._prev_env is None:
+            os.environ.pop("SERPLY_API_KEY", None)
+        else:
+            os.environ["SERPLY_API_KEY"] = self._prev_env
+
+    def test_serply_key_from_tools_config(self):
+        """tools.web_search.serply_api_key is resolved, and wins over env."""
+        cfg = {"tools": {"web_search": {"serply_api_key": "test-key-123"}}}
+        with patch.object(web_search_module, "conf", lambda: cfg):
+            self.assertEqual(web_search_module._get_api_key("serply"), "test-key-123")
+            with patch.dict(os.environ, {"SERPLY_API_KEY": "env-key-456"}):
+                self.assertEqual(web_search_module._get_api_key("serply"), "test-key-123")
+
+    def test_serply_key_env_fallback(self):
+        """Without a config value, SERPLY_API_KEY is used; both empty -> ''."""
+        with patch.object(web_search_module, "conf", lambda: {}):
+            with patch.dict(os.environ, {"SERPLY_API_KEY": "env-key-456"}):
+                self.assertEqual(web_search_module._get_api_key("serply"), "env-key-456")
+            self.assertEqual(web_search_module._get_api_key("serply"), "")
+
+
+class TestSerplyBackend(unittest.TestCase):
+    """Behaviour of WebSearch._search_serply with a stubbed HTTP layer."""
+
+    def setUp(self):
+        self.tool = web_search_module.WebSearch()
+
+    def test_search_serply_maps_results(self):
+        """Serply's title/link/description map to title/url/snippet, and the
+        key travels in the X-Api-Key header alongside an explicit User-Agent."""
+        payload = _serply_payload([
+            {"title": "T1", "link": "https://a.example/1", "description": "s1"},
+            {"title": "T2", "link": "https://a.example/2"},
+        ])
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module.requests, "get",
+                             return_value=_fake_response(200, payload)) as mock_get:
+            result = self.tool._search_serply("cowagent", 10)
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.result["backend"], "serply")
+        self.assertEqual(result.result["total"], 2)
+        self.assertEqual(result.result["count"], 2)
+        first, second = result.result["results"]
+        self.assertEqual(first, {"title": "T1", "url": "https://a.example/1", "snippet": "s1"})
+        self.assertEqual(second, {"title": "T2", "url": "https://a.example/2", "snippet": ""})
+        headers = mock_get.call_args[1]["headers"]
+        self.assertEqual(headers.get("X-Api-Key"), "test-key-123")
+        self.assertTrue(headers.get("User-Agent"))
+
+    def test_search_serply_clamps_count(self):
+        """count is clamped into 1-50 and sent as the `num` query parameter;
+        a falsy count falls back to the default of 10."""
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module.requests, "get",
+                             return_value=_fake_response(200, _serply_payload([]))) as mock_get:
+            for count, expected in ((50, 50), (99, 50), (0, 10), (None, 10), (10, 10)):
+                with self.subTest(count=count):
+                    self.tool._search_serply("q", count)
+                    url = mock_get.call_args[0][0]
+                    self.assertIn(f"num={expected}", url)
+                    self.assertIn("q=q", url)
+
+    def test_search_serply_error_status_mapping(self):
+        """401/429 map to specific messages; other statuses are generic."""
+        cases = {
+            401: "Invalid Serply API key",
+            429: "rate limit reached",
+            500: "HTTP 500",
+        }
+        for status_code, fragment in cases.items():
+            with self.subTest(status_code=status_code):
+                with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                        patch.object(web_search_module.requests, "get",
+                                     return_value=_fake_response(status_code)):
+                    result = self.tool._search_serply("q", 10)
+                self.assertEqual(result.status, "error")
+                self.assertIn(fragment, result.result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Adds Serply as a sixth `web_search` backend, alongside Bocha, Zhipu, ERNIE (Qianfan), LinkAI and AnySearch. Follows the existing provider pattern exactly: added to `PROVIDER_ORDER` (last, since it isn't benchmarked against the Chinese-market providers), a `_get_api_key("serply")` branch reading `tools.web_search.serply_api_key` / `SERPLY_API_KEY`, and a `_search_serply` method matching the shape of the existing `_search_*` methods, normalized to the same result fields. Docs in `docs/tools/web-search.mdx` updated to list the sixth backend.

Rebased onto master after AnySearch (2c846d2a) landed: Serply is appended after `anysearch` in `PROVIDER_ORDER`. The provider-order assertion in the new `tests/test_web_search.py` now checks the full six-tuple, and equivalent unit tests for the Serply backend were added there (key resolution from config and env, result mapping and headers, count clamp, 401/429/500 error mapping).

Follow-up commit 4977dd3b wires Serply into the web console the same way AnySearch is: it joins `_SEARCH_PROVIDERS` and the labels in `channel/web/web_channel.py`, `_search_provider_key` resolves `tools.web_search.serply_api_key` (falling back to `SERPLY_API_KEY`), `set_search_credential` accepts `provider=serply`, and `console.js` gets the zh-CN, zh-TW and en strings for the key modal so Serply appears under Model Management > Search with its own API key editor. The zh and ja `web_search` docs now match the English page.

Serply is a SERP API for Google and Bing search, plus other verticals.

## Type of change

- [x] New feature

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [ ] Linked related issue (if any): closes #

## Testing

Called `WebSearch.execute()` directly with `provider=serply` and a real `SERPLY_API_KEY`, confirmed real results came back in the shared response shape. Confirmed `configured_providers()` and the "no provider configured" error path still work correctly with no keys set.

`tests/test_web_search.py` also checks that the console's `_SEARCH_PROVIDERS` and dedicated-key resolution stay in sync with `PROVIDER_ORDER`; 23 tests pass in that file.

Serply support is optional; behavior is unchanged when `SERPLY_API_KEY` is unset.

Disclosure: I work with Serply. Happy to adjust scope, naming, or drop this
entirely if it isn't a direction you want for the project.


