### PR TITLE
feat(mcp): add retrieval observability and fallback tests

### DIFF
--- a/agent/chat/service.py
+++ b/agent/chat/service.py
@@ -119,6 +119,13 @@ class ChatService:
                     # a new segment; collect tool results until turn_end.
                     state.pending_tool_results = []
 
+            elif event_type == "tool_retrieval":
+                # Forward sanitized retrieval metadata for progress displays.
+                send_chunk_fn({
+                    "chunk_type": "tool_retrieval",
+                    "data": data,
+                })
+
             elif event_type == "file_to_send":
                 url = data.get("url") or ""
                 if url:

--- a/agent/protocol/agent_stream.py
+++ b/agent/protocol/agent_stream.py
@@ -1113,7 +1113,7 @@ class AgentStreamExecutor:
             from agent.tools import ToolManager
             from agent.tools.mcp.tool_retrieval import (
                 build_retrieval_query,
-                select_mcp_tools,
+                select_mcp_tools_with_metadata,
             )
 
             tm = ToolManager()
@@ -1121,20 +1121,34 @@ class AgentStreamExecutor:
             query = build_retrieval_query(self.messages)
             query_vector = tm.embed_query(query)
 
-            selected = select_mcp_tools(
+            decision = select_mcp_tools_with_metadata(
                 query_vector,
                 tool_vectors,
                 top_k,
                 getattr(self, "_retrieved_mcp_names", set()),
             )
-            if selected is None:
+            if decision is None or decision.fallback_reason is not None:
                 # No provider / empty index / error → full injection.
+                self._emit_tool_retrieval_event(
+                    mcp_tools,
+                    builtin_tools,
+                    top_k,
+                    decision=decision,
+                    mode="fallback",
+                )
                 return all_tools
 
             # Persist the accumulated selection for subsequent turns.
-            self._retrieved_mcp_names = selected
+            self._retrieved_mcp_names = decision.selected
 
-            selected_mcp = [t for t in mcp_tools if t.name in selected]
+            selected_mcp = [t for t in mcp_tools if t.name in decision.selected]
+            self._emit_tool_retrieval_event(
+                mcp_tools,
+                builtin_tools,
+                top_k,
+                decision=decision,
+                mode="retrieved",
+            )
             logger.info(
                 f"[ToolRetrieval] Injecting {len(builtin_tools)} built-in + "
                 f"{len(selected_mcp)}/{len(mcp_tools)} MCP tool(s) (top_k={top_k})"
@@ -1142,7 +1156,64 @@ class AgentStreamExecutor:
             return builtin_tools + selected_mcp
         except Exception as e:
             logger.debug(f"[ToolRetrieval] full injection (retrieval skipped): {e}")
+            self._emit_tool_retrieval_event(
+                mcp_tools if "mcp_tools" in locals() else [],
+                builtin_tools if "builtin_tools" in locals() else [],
+                top_k if "top_k" in locals() else 0,
+                mode="fallback",
+                fallback_reason="retrieval_error",
+            )
             return all_tools
+
+    def _emit_tool_retrieval_event(
+        self,
+        mcp_tools: List[BaseTool],
+        builtin_tools: List[BaseTool],
+        top_k: int,
+        decision=None,
+        mode: str = "fallback",
+        fallback_reason: Optional[str] = None,
+    ) -> None:
+        """Expose sanitized MCP retrieval metadata to streaming consumers."""
+        if not callable(getattr(self, "_emit_event", None)):
+            return
+
+        try:
+            fallback_reason = fallback_reason or (
+                decision.fallback_reason
+                if decision is not None
+                else "selection_unavailable"
+            )
+            selected = decision.selected if decision is not None else set()
+            ranked = decision.ranked if decision is not None else []
+            candidate_count = decision.candidate_count if decision is not None else 0
+            rank_limit = max(top_k, 0)
+            injected_names = (
+                sorted(tool.name for tool in mcp_tools)
+                if mode == "fallback" else sorted(selected)
+            )
+            self._emit_event("tool_retrieval", {
+                "enabled": True,
+                "mode": mode,
+                "total_mcp_tools": len(mcp_tools),
+                "selected_mcp_tools": (
+                    len([tool for tool in mcp_tools if tool.name in selected])
+                    if mode == "retrieved" else len(mcp_tools)
+                ),
+                "builtin_tools": len(builtin_tools),
+                "top_k": top_k,
+                "candidate_count": candidate_count,
+                "selected_tools": injected_names,
+                "ranked_tools": [
+                    {"name": name, "score": round(float(score), 6)}
+                    for name, score in ranked[:rank_limit]
+                ],
+                "fallback_reason": fallback_reason,
+            })
+        except Exception as e:
+            # Observability must never turn a safe retrieval fallback into an
+            # agent failure, even when a custom event consumer is malformed.
+            logger.debug(f"[ToolRetrieval] event emission skipped: {e}")
 
     def _call_llm_stream(self, retry_on_empty=True, retry_count=0, max_retries=3,
                          _overflow_stage: int = 0) -> Tuple[str, List[Dict], Optional[str]]:

--- a/agent/tools/mcp/tool_retrieval.py
+++ b/agent/tools/mcp/tool_retrieval.py
@@ -10,8 +10,10 @@ the conversation context.
 
 Invariants (per maintainer review of the feature proposal):
   * Built-in tools are never handled here — the caller injects them in full.
-  * Any failure / missing input returns None so the caller falls back to
-    full injection; tools must never be silently dropped.
+  * The legacy selector returns None on any failure / missing input so the
+    caller falls back to full injection; tools must never be silently dropped.
+    The metadata selector represents the same fallback as a decision with a
+    ``fallback_reason``.
   * Selection is union-accumulated across turns by the caller (only-grows),
     so a tool that already produced a tool_use in the message history can
     never disappear from the schema mid-run (which would make Claude/MiniMax
@@ -118,31 +120,23 @@ def select_mcp_tools(
         "fall back to full injection" (no query vector, empty/invalid index,
         or any unexpected error). This function never raises.
     """
-    accumulated: Set[str] = set(already_selected) if already_selected else set()
-
-    if not query_vector or not tool_vectors or top_k <= 0:
+    decision = select_mcp_tools_with_metadata(
+        query_vector,
+        tool_vectors,
+        top_k,
+        already_selected,
+    )
+    if decision is None or decision.fallback_reason is not None:
         return None
+    return decision.selected
 
+
+def _is_finite_vector(vector: Sequence[float]) -> bool:
+    """Return whether every vector value is a finite number."""
     try:
-        expected_dim = len(query_vector)
-        # Only rank candidates whose vector dimensionality matches the query.
-        # A dimension mismatch means the index was built with a different
-        # embedding model; ranking across dims is meaningless.
-        candidates = {
-            name: vec
-            for name, vec in tool_vectors.items()
-            if vec and len(vec) == expected_dim
-        }
-        if not candidates:
-            return None
-
-        ranked = _rank_by_similarity(query_vector, candidates)
-        for name, _score in ranked[:top_k]:
-            accumulated.add(name)
-        return accumulated
-    except Exception:
-        # Selection must never break the agent — fall back to full injection.
-        return None
+        return all(math.isfinite(float(value)) for value in vector)
+    except (TypeError, ValueError):
+        return False
 
 
 def select_mcp_tools_with_metadata(
@@ -151,8 +145,97 @@ def select_mcp_tools_with_metadata(
     top_k: int,
     already_selected: Optional[Set[str]] = None,
 ) -> Optional[McpRetrievalDecision]:
-    """Return MCP retrieval selection plus metadata for observability."""
-    raise NotImplementedError
+    """Return MCP retrieval selection plus metadata for observability.
+
+    A decision with ``fallback_reason`` set describes a safe full-injection
+    fallback. The legacy ``select_mcp_tools`` wrapper converts that decision
+    back to ``None`` so existing callers keep their current behavior.
+    """
+    accumulated: Set[str] = set(already_selected) if already_selected else set()
+
+    try:
+        if query_vector is None:
+            return McpRetrievalDecision(
+                selected=accumulated,
+                ranked=[],
+                candidate_count=0,
+                fallback_reason="missing_query_vector",
+            )
+        if len(query_vector) == 0:
+            return McpRetrievalDecision(
+                selected=accumulated,
+                ranked=[],
+                candidate_count=0,
+                fallback_reason="missing_query_vector",
+            )
+        if not _is_finite_vector(query_vector):
+            return McpRetrievalDecision(
+                selected=accumulated,
+                ranked=[],
+                candidate_count=0,
+                fallback_reason="invalid_query_vector",
+            )
+        if not tool_vectors:
+            return McpRetrievalDecision(
+                selected=accumulated,
+                ranked=[],
+                candidate_count=0,
+                fallback_reason="empty_tool_index",
+            )
+        if top_k <= 0:
+            return McpRetrievalDecision(
+                selected=accumulated,
+                ranked=[],
+                candidate_count=0,
+                fallback_reason="invalid_top_k",
+            )
+
+        expected_dim = len(query_vector)
+        # Only rank candidates whose vector dimensionality matches the query.
+        # A dimension mismatch means the index was built with a different
+        # embedding model; ranking across dims is meaningless.
+        candidates = {}
+        for name, vec in tool_vectors.items():
+            try:
+                if (
+                    vec is not None
+                    and len(vec) > 0
+                    and len(vec) == expected_dim
+                    and _is_finite_vector(vec)
+                ):
+                    candidates[name] = vec
+            except (TypeError, ValueError):
+                continue
+        if not candidates:
+            return McpRetrievalDecision(
+                selected=accumulated,
+                ranked=[],
+                candidate_count=0,
+                fallback_reason="no_compatible_candidates",
+            )
+
+        ranked = _rank_by_similarity(query_vector, candidates)
+        if not all(math.isfinite(float(score)) for _name, score in ranked):
+            return McpRetrievalDecision(
+                selected=accumulated,
+                ranked=[],
+                candidate_count=0,
+                fallback_reason="non_finite_score",
+            )
+        accumulated.update(name for name, _score in ranked[:top_k])
+        return McpRetrievalDecision(
+            selected=accumulated,
+            ranked=ranked,
+            candidate_count=len(candidates),
+        )
+    except Exception:
+        # Selection must never break the agent — fall back to full injection.
+        return McpRetrievalDecision(
+            selected=accumulated,
+            ranked=[],
+            candidate_count=0,
+            fallback_reason="selection_error",
+        )
 
 
 def _rank_by_similarity(

--- a/agent/tools/mcp/tool_retrieval.py
+++ b/agent/tools/mcp/tool_retrieval.py
@@ -17,8 +17,9 @@ Invariants (per maintainer review of the feature proposal):
     never disappear from the schema mid-run (which would make Claude/MiniMax
     raise a message-format error).
 """
+from dataclasses import dataclass
 import math
-from typing import Dict, List, Optional, Sequence, Set
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 try:
     import numpy as np
@@ -31,6 +32,19 @@ except ImportError:
 # query is not enough; a short recent window captures the drift without
 # bloating the query with stale context.
 DEFAULT_QUERY_MESSAGES = 5
+
+
+@dataclass(frozen=True)
+class McpRetrievalDecision:
+    """Metadata for one MCP tool retrieval decision.
+
+    ``selected`` is the accumulated tool set to inject. ``ranked`` contains the
+    current turn's similarity ranking, without query text or raw vectors.
+    """
+    selected: Set[str]
+    ranked: List[Tuple[str, float]]
+    candidate_count: int
+    fallback_reason: Optional[str] = None
 
 
 def build_retrieval_query(messages: list, max_messages: int = DEFAULT_QUERY_MESSAGES) -> str:
@@ -129,6 +143,16 @@ def select_mcp_tools(
     except Exception:
         # Selection must never break the agent — fall back to full injection.
         return None
+
+
+def select_mcp_tools_with_metadata(
+    query_vector: Optional[Sequence[float]],
+    tool_vectors: Dict[str, Sequence[float]],
+    top_k: int,
+    already_selected: Optional[Set[str]] = None,
+) -> Optional[McpRetrievalDecision]:
+    """Return MCP retrieval selection plus metadata for observability."""
+    raise NotImplementedError
 
 
 def _rank_by_similarity(

--- a/tests/test_mcp_tool_retrieval.py
+++ b/tests/test_mcp_tool_retrieval.py
@@ -18,6 +18,7 @@ from agent.tools.mcp.tool_retrieval import (
     build_retrieval_query,
     cosine_similarity,
     select_mcp_tools,
+    select_mcp_tools_with_metadata,
 )
 from agent.tools.mcp.mcp_tool import McpTool
 
@@ -164,6 +165,49 @@ class TestSelectMcpTools(unittest.TestCase):
                                            already_selected=set()))
 
 
+class TestSelectMcpToolsMetadata(unittest.TestCase):
+
+    def setUp(self):
+        self.vectors = {
+            "a": [1.0, 0.0, 0.0],
+            "b": [0.0, 1.0, 0.0],
+            "c": [0.0, 0.0, 1.0],
+            "d": [0.9, 0.1, 0.0],
+        }
+
+    def test_returns_selection_and_ranking_metadata(self):
+        decision = select_mcp_tools_with_metadata(
+            [1.0, 0.0, 0.0], self.vectors, top_k=2
+        )
+
+        self.assertEqual(decision.selected, {"a", "d"})
+        ranked_names = [name for name, _score in decision.ranked]
+        self.assertEqual(ranked_names[:2], ["a", "d"])
+        self.assertEqual(set(ranked_names), set(self.vectors))
+        self.assertEqual(decision.candidate_count, 4)
+        self.assertIsNone(decision.fallback_reason)
+
+    def test_reports_fallback_reason(self):
+        decision = select_mcp_tools_with_metadata(
+            None, self.vectors, top_k=2, already_selected={"existing"}
+        )
+
+        self.assertEqual(decision.selected, {"existing"})
+        self.assertEqual(decision.fallback_reason, "missing_query_vector")
+        self.assertEqual(decision.ranked, [])
+
+    def test_rejects_non_finite_vectors(self):
+        decision = select_mcp_tools_with_metadata(
+            [1.0, 0.0], {"bad": [float("nan"), 1.0]}, top_k=1
+        )
+
+        self.assertEqual(decision.fallback_reason, "no_compatible_candidates")
+        self.assertEqual(decision.ranked, [])
+
+    def test_legacy_api_keeps_fallback_contract(self):
+        self.assertIsNone(select_mcp_tools(None, self.vectors, top_k=2))
+
+
 # --------------------------------------------------------------------------
 # Executor integration: AgentStream._select_tools_for_injection
 # --------------------------------------------------------------------------
@@ -179,11 +223,21 @@ class TestSelectToolsForInjection(unittest.TestCase):
         for i in range(mcp_count):
             name = f"mcp_{i}"
             tools[name] = _mcp_tool(name, f"tool number {i}")
-        return SimpleNamespace(
+        fake = SimpleNamespace(
             tools=tools,
             messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
             _retrieved_mcp_names=set(),
         )
+        fake.events = []
+        fake._emit_event = lambda event_type, data=None: fake.events.append({
+            "type": event_type,
+            "data": data or {},
+        })
+        from agent.protocol.agent_stream import AgentStreamExecutor
+        fake._emit_tool_retrieval_event = (
+            AgentStreamExecutor._emit_tool_retrieval_event.__get__(fake)
+        )
+        return fake
 
     def _call(self, fake_self):
         from agent.protocol.agent_stream import AgentStreamExecutor
@@ -219,6 +273,18 @@ class TestSelectToolsForInjection(unittest.TestCase):
              patch("agent.tools.ToolManager", return_value=fake_tm):
             result = self._call(fake)
         self.assertEqual(len(result), len(fake.tools))
+        retrieval_events = [event for event in fake.events if event["type"] == "tool_retrieval"]
+        self.assertEqual(len(retrieval_events), 1)
+        self.assertEqual(retrieval_events[0]["data"]["mode"], "fallback")
+        self.assertEqual(
+            retrieval_events[0]["data"]["fallback_reason"],
+            "missing_query_vector",
+        )
+        self.assertEqual(retrieval_events[0]["data"]["selected_mcp_tools"], 25)
+        self.assertEqual(
+            retrieval_events[0]["data"]["selected_tools"],
+            sorted(f"mcp_{i}" for i in range(25)),
+        )
 
     def test_builtins_always_injected_and_set_grows(self):
         """Maintainer scenario 3: multi-turn MCP set only grows; builtins stay."""
@@ -247,6 +313,12 @@ class TestSelectToolsForInjection(unittest.TestCase):
         self.assertIn("mcp_0", names2)
         self.assertIn("mcp_1", names2)
         self.assertTrue(fake._retrieved_mcp_names >= {"mcp_0", "mcp_1"})
+        retrieval_events = [event for event in fake.events if event["type"] == "tool_retrieval"]
+        self.assertEqual(len(retrieval_events), 2)
+        self.assertEqual(retrieval_events[0]["data"]["mode"], "retrieved")
+        self.assertEqual(retrieval_events[0]["data"]["selected_tools"], ["mcp_0"])
+        self.assertEqual(retrieval_events[1]["data"]["selected_tools"], ["mcp_0", "mcp_1"])
+        self.assertEqual(retrieval_events[0]["data"]["candidate_count"], 25)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The on-demand MCP tool retrieval path can select tools, but it does not expose why a decision was made or whether retrieval fell back to full injection. Retrieval failures are therefore difficult to diagnose, and the fallback and multi-turn behavior lack complete regression coverage.

## Solution

Keep `select_mcp_tools()` backward compatible and add a metadata-returning selector. Emit a sanitized `tool_retrieval` event at the executor tool-injection boundary, while treating retrieval and observability failures as safe full-injection fallbacks.

## Changes

- Added `McpRetrievalDecision` with selected tools, similarity ranking, candidate count, and fallback reason.
- Implemented metadata-aware selection with validation for missing, incompatible, and non-finite vectors.
- Integrated retrieval metadata into `AgentStreamExecutor` without changing the existing tool-injection contract.
- Added structured `tool_retrieval` events and forwarded them through `ChatService` as streaming chunks.
- Preserved built-in tool injection and the multi-turn only-grows invariant.
- Added tests for normal selection, fallback behavior, invalid vectors, legacy API compatibility, event metadata, and multi-turn retrieval.

## Testing

- `python -m unittest -v tests/test_mcp_tool_retrieval.py` (21 passed)
- `python -m py_compile agent/tools/mcp/tool_retrieval.py agent/protocol/agent_stream.py agent/chat/service.py tests/test_mcp_tool_retrieval.py`
- Full suite: `841 passed, 38 failed, 28 skipped`. The failures are outside the changed files and match existing environment or unrelated module issues, including Windows SQLite file locks, missing browser dependencies, credential guard, and encoding cases.

## Notes for Reviewer

- The legacy `select_mcp_tools()` API still returns `Set[str]` on success and `None` on fallback.
- Retrieval fallback always injects the complete available tool set, so tool availability is never silently reduced.
- Events contain tool names, counts, scores, and fallback reasons only; they do not include the retrieval query or raw embedding vectors.
- Retrieval remains disabled by default through the existing configuration flag.