### PR TITLE
feat: add LiteLLM as a provider

### DIFF
--- a/common/const.py
+++ b/common/const.py
@@ -18,6 +18,7 @@ DEEPSEEK = "deepseek"
 MIMO = "mimo"  # Xiaomi MiMo
 CUSTOM = "custom"  # custom OpenAI-compatible API, bot_type won't auto-switch on model change
 MODELSCOPE = "modelscope"
+LITELLM = "litellm"  # LiteLLM SDK gateway: one provider reaching 100+ LLMs (provider-prefixed model, e.g. anthropic/claude-3-5-sonnet)
 
 # Model list
 # Claude (Anthropic)

--- a/config.py
+++ b/config.py
@@ -228,6 +228,11 @@ available_setting = {
     "zhipu_ai_api_base": "https://open.bigmodel.cn/api/paas/v4",
     "moonshot_api_key": "",
     "moonshot_base_url": "https://api.moonshot.cn/v1",
+    # LiteLLM gateway config (bot_type "litellm"). Model is provider-prefixed,
+    # e.g. anthropic/claude-3-5-sonnet. api_key/base_url are optional: when blank
+    # LiteLLM falls back to the provider's own env vars, or a LiteLLM proxy URL.
+    "litellm_api_key": "",
+    "litellm_base_url": "",
     # Doubao (Volcano Ark) platform config
     "ark_api_key": "",
     "ark_base_url": "https://ark.cn-beijing.volces.com/api/v3",
@@ -610,6 +615,8 @@ def load_config():
         "zhipu_ai_api_base": "ZHIPU_AI_API_BASE",
         "moonshot_api_key": "MOONSHOT_API_KEY",
         "moonshot_api_base": "MOONSHOT_API_BASE",
+        "litellm_api_key": "LITELLM_API_KEY",
+        "litellm_base_url": "LITELLM_BASE_URL",
         "ark_api_key": "ARK_API_KEY",
         "ark_api_base": "ARK_API_BASE",
         "dashscope_api_key": "DASHSCOPE_API_KEY",

--- a/models/bot_factory.py
+++ b/models/bot_factory.py
@@ -81,4 +81,8 @@ def create_bot(bot_type):
         from models.doubao.doubao_bot import DoubaoBot
         return DoubaoBot()
 
+    elif bot_type == const.LITELLM:
+        from models.litellm.litellm_bot import LiteLLMBot
+        return LiteLLMBot()
+
     raise RuntimeError

--- a/models/litellm/litellm_bot.py
+++ b/models/litellm/litellm_bot.py
@@ -1,0 +1,214 @@
+# encoding:utf-8
+
+"""
+LiteLLM Bot — one provider that reaches 100+ LLMs through the LiteLLM SDK.
+
+Unlike the generic ``custom`` OpenAI-compatible bot (which only talks to a single
+OpenAI-shaped HTTP endpoint), this bot calls ``litellm.completion`` directly, so a
+provider-prefixed model string routes natively to the right backend and LiteLLM
+handles that provider's own auth:
+
+    anthropic/claude-3-5-sonnet, gemini/gemini-1.5-pro, groq/llama-3.1-70b,
+    bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0, azure/<deployment>, ...
+
+Config (config.json):
+    "bot_type": "litellm",
+    "model": "anthropic/claude-3-5-sonnet",   # provider-prefixed
+    "litellm_api_key": "",                      # optional; falls back to the
+                                                 # provider's own env var
+    "litellm_base_url": ""                       # optional; e.g. a LiteLLM proxy
+"""
+
+import time
+from typing import Optional
+
+from models.bot import Bot
+from models.openai_compatible_bot import OpenAICompatibleBot
+from models.session_manager import SessionManager
+from bridge.context import ContextType
+from bridge.reply import Reply, ReplyType
+from common.log import logger
+from config import conf, load_config
+from .litellm_session import LiteLLMSession
+
+
+class LiteLLMBot(Bot, OpenAICompatibleBot):
+    """LiteLLM gateway bot (chat + agent tools + vision) via the litellm SDK."""
+
+    def __init__(self):
+        super().__init__()
+        model = conf().get("model") or "gpt-4o-mini"
+        self.sessions = SessionManager(LiteLLMSession, model=model)
+        self.args = {
+            "model": model,
+            "temperature": conf().get("temperature", 0.7),
+            "top_p": conf().get("top_p", 1.0),
+        }
+
+    # ---- config plumbing (used by the inherited agent tool/vision methods) ----
+
+    @property
+    def api_key(self):
+        return conf().get("litellm_api_key")
+
+    @property
+    def base_url(self):
+        # Optional. When unset LiteLLM uses the provider's default endpoint.
+        return conf().get("litellm_base_url") or None
+
+    def get_api_config(self):
+        return {
+            "api_key": self.api_key,
+            "api_base": self.base_url,
+            "model": conf().get("model") or "gpt-4o-mini",
+            "default_temperature": conf().get("temperature", 0.7),
+            "default_top_p": conf().get("top_p", 1.0),
+        }
+
+    def _completion_kwargs(self):
+        """Common kwargs for every litellm call: credentials + cross-provider safety."""
+        kwargs = {"drop_params": True}
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.base_url:
+            kwargs["api_base"] = self.base_url
+        return kwargs
+
+    # ---- classic chat path ----
+
+    def reply(self, query, context=None):
+        if context.type != ContextType.TEXT:
+            return Reply(ReplyType.ERROR, "Bot cannot process message of type {}".format(context.type))
+
+        logger.info("[LITELLM] query={}".format(query))
+        session_id = context["session_id"]
+
+        clear_memory_commands = conf().get("clear_memory_commands", [])
+        if query in clear_memory_commands:
+            self.sessions.clear_session(session_id)
+            return Reply(ReplyType.INFO, "Memory cleared.")
+
+        session = self.sessions.session_query(query, session_id)
+        model = context.get("litellm_model")
+        new_args = self.args.copy()
+        if model:
+            new_args["model"] = model
+
+        reply_content = self.reply_text(session, args=new_args)
+        logger.debug(
+            "[LITELLM] session_id={}, reply_cont={}, completion_tokens={}".format(
+                session_id, reply_content["content"], reply_content["completion_tokens"]
+            )
+        )
+        if reply_content["completion_tokens"] > 0:
+            self.sessions.session_reply(reply_content["content"], session_id, reply_content["total_tokens"])
+            return Reply(ReplyType.TEXT, reply_content["content"])
+        return Reply(ReplyType.ERROR, reply_content["content"])
+
+    def reply_text(self, session: LiteLLMSession, args=None, retry_count: int = 0) -> dict:
+        """Call litellm.completion and return {total_tokens, completion_tokens, content}."""
+        try:
+            import litellm
+
+            body = dict(args) if args else dict(self.args)
+            response = litellm.completion(
+                messages=session.messages,
+                **body,
+                **self._completion_kwargs(),
+            )
+            usage = getattr(response, "usage", None)
+            return {
+                "total_tokens": getattr(usage, "total_tokens", 0) if usage else 0,
+                "completion_tokens": getattr(usage, "completion_tokens", 0) if usage else 0,
+                "content": response.choices[0].message.content or "",
+            }
+        except ImportError:
+            logger.error("[LITELLM] litellm is not installed. Install it with `pip install litellm`.")
+            return {"completion_tokens": 0, "content": "litellm is not installed on the server."}
+        except Exception as e:
+            need_retry = retry_count < 2
+            cls_name = type(e).__name__
+            # Retry only on transient errors; surface auth/bad-request immediately.
+            transient = cls_name in (
+                "Timeout", "APIConnectionError", "InternalServerError",
+                "ServiceUnavailableError", "RateLimitError",
+            )
+            logger.warning("[LITELLM] completion failed (attempt {}): {}: {}".format(retry_count + 1, cls_name, e))
+            if transient and need_retry:
+                time.sleep(3)
+                return self.reply_text(session, args, retry_count + 1)
+            return {"completion_tokens": 0, "content": "[LiteLLM error] {}".format(e)}
+
+    # ---- agent tool-calling transport: reuse the base's format conversion /
+    #      request building, but dispatch through the litellm SDK ----
+
+    def _handle_sync_response(self, request_params, api_key, api_base):
+        try:
+            import litellm
+
+            params = dict(request_params)
+            params.pop("stream", None)
+            response = litellm.completion(
+                api_key=api_key or None,
+                api_base=api_base or None,
+                drop_params=True,
+                **params,
+            )
+            return response.model_dump() if hasattr(response, "model_dump") else response
+        except Exception as e:
+            logger.error("[LITELLM] sync response error: {}".format(e))
+            return {"error": True, "message": str(e), "status_code": 500}
+
+    def _handle_stream_response(self, request_params, api_key, api_base):
+        try:
+            import litellm
+
+            params = dict(request_params)
+            params.pop("stream", None)
+            stream = litellm.completion(
+                api_key=api_key or None,
+                api_base=api_base or None,
+                drop_params=True,
+                stream=True,
+                **params,
+            )
+            for chunk in stream:
+                yield chunk.model_dump() if hasattr(chunk, "model_dump") else chunk
+        except Exception as e:
+            logger.error("[LITELLM] stream response error: {}".format(e))
+            yield {"error": True, "message": str(e), "status_code": 500}
+
+    # ---- vision via the litellm SDK (OpenAI-style image_url content) ----
+
+    def call_vision(self, image_url: str, question: str,
+                    model: Optional[str] = None,
+                    max_tokens: int = 1000) -> dict:
+        try:
+            import litellm
+
+            vision_model = model or self.args.get("model")
+            response = litellm.completion(
+                model=vision_model,
+                max_tokens=max_tokens,
+                messages=[{
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": question},
+                        {"type": "image_url", "image_url": {"url": image_url}},
+                    ],
+                }],
+                **self._completion_kwargs(),
+            )
+            usage = getattr(response, "usage", None)
+            return {
+                "model": vision_model,
+                "content": response.choices[0].message.content or "",
+                "usage": {
+                    "prompt_tokens": getattr(usage, "prompt_tokens", 0) if usage else 0,
+                    "completion_tokens": getattr(usage, "completion_tokens", 0) if usage else 0,
+                    "total_tokens": getattr(usage, "total_tokens", 0) if usage else 0,
+                },
+            }
+        except Exception as e:
+            logger.error("[LITELLM] call_vision error: {}".format(e))
+            return {"error": True, "message": str(e)}

