### PR TITLE
docs(ja): add 繁體中文 link to language switcher

### DIFF
--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  [<a href="../../README.md">English</a>] | [<a href="../zh/README.md">中文</a>] | [日本語]
+  [<a href="../../README.md">English</a>] | [<a href="../zh/README.md">中文</a>] | [<a href="../zh/README-Hant.md">繁體中文</a>] | [日本語]
 </p>
 
 **CowAgent** は、自律的にタスクを計画し、コンピュータや外部リソースを操作し、Skill を作成・実行し、パーソナルナレッジベースと長期記憶を構築し、自己進化によってユーザーとともに成長するオープンソースのスーパー AI アシスタントです。エンドツーエンドの Agent Harness のリファレンス実装の一つでもあります。


### PR DESCRIPTION
## Problem

The Japanese README (`docs/ja/README.md`) language switcher only links to **English**, **中文**, and **日本語**. The other three localized READMEs (English, Simplified Chinese, Traditional Chinese) each link to all four languages, so the Japanese page is the only one missing the **繁體中文** (Traditional Chinese) entry. Visitors reading the Japanese README cannot jump directly to the Traditional Chinese translation.

## Solution

Add the missing **繁體中文** link to the language switcher in `docs/ja/README.md`, pointing to `../zh/README-Hant.md`. The relative path mirrors the existing `../zh/README.md` link used for **中文** on the same line, and matches how the English and Simplified Chinese READMEs reference the Traditional Chinese file.

Before:

```
[English] | [中文] | [日本語]
```

After:

```
[English] | [中文] | [繁體中文] | [日本語]
```

## Testing

- Verified `docs/zh/README-Hant.md` exists in the repo.
- Confirmed the relative path `../zh/README-Hant.md` resolves correctly from `docs/ja/README.md` (consistent with the existing `../zh/README.md` link on the same line).
- Confirmed the other three READMEs already list all four languages, so this change makes the switcher consistent across every localization.
- Docs-only change; no code, build, or tests affected.
