### PR TITLE
feat(run): introduce run as a first-class, persisted concept

### DIFF
--- a/agent/memory/conversation_store.py
+++ b/agent/memory/conversation_store.py
@@ -56,6 +56,43 @@ CREATE INDEX IF NOT EXISTS idx_messages_session
 
 CREATE INDEX IF NOT EXISTS idx_sessions_last_active
     ON sessions (last_active);
+
+-- A run is one addressable, persisted unit of an agent's work: the thing a
+-- delegated task, a subagent spawn or a scheduled job can be looked up by,
+-- resumed from and reported on after the call that started it has returned.
+-- Distinct from a session (who the conversation is with) and an agent (who is
+-- doing the work). Kept in the same per-agent database as sessions/messages.
+CREATE TABLE IF NOT EXISTS runs (
+    run_id       TEXT    PRIMARY KEY,
+    agent_id     TEXT    NOT NULL DEFAULT '',
+    -- Reserved for the tenancy dimension; empty until per-user isolation lands,
+    -- so filtering by owner is an additive query change rather than a schema one.
+    user_id      TEXT    NOT NULL DEFAULT '',
+    session_id   TEXT    NOT NULL DEFAULT '',
+    -- The run that spawned this one (a delegation or subagent). Empty for a
+    -- top-level run. Lets a whole delegation tree be walked from any node.
+    parent_run_id TEXT   NOT NULL DEFAULT '',
+    -- Free-form external work handle and where it came from. task_source is
+    -- empty for a native CowAgent run; a non-empty value names the external
+    -- system and task_id then addresses a work item within it. TEXT on purpose:
+    -- it must hold external ids, never a foreign key into a table we own.
+    task_id      TEXT    NOT NULL DEFAULT '',
+    task_source  TEXT    NOT NULL DEFAULT '',
+    status       TEXT    NOT NULL DEFAULT 'running',
+    started_at   INTEGER NOT NULL,
+    ended_at     INTEGER,
+    error        TEXT    NOT NULL DEFAULT '',
+    extras       TEXT    NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_runs_session
+    ON runs (session_id, started_at);
+
+CREATE INDEX IF NOT EXISTS idx_runs_parent
+    ON runs (parent_run_id);
+
+CREATE INDEX IF NOT EXISTS idx_runs_task
+    ON runs (task_source, task_id);
 """
 
 # Migration: add channel_type column to existing databases that predate it.
@@ -80,6 +117,13 @@ ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;
 # Always optional — readers must tolerate missing column / empty / invalid JSON.
 _MIGRATION_ADD_MSG_EXTRAS = """
 ALTER TABLE messages ADD COLUMN extras TEXT NOT NULL DEFAULT '';
+"""
+
+# Attribute each message to the run that produced it, so a run's trace can be
+# reconstructed and a delegated/subagent turn is distinguishable from its
+# parent's. Empty for messages written before runs were tracked.
+_MIGRATION_ADD_MSG_RUN_ID = """
+ALTER TABLE messages ADD COLUMN run_id TEXT NOT NULL DEFAULT '';
 """
 
 DEFAULT_MAX_AGE_DAYS: int = 30
@@ -464,6 +508,7 @@ class ConversationStore:
         messages: List[Dict[str, Any]],
         channel_type: str = "",
         create_if_missing: bool = True,
+        run_id: Optional[str] = None,
     ) -> bool:
         """
         Append new messages to a session's history.
@@ -480,6 +525,10 @@ class ConversationStore:
                           gone. Callers that already stored the user turn use
                           this so a session deleted mid-run is not recreated
                           from the reply alone.
+            run_id: The run these messages belong to. Falls back to the ambient
+                          RuntimeIdentity's run id, so callers inside a run do
+                          not have to thread it through. A per-message ``run_id``
+                          key overrides it for that one message.
 
         Returns:
             True when the messages were written, False when the session was
@@ -487,6 +536,10 @@ class ConversationStore:
         """
         if not messages:
             return False
+
+        if run_id is None:
+            from common.utils import current_agent_run_id
+            run_id = current_agent_run_id() or ""
 
         now = int(time.time())
         with self._lock:
@@ -531,13 +584,14 @@ class ConversationStore:
                         )
                         extras_obj = msg.get("extras") or {}
                         extras = json.dumps(extras_obj, ensure_ascii=False) if extras_obj else ""
+                        msg_run_id = str(msg.get("run_id") or run_id or "")
                         conn.execute(
                             """
                             INSERT OR IGNORE INTO messages
-                                (session_id, seq, role, content, created_at, extras)
-                            VALUES (?, ?, ?, ?, ?, ?)
+                                (session_id, seq, role, content, created_at, extras, run_id)
+                            VALUES (?, ?, ?, ?, ?, ?, ?)
                             """,
-                            (session_id, next_seq, role, content, now, extras),
+                            (session_id, next_seq, role, content, now, extras, msg_run_id),
                         )
                         next_seq += 1
 
@@ -983,6 +1037,198 @@ class ConversationStore:
             finally:
                 conn.close()
 
+    # ------------------------------------------------------------------
+    # Runs: addressable, persisted units of work
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _run_row_to_dict(row: tuple) -> Dict[str, Any]:
+        (
+            run_id, agent_id, user_id, session_id, parent_run_id,
+            task_id, task_source, status, started_at, ended_at, error, raw_extras,
+        ) = row
+        try:
+            extras = json.loads(raw_extras) if raw_extras else {}
+            if not isinstance(extras, dict):
+                extras = {}
+        except Exception:
+            extras = {}
+        return {
+            "run_id": run_id,
+            "agent_id": agent_id,
+            "user_id": user_id,
+            "session_id": session_id,
+            "parent_run_id": parent_run_id,
+            "task_id": task_id,
+            "task_source": task_source,
+            "status": status,
+            "started_at": started_at,
+            "ended_at": ended_at,
+            "error": error,
+            "extras": extras,
+        }
+
+    _RUN_COLUMNS = (
+        "run_id, agent_id, user_id, session_id, parent_run_id, "
+        "task_id, task_source, status, started_at, ended_at, error, extras"
+    )
+
+    def create_run(
+        self,
+        run_id: str,
+        *,
+        agent_id: str = "",
+        user_id: str = "",
+        session_id: str = "",
+        parent_run_id: str = "",
+        task_id: str = "",
+        task_source: str = "",
+        status: str = "running",
+        extras: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Record the start of a run. Idempotent: a second call with the same
+        run_id is ignored so a retried entry point does not duplicate the row.
+
+        Returns True when a new row was written, False when it already existed.
+        """
+        if not run_id:
+            raise ValueError("run_id is required")
+        now = int(time.time())
+        extras_json = (
+            json.dumps(extras, ensure_ascii=False) if extras else ""
+        )
+        with self._lock:
+            conn = self._connect()
+            try:
+                with conn:
+                    cur = conn.execute(
+                        """
+                        INSERT OR IGNORE INTO runs
+                            (run_id, agent_id, user_id, session_id, parent_run_id,
+                             task_id, task_source, status, started_at, ended_at,
+                             error, extras)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, '', ?)
+                        """,
+                        (
+                            run_id, agent_id, user_id, session_id, parent_run_id,
+                            task_id, task_source, status, now, extras_json,
+                        ),
+                    )
+                    return cur.rowcount > 0
+            finally:
+                conn.close()
+
+    def finish_run(
+        self,
+        run_id: str,
+        status: str = "done",
+        error: str = "",
+        extras: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Mark a run finished (or failed). Sets ended_at and, when given,
+        merges ``extras`` into the stored sidecar. Returns True if the run
+        existed.
+        """
+        if not run_id:
+            return False
+        now = int(time.time())
+        with self._lock:
+            conn = self._connect()
+            try:
+                with conn:
+                    if extras:
+                        row = conn.execute(
+                            "SELECT extras FROM runs WHERE run_id = ?", (run_id,)
+                        ).fetchone()
+                        if row is None:
+                            return False
+                        try:
+                            cur_extras = json.loads(row[0]) if row[0] else {}
+                            if not isinstance(cur_extras, dict):
+                                cur_extras = {}
+                        except Exception:
+                            cur_extras = {}
+                        cur_extras.update(extras)
+                        extras_json = json.dumps(cur_extras, ensure_ascii=False)
+                        cur = conn.execute(
+                            """
+                            UPDATE runs
+                            SET status = ?, error = ?, ended_at = ?, extras = ?
+                            WHERE run_id = ?
+                            """,
+                            (status, error, now, extras_json, run_id),
+                        )
+                    else:
+                        cur = conn.execute(
+                            """
+                            UPDATE runs
+                            SET status = ?, error = ?, ended_at = ?
+                            WHERE run_id = ?
+                            """,
+                            (status, error, now, run_id),
+                        )
+                    return cur.rowcount > 0
+            finally:
+                conn.close()
+
+    def get_run(self, run_id: str) -> Optional[Dict[str, Any]]:
+        """Return a single run by id, or None."""
+        if not run_id:
+            return None
+        with self._lock:
+            conn = self._connect()
+            try:
+                row = conn.execute(
+                    f"SELECT {self._RUN_COLUMNS} FROM runs WHERE run_id = ?",
+                    (run_id,),
+                ).fetchone()
+            finally:
+                conn.close()
+        return self._run_row_to_dict(row) if row else None
+
+    def list_runs(
+        self,
+        session_id: Optional[str] = None,
+        parent_run_id: Optional[str] = None,
+        task_source: Optional[str] = None,
+        task_id: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """List runs, newest first, filtered by any combination of the given
+        dimensions. ``parent_run_id=''`` selects top-level runs only.
+        """
+        clauses: List[str] = []
+        params: List[Any] = []
+        if session_id is not None:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        if parent_run_id is not None:
+            clauses.append("parent_run_id = ?")
+            params.append(parent_run_id)
+        if task_source is not None:
+            clauses.append("task_source = ?")
+            params.append(task_source)
+        if task_id is not None:
+            clauses.append("task_id = ?")
+            params.append(task_id)
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(max(1, limit))
+        with self._lock:
+            conn = self._connect()
+            try:
+                rows = conn.execute(
+                    f"SELECT {self._RUN_COLUMNS} FROM runs {where} "
+                    "ORDER BY started_at DESC, run_id DESC LIMIT ?",
+                    tuple(params),
+                ).fetchall()
+            finally:
+                conn.close()
+        return [self._run_row_to_dict(r) for r in rows]
+
     def load_history_page(
         self,
         session_id: str,
@@ -1319,6 +1565,13 @@ class ConversationStore:
                 logger.info("[ConversationStore] Migrated: added messages.extras column")
             except Exception as e:
                 logger.warning(f"[ConversationStore] Migration (extras) failed: {e}")
+        if "run_id" not in msg_cols:
+            try:
+                conn.execute(_MIGRATION_ADD_MSG_RUN_ID)
+                conn.commit()
+                logger.info("[ConversationStore] Migrated: added messages.run_id column")
+            except Exception as e:
+                logger.warning(f"[ConversationStore] Migration (run_id) failed: {e}")
 
     def _connect(self) -> sqlite3.Connection:
         with self._lock:

--- a/agent/protocol/agent_stream.py
+++ b/agent/protocol/agent_stream.py
@@ -696,7 +696,7 @@ class AgentStreamExecutor:
         # Respect a run id an outer scope already set (a subagent spawn or a
         # delegated task passes one down); only mint a fresh one when this turn
         # is the top of its own run. Writing through set_agent_run_id keeps the
-        # LinkAI-tagging path and RuntimeIdentity on the same id.
+        # outbound header-tagging path and RuntimeIdentity on the same id.
         import uuid as _uuid
         from common.utils import set_agent_run_id, clear_agent_run_id, current_agent_run_id
         _run_token = None

--- a/agent/protocol/agent_stream.py
+++ b/agent/protocol/agent_stream.py
@@ -693,9 +693,15 @@ class AgentStreamExecutor:
         final_response = ""
         turn = 0
 
+        # Respect a run id an outer scope already set (a subagent spawn or a
+        # delegated task passes one down); only mint a fresh one when this turn
+        # is the top of its own run. Writing through set_agent_run_id keeps the
+        # LinkAI-tagging path and RuntimeIdentity on the same id.
         import uuid as _uuid
-        from common.utils import set_agent_run_id, clear_agent_run_id
-        _run_token = set_agent_run_id(_uuid.uuid4().hex)
+        from common.utils import set_agent_run_id, clear_agent_run_id, current_agent_run_id
+        _run_token = None
+        if not current_agent_run_id():
+            _run_token = set_agent_run_id(_uuid.uuid4().hex)
         cancelled = False
         try:
             while turn < self.max_turns:
@@ -1058,7 +1064,8 @@ class AgentStreamExecutor:
             raise
 
         finally:
-            clear_agent_run_id(_run_token)
+            if _run_token is not None:
+                clear_agent_run_id(_run_token)
             if self.steer_inbox is not None:
                 self.steer_inbox.close()
             final_response = final_response.strip() if final_response else final_response

--- a/agent/subagent/runner.py
+++ b/agent/subagent/runner.py
@@ -147,10 +147,63 @@ def _notify(on_state, index: int, state: Dict[str, Any]) -> None:
         logger.debug(f"[SubAgent] state callback failed: {e}")
 
 
+def _open_run(parent, run_id: str, template) -> Optional[Any]:
+    """Record the start of a spawned run, returning the store to close it with.
+
+    None means the spawn is not being recorded, either because the parent's
+    workspace is unknown — there is no database to attribute it to, and
+    guessing a global one would write another workspace's history — or because
+    the write failed. Bookkeeping never blocks a spawn.
+
+    The parent's run id is read before the caller enters its own identity
+    scope, so it is still the ambient one and becomes this run's parent.
+    """
+    workspace = getattr(parent, "workspace_dir", None)
+    if not workspace:
+        return None
+    try:
+        from agent.memory import get_conversation_store
+        from common.utils import current_agent_run_id
+
+        store = get_conversation_store(workspace)
+        store.create_run(
+            run_id,
+            agent_id=getattr(parent, "_current_agent_id", "") or "",
+            session_id=getattr(parent, "_current_session_id", "") or "",
+            parent_run_id=current_agent_run_id() or "",
+            extras={"subagent_type": template.name},
+        )
+        return store
+    except Exception as e:
+        logger.debug(f"[SubAgent] could not record run {run_id}: {e}")
+        return None
+
+
+# What the runs table calls a finished run, keyed by the status this module
+# reports to its caller.
+_RUN_STATUS = {"completed": "done", "cancelled": "cancelled", "failed": "failed"}
+
+
+def _close_run(store, run_id: str, result: Dict[str, Any]) -> None:
+    """Mark a spawned run finished. Silent on failure, like _open_run."""
+    if store is None:
+        return
+    try:
+        store.finish_run(
+            run_id,
+            status=_RUN_STATUS.get(result.get("status", ""), "done"),
+            error=str(result.get("error", "")),
+        )
+    except Exception as e:
+        logger.debug(f"[SubAgent] could not close run {run_id}: {e}")
+
+
 def _run_one(parent, template, task: SubagentTask, index: int, cancel_event,
              on_state=None, on_event=None) -> Dict[str, Any]:
     started = time.time()
     run_id = uuid.uuid4().hex[:12]
+    # Before identity_scope below, so the parent's run id is still ambient.
+    run_store = _open_run(parent, run_id, template)
     result: Dict[str, Any] = {"task_index": index, "subagent_type": template.name}
     _notify(on_state, index, {"status": "running", "subagent_type": template.name})
 
@@ -183,6 +236,7 @@ def _run_one(parent, template, task: SubagentTask, index: int, cancel_event,
         result["error"] = str(e)
 
     result["duration_seconds"] = round(time.time() - started, 2)
+    _close_run(run_store, run_id, result)
     _notify(on_state, index, result)
     return result
 

--- a/bridge/agent_bridge.py
+++ b/bridge/agent_bridge.py
@@ -4,6 +4,7 @@ Agent Bridge - Integrates Agent system with existing COW bridge
 
 import os
 import threading
+import uuid
 from typing import Dict, Iterator, Optional, List, Tuple
 
 from agent.protocol import (
@@ -484,6 +485,60 @@ class AgentBridge:
         from agent.memory import get_conversation_store
         return get_conversation_store(profile.workspace)
 
+    def _begin_run(self, session_id: str, agent_id: str, context: Context = None):
+        """Open a run for this turn and make its id the ambient one.
+
+        Returns ``(run_id, token, store)``; every element is None when the run
+        could not be recorded. Bookkeeping must never break a reply, so any
+        failure here degrades to "no run row" rather than raising: the turn
+        still runs, it just is not addressable afterwards.
+
+        A run id already in scope means this turn was started by another run
+        (a delegation or a spawn), so that one becomes the parent and the tree
+        stays walkable from either end.
+        """
+        from common.utils import current_agent_run_id, set_agent_run_id
+
+        try:
+            parent_run_id = current_agent_run_id() or ""
+            run_id = uuid.uuid4().hex
+            store = self.get_conversation_store(agent_id)
+            # An external system driving this work passes its own handle
+            # through the context; a native turn leaves both empty.
+            task_id = str((context.get("task_id") if context else "") or "")
+            task_source = str((context.get("task_source") if context else "") or "")
+            store.create_run(
+                run_id,
+                agent_id=agent_id or "",
+                session_id=session_id or "",
+                parent_run_id=parent_run_id,
+                task_id=task_id,
+                task_source=task_source,
+            )
+            # Set last: once the ambient id changes, the caller owes us a reset.
+            token = set_agent_run_id(run_id)
+            return run_id, token, store
+        except Exception as e:
+            logger.warning(f"[AgentBridge] Could not open run: {e}")
+            return None, None, None
+
+    def _end_run(self, store, run_id: str, token, status: str, error: str = "") -> None:
+        """Close a run and restore the previous ambient run id.
+
+        The reset happens even when the status update fails, or the ambient id
+        would leak into whatever this thread handles next.
+        """
+        from common.utils import clear_agent_run_id
+
+        try:
+            if store is not None and run_id:
+                store.finish_run(run_id, status=status, error=error)
+        except Exception as e:
+            logger.warning(f"[AgentBridge] Could not close run {run_id}: {e}")
+        finally:
+            if token is not None:
+                clear_agent_run_id(token)
+
     @staticmethod
     def _runtime_key(agent_id: str, session_id: str) -> Tuple[str, str]:
         return agent_id, session_id
@@ -665,6 +720,11 @@ class AgentBridge:
         cancel_event = None
         token_key = None
         steer_inbox = None
+        run_id = None
+        run_token = None
+        run_store = None
+        run_status = "done"
+        run_error = ""
         try:
             # Extract session_id from context for user isolation
             if context:
@@ -750,6 +810,13 @@ class AgentBridge:
                 )
                 self._trim_in_memory_to_turns(agent, scheduler_keep_turns)
 
+            # Open the run before anything is persisted, so both the user turn
+            # and the reply are attributed to it and the work is addressable
+            # while it is still in flight.
+            run_id, run_token, run_store = self._begin_run(
+                session_id, resolved_agent_id, context
+            )
+
             # Eagerly persist the user message BEFORE running the agent so the
             # session and the user's bubble are immediately visible — even if
             # the user switches away or refreshes before the reply finishes.
@@ -807,6 +874,12 @@ class AgentBridge:
                         pass
                 if session_id and steer_inbox is not None:
                     get_steer_registry().unregister(session_id, steer_inbox)
+
+            # A cancelled turn is not a failure, but it is not a completed run
+            # either: the distinction is what tells a reader whether the result
+            # is trustworthy or simply absent.
+            if cancel_event is not None and cancel_event.is_set():
+                run_status = "cancelled"
 
             # Persist new messages generated during this run
             if session_id:
@@ -876,6 +949,8 @@ class AgentBridge:
             
         except Exception as e:
             logger.error(f"Agent reply error: {e}")
+            run_status = "failed"
+            run_error = str(e)
             # The in-memory context may have been reset to recover from a format
             # error or overflow, but the stored history is deliberately left
             # intact: it is irreplaceable and is never reloaded with tool blocks.
@@ -891,6 +966,9 @@ class AgentBridge:
                 except Exception:
                     pass
             return Reply(ReplyType.ERROR, f"Agent error: {str(e)}")
+
+        finally:
+            self._end_run(run_store, run_id, run_token, run_status, run_error)
     
     def _schedule_mcp_hot_reload(self, agent):
         """

--- a/common/utils.py
+++ b/common/utils.py
@@ -2,7 +2,6 @@ import io
 import os
 import re
 import sys
-from contextvars import ContextVar
 from typing import Optional
 from urllib.parse import urlparse
 from common.log import logger
@@ -249,25 +248,43 @@ def _client_os() -> str:
     return p or ""
 
 
-_run_id: "ContextVar[Optional[str]]" = ContextVar("agent_run_id", default=None)
-
-
 def set_agent_run_id(run_id: Optional[str]):
+    """Set the ambient run id. Kept for callers that only need the run id and
+    do not carry a full RuntimeIdentity; it writes the single source of truth,
+    ``RuntimeIdentity.run_id``, so this value and the identity never diverge.
+
+    Returns a token accepted by ``clear_agent_run_id``.
+    """
+    from common.runtime_identity import current_identity, _current
+
     value = str(run_id).strip() if run_id is not None and str(run_id).strip() else None
-    return _run_id.set(value)
+    return _current.set(current_identity().derive(run_id=value))
 
 
 def clear_agent_run_id(token) -> None:
+    from common.runtime_identity import _current
+
     try:
-        _run_id.reset(token)
+        _current.reset(token)
     except Exception:
         pass
 
 
 def current_agent_run_id() -> Optional[str]:
-    """Current run id: in-process ContextVar first, else the value passed to a
-    child process via the COW_AGENT_RUN_ID env var."""
-    return _run_id.get() or (os.environ.get("COW_AGENT_RUN_ID") or "").strip() or None
+    """Current run id: the ambient ``RuntimeIdentity`` first, else the value
+    passed to a child process via the COW_AGENT_RUN_ID env var.
+
+    One source of truth: subagents and delegated work set the run id through
+    ``RuntimeIdentity`` (via ``identity_scope``), and this reads the same field
+    so the id carried on state paths matches the one tagged onto LinkAI calls.
+    """
+    from common.runtime_identity import current_identity
+
+    return (
+        current_identity().run_id
+        or (os.environ.get("COW_AGENT_RUN_ID") or "").strip()
+        or None
+    )
 
 
 def apply_client_source(headers: dict) -> dict:

--- a/common/utils.py
+++ b/common/utils.py
@@ -276,7 +276,8 @@ def current_agent_run_id() -> Optional[str]:
 
     One source of truth: subagents and delegated work set the run id through
     ``RuntimeIdentity`` (via ``identity_scope``), and this reads the same field
-    so the id carried on state paths matches the one tagged onto LinkAI calls.
+    so the id carried on state paths matches the one tagged onto outbound
+    requests via the ``X-Agent-Run-Id`` header.
     """
     from common.runtime_identity import current_identity
 

--- a/tests/test_conversation_runs.py
+++ b/tests/test_conversation_runs.py
@@ -1,0 +1,177 @@
+"""Tests for run tracking in the conversation store: the runs table, the
+messages.run_id column, and how a message picks up its run id."""
+
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from agent.memory.conversation_store import ConversationStore
+from common.runtime_identity import identity_scope
+
+
+def _store(tmpdir):
+    return ConversationStore(Path(tmpdir) / "index.db")
+
+
+def _message_run_ids(db_path, session_id):
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return [
+            row[0]
+            for row in conn.execute(
+                "SELECT run_id FROM messages WHERE session_id = ? ORDER BY seq ASC",
+                (session_id,),
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def test_runs_table_and_message_column_exist():
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "index.db"
+        ConversationStore(db)
+        conn = sqlite3.connect(str(db))
+        try:
+            run_cols = {r[1] for r in conn.execute("PRAGMA table_info(runs)")}
+            assert {
+                "run_id", "agent_id", "user_id", "session_id", "parent_run_id",
+                "task_id", "task_source", "status", "started_at", "ended_at",
+                "error", "extras",
+            } <= run_cols
+            msg_cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
+            assert "run_id" in msg_cols
+        finally:
+            conn.close()
+
+
+def test_create_run_is_idempotent():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = _store(tmp)
+        assert store.create_run("r1", agent_id="sales", session_id="s1") is True
+        # A retried entry point must not duplicate the row or reset its fields.
+        assert store.create_run("r1", agent_id="other") is False
+        run = store.get_run("r1")
+        assert run["agent_id"] == "sales"
+        assert run["status"] == "running"
+        assert run["ended_at"] is None
+
+
+def test_finish_run_sets_status_and_merges_extras():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = _store(tmp)
+        store.create_run("r1", session_id="s1", extras={"a": 1})
+        assert store.finish_run("r1", status="done", extras={"b": 2}) is True
+        run = store.get_run("r1")
+        assert run["status"] == "done"
+        assert run["ended_at"] is not None
+        assert run["extras"] == {"a": 1, "b": 2}
+        # Finishing a run that does not exist reports failure rather than raising.
+        assert store.finish_run("missing", status="done") is False
+
+
+def test_external_task_handle_is_free_form_text():
+    """task_id/task_source must hold an external id, not a foreign key we own."""
+    with tempfile.TemporaryDirectory() as tmp:
+        store = _store(tmp)
+        store.create_run(
+            "r1", session_id="s1", task_id="T-260826-001", task_source="linkai"
+        )
+        found = store.list_runs(task_source="linkai", task_id="T-260826-001")
+        assert [r["run_id"] for r in found] == ["r1"]
+
+
+def test_list_runs_filters_parent_and_session():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = _store(tmp)
+        store.create_run("root", session_id="s1")
+        store.create_run("child_a", session_id="s1", parent_run_id="root")
+        store.create_run("child_b", session_id="s1", parent_run_id="root")
+        store.create_run("other", session_id="s2")
+
+        children = store.list_runs(parent_run_id="root")
+        assert {r["run_id"] for r in children} == {"child_a", "child_b"}
+
+        # parent_run_id="" selects top-level runs only.
+        top_level = {r["run_id"] for r in store.list_runs(parent_run_id="")}
+        assert top_level == {"root", "other"}
+
+        s1 = {r["run_id"] for r in store.list_runs(session_id="s1")}
+        assert s1 == {"root", "child_a", "child_b"}
+
+
+def test_append_messages_records_explicit_run_id():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = _store(tmp)
+        store.append_messages(
+            "s1", [{"role": "user", "content": "hi"}], run_id="r1"
+        )
+        assert _message_run_ids(Path(tmp) / "index.db", "s1") == ["r1"]
+
+
+def test_append_messages_falls_back_to_ambient_run_id():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = _store(tmp)
+        with identity_scope(run_id="ambient"):
+            store.append_messages("s1", [{"role": "user", "content": "hi"}])
+        assert _message_run_ids(Path(tmp) / "index.db", "s1") == ["ambient"]
+
+
+def test_per_message_run_id_overrides_batch():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = _store(tmp)
+        store.append_messages(
+            "s1",
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "yo", "run_id": "special"},
+            ],
+            run_id="batch",
+        )
+        assert _message_run_ids(Path(tmp) / "index.db", "s1") == ["batch", "special"]
+
+
+def test_legacy_db_is_migrated():
+    """A database predating run tracking gains the runs table and the run_id
+    column, and its existing rows default to an empty run id."""
+    with tempfile.TemporaryDirectory() as tmp:
+        db = Path(tmp) / "index.db"
+        conn = sqlite3.connect(str(db))
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                session_id TEXT PRIMARY KEY, created_at INTEGER,
+                last_active INTEGER, msg_count INTEGER DEFAULT 0
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT,
+                seq INTEGER, role TEXT, content TEXT, created_at INTEGER,
+                UNIQUE(session_id, seq)
+            );
+            INSERT INTO sessions VALUES ('old', 1, 1, 1);
+            INSERT INTO messages (session_id, seq, role, content, created_at)
+                VALUES ('old', 0, 'user', '"legacy"', 1);
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        ConversationStore(db)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            assert conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='runs'"
+            ).fetchone()
+            msg_cols = {r[1] for r in conn.execute("PRAGMA table_info(messages)")}
+            assert "run_id" in msg_cols
+            old = conn.execute(
+                "SELECT run_id FROM messages WHERE session_id = 'old'"
+            ).fetchone()[0]
+            assert old == ""
+        finally:
+            conn.close()

--- a/tests/test_run_lifecycle.py
+++ b/tests/test_run_lifecycle.py
@@ -1,0 +1,165 @@
+"""Tests for opening and closing a run around a turn.
+
+Exercised through AgentBridge._begin_run / _end_run against a real store, so
+these cover the actual rows written rather than a mocked call log.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from agent.memory.conversation_store import ConversationStore
+from bridge.agent_bridge import AgentBridge
+from common.runtime_identity import identity_scope
+from common.utils import current_agent_run_id
+
+
+class _Bridge:
+    """The two methods under test, bound to a store we control.
+
+    Built without AgentBridge.__init__ (which boots a whole runtime) so the
+    test exercises the real methods against a temporary database.
+    """
+
+    def __init__(self, store):
+        self._store = store
+
+    _begin_run = AgentBridge._begin_run
+    _end_run = AgentBridge._end_run
+
+    def get_conversation_store(self, agent_id=None):
+        return self._store
+
+
+def _context(**kwargs):
+    """A stand-in for bridge.Context: only .get is used by the code path."""
+    return SimpleNamespace(get=lambda key, default=None: kwargs.get(key, default))
+
+
+class RunLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.store = ConversationStore(Path(self._tmp.name) / "index.db")
+        self.bridge = _Bridge(self.store)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_run_is_recorded_and_becomes_the_ambient_id(self):
+        run_id, token, store = self.bridge._begin_run("s1", "sales", None)
+
+        self.assertIsNotNone(run_id)
+        self.assertEqual(current_agent_run_id(), run_id)
+        run = self.store.get_run(run_id)
+        self.assertEqual(run["agent_id"], "sales")
+        self.assertEqual(run["session_id"], "s1")
+        self.assertEqual(run["status"], "running")
+        self.assertIsNone(run["ended_at"])
+
+        self.bridge._end_run(store, run_id, token, "done")
+
+        run = self.store.get_run(run_id)
+        self.assertEqual(run["status"], "done")
+        self.assertIsNotNone(run["ended_at"])
+        # The ambient id must not survive the turn.
+        self.assertIsNone(current_agent_run_id())
+
+    def test_failure_is_recorded_with_its_message(self):
+        run_id, token, store = self.bridge._begin_run("s1", "sales", None)
+        self.bridge._end_run(store, run_id, token, "failed", "boom")
+
+        run = self.store.get_run(run_id)
+        self.assertEqual(run["status"], "failed")
+        self.assertEqual(run["error"], "boom")
+
+    def test_cancelled_is_distinct_from_failed(self):
+        run_id, token, store = self.bridge._begin_run("s1", "sales", None)
+        self.bridge._end_run(store, run_id, token, "cancelled")
+
+        self.assertEqual(self.store.get_run(run_id)["status"], "cancelled")
+
+    def test_a_run_started_inside_another_records_its_parent(self):
+        """A delegation or spawn nests: the tree has to stay walkable."""
+        outer_id, outer_token, outer_store = self.bridge._begin_run("s1", "sales", None)
+        inner_id, inner_token, inner_store = self.bridge._begin_run("s1", "support", None)
+
+        self.assertEqual(self.store.get_run(inner_id)["parent_run_id"], outer_id)
+        self.assertEqual(self.store.get_run(outer_id)["parent_run_id"], "")
+        children = self.store.list_runs(parent_run_id=outer_id)
+        self.assertEqual([c["run_id"] for c in children], [inner_id])
+
+        self.bridge._end_run(inner_store, inner_id, inner_token, "done")
+        # Closing the inner run restores the outer one as ambient.
+        self.assertEqual(current_agent_run_id(), outer_id)
+        self.bridge._end_run(outer_store, outer_id, outer_token, "done")
+        self.assertIsNone(current_agent_run_id())
+
+    def test_external_task_handle_is_carried_from_the_context(self):
+        run_id, token, store = self.bridge._begin_run(
+            "s1", "sales", _context(task_id="T-1", task_source="board")
+        )
+
+        run = self.store.get_run(run_id)
+        self.assertEqual(run["task_id"], "T-1")
+        self.assertEqual(run["task_source"], "board")
+        self.bridge._end_run(store, run_id, token, "done")
+
+    def test_a_native_turn_leaves_the_task_handle_empty(self):
+        run_id, token, store = self.bridge._begin_run("s1", "sales", _context())
+
+        run = self.store.get_run(run_id)
+        self.assertEqual(run["task_id"], "")
+        self.assertEqual(run["task_source"], "")
+        self.bridge._end_run(store, run_id, token, "done")
+
+    def test_messages_written_during_the_run_carry_its_id(self):
+        run_id, token, store = self.bridge._begin_run("s1", "sales", None)
+        # No explicit run_id: the store reads the ambient one _begin_run set.
+        self.store.append_messages("s1", [{"role": "user", "content": "hi"}])
+        self.bridge._end_run(store, run_id, token, "done")
+
+        stored = self.store.list_runs(session_id="s1")
+        self.assertEqual([r["run_id"] for r in stored], [run_id])
+
+    def test_a_store_that_cannot_record_does_not_break_the_turn(self):
+        """Bookkeeping is never allowed to fail a reply."""
+
+        class _Broken:
+            def create_run(self, *a, **kw):
+                raise RuntimeError("disk full")
+
+        bridge = _Bridge(_Broken())
+        run_id, token, store = bridge._begin_run("s1", "sales", None)
+
+        self.assertIsNone(run_id)
+        self.assertIsNone(token)
+        self.assertIsNone(store)
+        # No ambient id was set, so nothing leaks into the next turn.
+        self.assertIsNone(current_agent_run_id())
+        # And closing a run that was never opened is a no-op, not a crash.
+        bridge._end_run(store, run_id, token, "done")
+
+    def test_the_ambient_id_is_restored_even_if_closing_fails(self):
+        class _HalfBroken:
+            def create_run(self, *a, **kw):
+                return True
+
+            def finish_run(self, *a, **kw):
+                raise RuntimeError("gone")
+
+        bridge = _Bridge(_HalfBroken())
+        with identity_scope(run_id="outer"):
+            run_id, token, store = bridge._begin_run("s1", "sales", None)
+            self.assertEqual(current_agent_run_id(), run_id)
+            bridge._end_run(store, run_id, token, "done")
+            # finish_run blew up, but the scope was still unwound.
+            self.assertEqual(current_agent_run_id(), "outer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_subagent_run_records.py
+++ b/tests/test_subagent_run_records.py
@@ -1,0 +1,105 @@
+"""A spawned sub agent gets its own run row, parented to the turn that spawned it.
+
+These go through runner._open_run / _close_run against a real store rather than
+running a whole sub agent, which needs a live model.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from agent.memory.conversation_store import ConversationStore
+from agent.subagent import runner
+from common.runtime_identity import identity_scope
+
+
+def _template(name="general-purpose"):
+    return SimpleNamespace(name=name)
+
+
+class SubagentRunRecordTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.workspace = self._tmp.name
+        # runner resolves the store from the parent's workspace; point that at
+        # a temporary one so nothing touches a real ~/cow database.
+        self.store = ConversationStore(
+            Path(self.workspace) / "memory" / "long-term" / "index.db"
+        )
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _parent(self, **kwargs):
+        defaults = {
+            "workspace_dir": self.workspace,
+            "_current_agent_id": "sales",
+            "_current_session_id": "sess-1",
+        }
+        defaults.update(kwargs)
+        return SimpleNamespace(**defaults)
+
+    def test_spawn_is_recorded_under_the_parent_run(self):
+        with identity_scope(run_id="parent-run"):
+            store = runner._open_run(self._parent(), "child-1", _template())
+        self.assertIsNotNone(store)
+
+        run = self.store.get_run("child-1")
+        self.assertIsNotNone(run)
+        self.assertEqual(run["parent_run_id"], "parent-run")
+        self.assertEqual(run["agent_id"], "sales")
+        self.assertEqual(run["session_id"], "sess-1")
+        self.assertEqual(run["status"], "running")
+        self.assertEqual(run["extras"], {"subagent_type": "general-purpose"})
+
+        children = self.store.list_runs(parent_run_id="parent-run")
+        self.assertEqual([c["run_id"] for c in children], ["child-1"])
+
+    def test_completed_spawn_is_closed_as_done(self):
+        store = runner._open_run(self._parent(), "child-1", _template())
+        runner._close_run(store, "child-1", {"status": "completed"})
+
+        run = self.store.get_run("child-1")
+        self.assertEqual(run["status"], "done")
+        self.assertIsNotNone(run["ended_at"])
+
+    def test_failed_spawn_keeps_its_error(self):
+        store = runner._open_run(self._parent(), "child-1", _template())
+        runner._close_run(
+            store, "child-1", {"status": "failed", "error": "tool exploded"}
+        )
+
+        run = self.store.get_run("child-1")
+        self.assertEqual(run["status"], "failed")
+        self.assertEqual(run["error"], "tool exploded")
+
+    def test_cancelled_spawn_is_distinct_from_failed(self):
+        store = runner._open_run(self._parent(), "child-1", _template())
+        runner._close_run(store, "child-1", {"status": "cancelled"})
+
+        self.assertEqual(self.store.get_run("child-1")["status"], "cancelled")
+
+    def test_a_parent_without_a_workspace_is_not_recorded(self):
+        """No workspace means no database to attribute the spawn to. Guessing a
+        global one would write into an unrelated workspace's history."""
+        store = runner._open_run(
+            self._parent(workspace_dir=None), "child-1", _template()
+        )
+
+        self.assertIsNone(store)
+        # Closing a run that was never opened is a no-op rather than a crash.
+        runner._close_run(store, "child-1", {"status": "completed"})
+
+    def test_a_top_level_spawn_has_no_parent(self):
+        store = runner._open_run(self._parent(), "child-1", _template())
+        self.assertEqual(self.store.get_run("child-1")["parent_run_id"], "")
+        runner._close_run(store, "child-1", {"status": "completed"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Makes a "run" — one addressable unit of agent work — a persisted, traceable entity.
This is the foundation for cross-agent delegation and async task handoff.

## Changes

- **Unified run_id.** `RuntimeIdentity.run_id` is now the single source of truth.
  Previously `common/utils` kept its own ContextVar for outbound header tagging
  while subagents used `RuntimeIdentity`, so the two could disagree. `run_stream`
  now reuses an active run_id instead of always minting a new one.
- **Persistence.** New `runs` table in the conversation store (status, timing,
  parent run, external task handle, error), plus a `run_id` column on `messages`
  so every message is attributable to the run that produced it.
- **Lifecycle.** `AgentBridge` opens a run before the turn and closes it in
  `finally`, distinguishing done / failed / cancelled. Subagent spawns record
  their own runs parented to the invoking run.

## Compatibility

Additive only. Existing databases migrate on open, old rows keep a null `run_id`.
Run bookkeeping is best-effort — if it fails the turn still completes normally.

## Tests

24 new tests across run persistence, lifecycle, and subagent parenting.
Full suite shows no new failures.