--- a/models/litellm/litellm_session.py
+++ b/models/litellm/litellm_session.py
@@ -1,0 +1,63 @@
+from models.session_manager import Session
+from common.log import logger
+
+
+class LiteLLMSession(Session):
+    def __init__(self, session_id, system_prompt=None, model="gpt-4o-mini"):
+        super().__init__(session_id, system_prompt)
+        self.model = model
+        self.reset()
+
+    def discard_exceeding(self, max_tokens, cur_tokens=None):
+        precise = True
+        try:
+            cur_tokens = self.calc_tokens()
+        except Exception as e:
+            precise = False
+            if cur_tokens is None:
+                raise e
+            logger.debug("Exception when counting tokens precisely for query: {}".format(e))
+        while cur_tokens > max_tokens:
+            if len(self.messages) > 2:
+                self.messages.pop(1)
+            elif len(self.messages) == 2 and self.messages[1]["role"] == "assistant":
+                self.messages.pop(1)
+                if precise:
+                    cur_tokens = self.calc_tokens()
+                else:
+                    cur_tokens = cur_tokens - max_tokens
+                break
+            elif len(self.messages) == 2 and self.messages[1]["role"] == "user":
+                logger.warn("user message exceed max_tokens. total_tokens={}".format(cur_tokens))
+                break
+            else:
+                logger.debug("max_tokens={}, total_tokens={}, len(messages)={}".format(
+                    max_tokens, cur_tokens, len(self.messages)))
+                break
+            if precise:
+                cur_tokens = self.calc_tokens()
+            else:
+                cur_tokens = cur_tokens - max_tokens
+        return cur_tokens
+
+    def calc_tokens(self):
+        return num_tokens_from_messages(self.messages, self.model)
+
+
+def num_tokens_from_messages(messages, model):
+    """Approximate token count.
+
+    LiteLLM spans many providers/tokenizers, so a provider-agnostic character
+    heuristic is used here (matching the other OpenAI-compatible sessions in
+    this repo) rather than a model-specific tokenizer.
+    """
+    tokens = 0
+    for msg in messages:
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            tokens += len(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    tokens += len(block.get("text", ""))
+    return tokens

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,9 @@ wechatpy
 zai-sdk>=0.2.3
 # tongyi qwen sdk
 dashscope
+# litellm gateway (bot_type "litellm"): one provider reaching 100+ LLMs.
+# Lazy-imported, so it is only needed when bot_type is set to "litellm".
+litellm>=1.89,<2.0
 
 # feishu
 lark-oapi>=1.5.5

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,112 @@
+# encoding:utf-8
+"""
+Unit tests for the LiteLLM provider (models/litellm/litellm_bot.py).
+
+`litellm` is lazy-imported inside the bot, so these tests stub it in
+``sys.modules`` before it is used. No network access.
+"""
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import config as config_module
+from config import Config
+
+
+def set_conf(d):
+    config_module.config = Config(d)
+
+
+def install_litellm_stub(content="hello", raise_exc=None):
+    """Install a fake litellm module; return its completion spy (with .calls)."""
+    fake = types.ModuleType("litellm")
+
+    def completion(**kwargs):
+        completion.calls.append(kwargs)
+        if raise_exc is not None:
+            raise raise_exc
+        message = types.SimpleNamespace(content=content)
+        choice = types.SimpleNamespace(message=message)
+        usage = types.SimpleNamespace(total_tokens=42, completion_tokens=10, prompt_tokens=32)
+        return types.SimpleNamespace(choices=[choice], usage=usage)
+
+    completion.calls = []
+    fake.completion = completion
+    sys.modules["litellm"] = fake
+    return completion
+
+
+BASE_CONF = {
+    "bot_type": "litellm",
+    "model": "anthropic/claude-3-5-sonnet",
+    "litellm_api_key": "sk-test",
+    "litellm_base_url": "http://localhost:4000",
+    "temperature": 0.5,
+    "top_p": 0.9,
+}
+
+
+class TestFactory(unittest.TestCase):
+    def test_factory_returns_litellm_bot(self):
+        set_conf(dict(BASE_CONF))
+        install_litellm_stub()
+        import common.const as const
+        from models.bot_factory import create_bot
+        from models.litellm.litellm_bot import LiteLLMBot
+        bot = create_bot(const.LITELLM)
+        self.assertIsInstance(bot, LiteLLMBot)
+
+
+class TestReplyText(unittest.TestCase):
+    def _bot(self, conf):
+        set_conf(conf)
+        from models.litellm.litellm_bot import LiteLLMBot
+        return LiteLLMBot()
+
+    def test_dispatch_forwards_model_creds_and_drop_params(self):
+        spy = install_litellm_stub(content="4")
+        bot = self._bot(dict(BASE_CONF))
+        from models.litellm.litellm_session import LiteLLMSession
+        session = LiteLLMSession("s1", model="anthropic/claude-3-5-sonnet")
+        session.messages = [{"role": "user", "content": "2+2?"}]
+        out = bot.reply_text(session)
+        self.assertEqual(out["content"], "4")
+        self.assertEqual(out["total_tokens"], 42)
+        call = spy.calls[0]
+        self.assertEqual(call["model"], "anthropic/claude-3-5-sonnet")
+        self.assertTrue(call["drop_params"])
+        self.assertEqual(call["api_key"], "sk-test")
+        self.assertEqual(call["api_base"], "http://localhost:4000")
+
+    def test_credentials_omitted_when_blank(self):
+        spy = install_litellm_stub()
+        conf = dict(BASE_CONF)
+        conf["litellm_api_key"] = ""
+        conf["litellm_base_url"] = ""
+        bot = self._bot(conf)
+        from models.litellm.litellm_session import LiteLLMSession
+        session = LiteLLMSession("s2", model=conf["model"])
+        session.messages = [{"role": "user", "content": "hi"}]
+        bot.reply_text(session)
+        call = spy.calls[0]
+        self.assertNotIn("api_key", call)
+        self.assertNotIn("api_base", call)
+        self.assertTrue(call["drop_params"])
+
+    def test_transient_error_returns_error_content(self):
+        err = type("RateLimitError", (Exception,), {})("429")
+        install_litellm_stub(raise_exc=err)
+        bot = self._bot(dict(BASE_CONF))
+        from models.litellm.litellm_session import LiteLLMSession
+        session = LiteLLMSession("s3", model=BASE_CONF["model"])
+        session.messages = [{"role": "user", "content": "hi"}]
+        out = bot.reply_text(session)
+        self.assertEqual(out["completion_tokens"], 0)
+        self.assertIn("LiteLLM error", out["content"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION


## What does this PR do?

Adds **LiteLLM** as a new provider (`bot_type: "litellm"`), following the existing per provider pattern in `models/<provider>/`.

Unlike the generic `custom` OpenAI compatible bot (which only talks to a single OpenAI shaped HTTP endpoint), this provider calls the **LiteLLM SDK** directly (`litellm.completion`), so a single provider entry reaches **100+ models across every backend LiteLLM supports**, with each provider's *native* auth handled by LiteLLM:



**How it fits the codebase:**
* `models/litellm/litellm_bot.py`: `LiteLLMBot(Bot, OpenAICompatibleBot)`. Reuses the existing `OpenAICompatibleBot` message and tool format conversion and agent plumbing, but overrides the transport (`_handle_sync_response` and `_handle_stream_response`) to dispatch through the LiteLLM SDK. Implements the `reply()` and `reply_text()` chat path plus `call_vision()`.
* `models/litellm/litellm_session.py`: `LiteLLMSession` (mirrors the other provider sessions).
* `models/bot_factory.py`: routes `const.LITELLM` to `LiteLLMBot`.
* `common/const.py`: adds the `LITELLM` provider type.
* `config.py`: adds `litellm_api_key` and `litellm_base_url` settings plus env var mapping (`LITELLM_API_KEY` and `LITELLM_BASE_URL`).
* `requirements.txt`: adds `litellm>=1.89,<2.0` (lazy imported, so only needed when `bot_type` is `litellm`).

**Design notes:**
* `drop_params=True` on every call, so one config works across providers (Anthropic, Gemini, and others reject some OpenAI only sampling params).
* `api_key` and `base_url` are optional. When blank, LiteLLM falls back to each provider's own env var (or a LiteLLM proxy URL). Blank values are omitted, not sent as empty strings.
* **No model is hardcoded.** The model always comes from `config.json`; LiteLLM is intentionally left out of the static model list since available models depend on the user's config or proxy.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the Contributing Guide
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [ ] Linked related issue (if any): closes #

### Test evidence

`pytest tests/test_litellm_provider.py`:
```
tests/test_litellm_provider.py ....                                   [100%]
4 passed
```
Covers: factory returns `LiteLLMBot` for `const.LITELLM`; `reply_text` forwards model, credentials, and `drop_params` to `litellm.completion`; credentials omitted when blank (env var fallback); transient errors surface cleanly.
