### PR TITLE
feat(search): add AnySearch as a web search provider

### DIFF
--- a/agent/tools/web_search/web_search.py
+++ b/agent/tools/web_search/web_search.py
@@ -3,6 +3,7 @@
   - zhipu   (https://docs.bigmodel.cn/cn/guide/tools/web-search)
   - qianfan (https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy)
   - linkai  (https://link-ai.tech, fallback)
+  - anysearch (https://anysearch.com)
 
 Provider selection
   - strategy 'auto' (default): pick the first configured provider in the
@@ -17,6 +18,7 @@ Credentials
   - zhipu   : conf.zhipu_ai_api_key            ->  env ZHIPUAI_API_KEY
   - qianfan : conf.qianfan_api_key             ->  env QIANFAN_API_KEY
   - linkai  : conf.linkai_api_key              ->  env LINKAI_API_KEY
+  - anysearch : tools.web_search.anysearch_api_key  -> env ANYSEARCH_API_KEY
 """
 
 import json
@@ -36,13 +38,14 @@ DEFAULT_TIMEOUT = 30
 # quality + relevance: bocha (best overall), qianfan (best for hot news),
 # zhipu (strong on long-form articles), linkai (cloud aggregator, last
 # resort).
-PROVIDER_ORDER = ("bocha", "qianfan", "zhipu", "linkai")
+PROVIDER_ORDER = ("bocha", "qianfan", "zhipu", "linkai", "anysearch")
 
 PROVIDER_LABELS = {
     "bocha":   "Bocha",
     "zhipu":   "Zhipu",
     "qianfan": "Baidu Qianfan",
     "linkai":  "LinkAI",
+    "anysearch": "AnySearch",
 }
 
 
@@ -69,6 +72,9 @@ def _get_api_key(provider: str) -> str:
     if provider == "linkai":
         key = (conf().get("linkai_api_key") or "").strip()
         return key or os.environ.get("LINKAI_API_KEY", "").strip()
+    if provider == "anysearch":
+        key = (_tools_web_search_conf().get("anysearch_api_key") or "").strip()
+        return key or os.environ.get("ANYSEARCH_API_KEY", "").strip()
     return ""
 
 
@@ -209,7 +215,7 @@ class WebSearch(BaseTool):
         if not provider:
             return ToolResult.fail(
                 "Error: No search provider configured. "
-                "Configure one of BOCHA_API_KEY / zhipu_ai_api_key / qianfan_api_key / linkai_api_key."
+                "Configure one of BOCHA_API_KEY / zhipu_ai_api_key / qianfan_api_key / linkai_api_key / anysearch_api_key."
             )
 
         # Always log the routing decision so multi-provider deployments can
@@ -231,6 +237,8 @@ class WebSearch(BaseTool):
                 return self._search_qianfan(query, count, freshness)
             if provider == "linkai":
                 return self._search_linkai(query, count, freshness)
+            if provider == "anysearch":
+                return self._search_anysearch(query, count)
             return ToolResult.fail(f"Error: Unknown provider '{provider}'")
         except requests.Timeout:
             return ToolResult.fail(f"Error: Search request timed out after {DEFAULT_TIMEOUT}s")
@@ -483,4 +491,50 @@ class WebSearch(BaseTool):
         return ToolResult.success({
             "query": query, "backend": "linkai",
             "total": 1, "count": 1, "results": [{"content": str(raw)}],
+        })
+
+    def _search_anysearch(self, query: str, count: int) -> ToolResult:
+        api_key = _get_api_key("anysearch")
+        url = "https://api.anysearch.com/v1/search"
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        # AnySearch also serves anonymous traffic with a daily free quota, so
+        # the Authorization header is only sent when a key is configured.
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        # AnySearch accepts 1-20 results; the shared tool schema allows 1-50.
+        max_results = max(1, min(int(count or 10), 20))
+        payload = {"query": query, "max_results": max_results, "format": "json"}
+
+        logger.debug(f"[WebSearch] anysearch: query='{query}', max_results={max_results}")
+        resp = requests.post(url, headers=headers, json=payload, timeout=DEFAULT_TIMEOUT)
+
+        if resp.status_code == 401:
+            return ToolResult.fail("Error: Invalid AnySearch API key.")
+        if resp.status_code == 402:
+            return ToolResult.fail("Error: AnySearch quota exhausted. Check usage at https://anysearch.com")
+        if resp.status_code == 429:
+            return ToolResult.fail("Error: AnySearch API rate limit reached.")
+        if resp.status_code != 200:
+            return ToolResult.fail(f"Error: AnySearch API returned HTTP {resp.status_code}")
+
+        data = resp.json()
+        # AnySearch signals success with business code 0 (not 200).
+        api_code = data.get("code")
+        if api_code not in (0, None):
+            msg = data.get("message") or "Unknown error"
+            return ToolResult.fail(f"Error: AnySearch API error (code={api_code}): {msg}")
+
+        body = data.get("data") or {}
+        results = []
+        for it in body.get("results") or []:
+            results.append({
+                "title": it.get("title", ""),
+                "url": it.get("url", ""),
+                "snippet": it.get("snippet") or (it.get("content") or "")[:200],
+            })
+        total = (body.get("metadata") or {}).get("total_results", len(results))
+        return ToolResult.success({
+            "query": query, "backend": "anysearch",
+            "total": total, "count": len(results), "results": results,
         })

--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -68,6 +68,8 @@ const I18N = {
         models_search_add_desc: '选择一个搜索厂商进行配置',
         models_search_bocha_title: '配置博查 API Key',
         models_search_bocha_desc: '前往博查开放平台创建 API Key',
+        models_search_anysearch_title: '配置 AnySearch API Key',
+        models_search_anysearch_desc: '前往 anysearch.com 控制台创建 API Key。',
         models_search_edit_hint: '点击修改配置',
         models_unavailable: '不可用',
         models_set_via_env: '通过环境变量启用',
@@ -389,6 +391,8 @@ const I18N = {
         models_search_add_desc: '選擇一個搜尋廠商進行設定',
         models_search_bocha_title: '設定博查 API Key',
         models_search_bocha_desc: '前往博查開放平臺建立 API Key',
+        models_search_anysearch_title: '設定 AnySearch API Key',
+        models_search_anysearch_desc: '前往 anysearch.com 控制台建立 API Key',
         models_search_edit_hint: '點選修改設定',
         models_unavailable: '不可用',
         models_set_via_env: '透過環境變數啟用',
@@ -705,6 +709,8 @@ const I18N = {
         models_search_add_desc: 'Pick a search provider to configure',
         models_search_bocha_title: 'Configure Bocha API Key',
         models_search_bocha_desc: 'Create a key at the Bocha open platform.',
+        models_search_anysearch_title: 'Configure AnySearch API Key',
+        models_search_anysearch_desc: 'Create a key at the AnySearch console (anysearch.com).',
         models_search_edit_hint: 'Click to edit',
         models_unavailable: 'unavailable',
         models_set_via_env: 'enable via environment variable',
@@ -7863,8 +7869,8 @@ function openSearchAddProviderPicker(missingProviders) {
 }
 
 function _launchSearchProviderConfig(providerId, providerMeta) {
-    if (providerId === 'bocha') {
-        openSearchBochaModal(providerMeta);
+    if (providerId === 'bocha' || providerId === 'anysearch') {
+        openSearchKeyModal(providerId, providerMeta);
     } else {
         openVendorModal(providerId, () => loadModelsView({ preserveScroll: true }));
     }
@@ -7898,19 +7904,21 @@ function saveSearchCapability() {
 // Minimal bocha API-key modal. Reuses the existing vendor-modal markup
 // helpers would be nice, but bocha isn't in PROVIDER_MODELS (it's not a
 // model vendor), so we render a tiny dedicated dialog.
-function openSearchBochaModal(providerMeta) {
-    const existing = document.getElementById('search-bocha-modal');
+// For search vendors that hold their own keys.
+
+function openSearchKeyModal(providerId, providerMeta) {
+    const existing = document.getElementById('search-key-modal');
     if (existing) existing.remove();
 
     let masked = (providerMeta && providerMeta.api_key_masked) || '';
     if (!masked) {
         const searchCap = (modelsState && modelsState.capabilities && modelsState.capabilities.search) || {};
-        const bocha = (searchCap.providers || []).find(p => p.id === 'bocha');
+        const bocha = (searchCap.providers || []).find(p => p.id === providerId);
         if (bocha && bocha.api_key_masked) masked = bocha.api_key_masked;
     }
     const hasKey = !!masked;
     const clearBtnHtml = hasKey
-        ? `<button type="button" id="search-bocha-clear"
+        ? `<button type="button" id="search-key-clear"
                   class="px-3 py-1.5 rounded-md text-xs text-red-500 dark:text-red-400
                          hover:bg-red-50 dark:hover:bg-red-900/20 cursor-pointer transition-colors">
               ${t('models_clear_credential')}
@@ -7918,16 +7926,16 @@ function openSearchBochaModal(providerMeta) {
         : '';
 
     const modal = document.createElement('div');
-    modal.id = 'search-bocha-modal';
+    modal.id = 'search-key-modal';
     modal.className = 'fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm';
     modal.innerHTML = `
-        <div id="search-bocha-modal-card"
+        <div id="search-key-modal-card"
              class="bg-white dark:bg-[#1A1A1A] rounded-xl border border-slate-200 dark:border-white/10
                     w-full max-w-md mx-4 p-6 shadow-xl">
-            <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100 mb-1">${t('models_search_bocha_title')}</h3>
-            <p class="text-xs text-slate-500 dark:text-slate-400 mb-4">${t('models_search_bocha_desc')}</p>
+            <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100 mb-1">${t('models_search_' + providerId + '_title')}</h3>
+            <p class="text-xs text-slate-500 dark:text-slate-400 mb-4">${t('models_search_' + providerId + '_desc')}</p>
             <label class="block text-sm font-medium text-slate-600 dark:text-slate-400 mb-1.5">API Key</label>
-            <input id="search-bocha-key" type="text" autocomplete="off" data-1p-ignore data-lpignore="true"
+            <input id="search-key-input" type="text" autocomplete="off" data-1p-ignore data-lpignore="true"
                    class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600
                           bg-slate-50 dark:bg-white/5 text-sm text-slate-800 dark:text-slate-100
                           focus:outline-none focus:border-primary-500 font-mono ${hasKey ? 'cfg-key-masked' : ''}"
@@ -7937,12 +7945,12 @@ function openSearchBochaModal(providerMeta) {
             <div class="flex items-center justify-between gap-3 mt-5">
                 <div>${clearBtnHtml}</div>
                 <div class="flex items-center gap-3">
-                    <button type="button" onclick="document.getElementById('search-bocha-modal').remove()"
+                    <button type="button" onclick="document.getElementById('search-key-modal').remove()"
                             class="px-3 py-1.5 rounded-md text-sm text-slate-600 dark:text-slate-300
                                    hover:bg-slate-100 dark:hover:bg-white/5 transition-colors">
                         ${t('cancel')}
                     </button>
-                    <button type="button" onclick="_saveBochaKey()"
+                    <button type="button" onclick="_saveSearchKey('${providerId}')"
                             class="px-4 py-1.5 rounded-md bg-primary-500 hover:bg-primary-600 text-white text-sm font-medium
                                    cursor-pointer transition-colors">
                         ${t('save')}
@@ -7955,7 +7963,7 @@ function openSearchBochaModal(providerMeta) {
 
     // Reset masked sentinel as soon as the user starts editing so the save
     // handler can tell apart "kept the existing key" vs "typed a new one".
-    const input = document.getElementById('search-bocha-key');
+    const input = document.getElementById('search-key-input');
     if (input) {
         const unmask = () => {
             if (input.dataset.masked === '1') {
@@ -7971,8 +7979,8 @@ function openSearchBochaModal(providerMeta) {
         input.addEventListener('paste', unmask);
         if (!hasKey) setTimeout(() => input.focus(), 50);
     }
-    const clearBtn = document.getElementById('search-bocha-clear');
-    if (clearBtn) clearBtn.addEventListener('click', _clearBochaKey);
+    const clearBtn = document.getElementById('search-key-clear');
+    if (clearBtn) clearBtn.addEventListener('click', () => _clearSearchKey(providerId));
 
     modal.addEventListener('mousedown', (e) => {
         if (e.target === modal) modal.remove();
@@ -7986,12 +7994,12 @@ function openSearchBochaModal(providerMeta) {
     document.addEventListener('keydown', onKey);
 }
 
-function _saveBochaKey() {
-    const input = document.getElementById('search-bocha-key');
+function _saveSearchKey(providerId) {
+    const input = document.getElementById('search-key-input');
     if (!input) return;
     // Untouched masked value => no change requested; close silently.
     if (input.dataset.masked === '1') {
-        const modal = document.getElementById('search-bocha-modal');
+        const modal = document.getElementById('search-key-modal');
         if (modal) modal.remove();
         return;
     }
@@ -8003,24 +8011,24 @@ function _saveBochaKey() {
     fetch('/api/models', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'set_search_credential', api_key: apiKey }),
+        body: JSON.stringify({ action: 'set_search_credential', provider: providerId, api_key: apiKey }),
     }).then(r => r.json()).then(data => {
         if (data.status === 'success') {
-            const modal = document.getElementById('search-bocha-modal');
+            const modal = document.getElementById('search-key-modal');
             if (modal) modal.remove();
             loadModelsView({ preserveScroll: true });
         }
     });
 }
 
-function _clearBochaKey() {
+function _clearSearchKey(providerId) {
     fetch('/api/models', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'set_search_credential', api_key: '' }),
+        body: JSON.stringify({ action: 'set_search_credential', provider: providerId, api_key: '' }),
     }).then(r => r.json()).then(data => {
         if (data.status === 'success') {
-            const modal = document.getElementById('search-bocha-modal');
+            const modal = document.getElementById('search-key-modal');
             if (modal) modal.remove();
             loadModelsView({ preserveScroll: true });
         }
@@ -11856,6 +11864,7 @@ function deleteTask() {
         }
     });
 }
+
 
 document.getElementById('task-edit-schedule-type').addEventListener('change', updateTaskScheduleFields);
 document.getElementById('task-edit-action-type').addEventListener('change', updateTaskActionLabel);

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -3898,13 +3898,14 @@ class ModelsHandler:
 
     # Canonical search provider order. Mirrors PROVIDER_ORDER in
     # agent/tools/web_search/web_search.py — keep them in sync.
-    _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai")
+    _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai","anysearch")
 
     _SEARCH_PROVIDER_LABELS = {
         "bocha":   {"zh": "博查", "en": "Bocha"},
         "zhipu":   {"zh": "智谱", "en": "GLM"},
         "qianfan": {"zh": "百度千帆", "en": "ERNIE"},
         "linkai":  {"zh": "LinkAI", "en": "LinkAI"},
+        "anysearch": {"zh": "AnySearch", "en": "AnySearch"},
     }
 
     @classmethod
@@ -3920,6 +3921,11 @@ class ModelsHandler:
             return local_config.get("qianfan_api_key") or os.environ.get("QIANFAN_API_KEY", "")
         if provider == "linkai":
             return local_config.get("linkai_api_key") or os.environ.get("LINKAI_API_KEY", "")
+        if provider == "anysearch":
+            tools_cfg = local_config.get("tools") or {}
+            block = tools_cfg.get("web_search") or {} if isinstance(tools_cfg, dict) else {}
+            return (block.get("anysearch_api_key") if isinstance(block, dict) else "") or os.environ.get(
+                "ANYSEARCH_API_KEY", "")
         return ""
 
     @classmethod
@@ -3945,7 +3951,7 @@ class ModelsHandler:
                 # bocha owns its key under tools.web_search; the other three
                 # piggy-back on a model-vendor credential. Frontend uses
                 # this hint to decide which credential editor to surface.
-                "needs_dedicated_key": pid == "bocha",
+                "needs_dedicated_key": pid in ("bocha", "anysearch"),
                 "api_key_masked": ConfigHandler._mask_key(raw_key) if raw_key else "",
             })
             if ok:
@@ -4668,20 +4674,23 @@ class ModelsHandler:
         return json.dumps({"status": "success", "strategy": strategy, "provider": provider})
 
     def _handle_set_search_credential(self, data: dict) -> str:
-        """Persist the bocha API key under tools.web_search.bocha_api_key.
+        """Persist a dedicated search-provider key under tools.web_search.
 
-        The other three providers (zhipu/qianfan/linkai) reuse model-vendor
-        credentials, so they go through set_provider with the standard
-        model-vendor flow.
+        bocha and anysearch own their keys here; zhipu/qianfan/linkai reuse
+        model-vendor credentials and go through set_provider instead.
         """
+        provider = (data.get("provider") or "bocha").strip().lower()
+        if provider not in ("bocha", "anysearch"):
+            return json.dumps({"status": "error", "message": f"unsupported search provider: {provider!r}"})
+        key_field = f"{provider}_api_key"
         api_key = (data.get("api_key") or "").strip() if isinstance(data.get("api_key"), str) else ""
         local_config = conf()
         file_cfg = self._read_file_config()
-        self._set_nested_namespace_value(local_config, "tools", "web_search", "bocha_api_key", api_key)
-        self._set_nested_namespace_value(file_cfg,     "tools", "web_search", "bocha_api_key", api_key)
+        self._set_nested_namespace_value(local_config, "tools", "web_search", key_field, api_key)
+        self._set_nested_namespace_value(file_cfg, "tools", "web_search", key_field, api_key)
         self._write_file_config(file_cfg)
-        logger.info(f"[ModelsHandler] search credential set: bocha_api_key={'***' if api_key else ''}")
-        return json.dumps({"status": "success", "provider": "bocha"})
+        logger.info(f"[ModelsHandler] search credential set: {key_field}={'***' if api_key else ''}")
+        return json.dumps({"status": "success", "provider": provider})
 
     @staticmethod
     def _reset_bridge() -> None:

--- a/docs/ja/tools/web-search.mdx
+++ b/docs/ja/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - Web 検索
 description: インターネットからリアルタイム情報を検索。複数の検索プロバイダーに対応
 ---
 
-インターネットからリアルタイム情報、ニュース、リサーチなどを検索します。Bocha、百度 Qianfan、智谱（Zhipu）、LinkAI の 4 つのバックエンドに対応しており、いずれか 1 社を設定すれば利用可能です。
+インターネットからリアルタイム情報、ニュース、リサーチなどを検索します。Bocha、百度 Qianfan、智谱（Zhipu）、LinkAI、AnySearch の 5 つのバックエンドに対応しており、いずれか 1 社を設定すれば利用可能です。
 
 <Tip>
   [Web コンソール](/ja/channels/web) の「モデル管理 → 検索」パネルから、プロバイダーと戦略を可視化して設定するのが推奨です。設定ファイルを手動で編集する必要はありません。
@@ -17,8 +17,8 @@ description: インターネットからリアルタイム情報を検索。複�
 | 百度 Qianfan | `qianfan_api_key` を再利用 | [Qianfan コンソール](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | 智谱 Zhipu | `zhipu_ai_api_key` を再利用 | [Zhipu Open Platform](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | `linkai_api_key` を再利用 | [LinkAI コンソール](https://link-ai.tech/console/interface) |
-
-Bocha のみ独立した `bocha_api_key` が必要ですが、他の 3 社は対応するモデルの API Key をそのまま再利用するため、モデルを設定すれば検索機能も同時に利用可能になります。
+| AnySearch | `anysearch_api_key` を再利用 | [AnySearch Open Platform](https://anysearch.com/) |
+Bocha、AnySearch のみ独立した `api_key` が必要ですが、他の 3 社は対応するモデルの API Key をそのまま再利用するため、モデルを設定すれば検索機能も同時に利用可能になります。
 
 ## ルーティング戦略
 
@@ -47,5 +47,5 @@ Bocha のみ独立した `bocha_api_key` が必要ですが、他の 3 社は対
 | `provider` | string | いいえ | `auto` 戦略で複数プロバイダーを設定している場合に表示。単回のプロバイダー切り替えに使用 |
 
 <Note>
-  4 社の認証情報がいずれも未設定の場合、このツールは Agent に登録されません。
+  5 社の認証情報がいずれも未設定の場合、このツールは Agent に登録されません。
 </Note>

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - Web Search
 description: Search the internet for real-time information, with support for multiple search providers
 ---
 
-Search the internet for real-time information, news, research, and more. Supports four backends — Bocha, ERNIE, GLM, and LinkAI — and works once any one of them is configured.
+Search the internet for real-time information, news, research, and more. Supports five backends — Bocha, ERNIE, GLM, LinkAI, and AnySearch — and works once any one of them is configured.
 
 <Tip>
   It is recommended to configure providers and routing strategy visually from the "Model Management → Search" panel in the [Web console](/channels/web), without manually editing the configuration file.
@@ -17,8 +17,9 @@ Search the internet for real-time information, news, research, and more. Support
 | ERNIE | Reuses `qianfan_api_key` | [Qianfan Console](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | Zhipu | Reuses `zhipu_ai_api_key` | [Zhipu Open Platform](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | Reuses `linkai_api_key` | [LinkAI Console](https://link-ai.tech/console/interface) |
+| AnySearch | Reuses `anysearch_api_key` | [AnySearch Console](https://anysearch.com/) |
 
-Except for Bocha which requires a dedicated `bocha_api_key`, the other three reuse the corresponding model's API key — configuring the model automatically grants search capability.
+Except for Bocha and AnySearch which require dedicated keys (bocha_api_key / anysearch_api_key), the other three reuse the corresponding model's API key — configuring the model automatically grants search capability.
 
 ## Routing Strategy
 
@@ -47,5 +48,5 @@ Except for Bocha which requires a dedicated `bocha_api_key`, the other three reu
 | `provider` | string | No | Available when multiple providers are configured under the `auto` strategy; used to switch provider for a single call |
 
 <Note>
-  If none of the four credentials are configured, this tool is not registered with the Agent.
+  If none of the five credentials are configured, this tool is not registered with the Agent.
 </Note>

--- a/docs/zh/tools/web-search.mdx
+++ b/docs/zh/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - 联网搜索
 description: 搜索互联网获取实时信息，支持多个搜索厂商
 ---
 
-搜索互联网获取实时信息、新闻、研究等内容。支持博查、百度千帆、智谱、LinkAI 四个后端，配置任意一家即可使用。
+搜索互联网获取实时信息、新闻、研究等内容。支持博查、百度千帆、智谱、LinkAI、AnySearch五个后端，配置任意一家即可使用。
 
 <Tip>
   推荐通过 [Web 控制台](/zh/channels/web) 的「模型管理 → 搜索」面板可视化配置厂商与策略，无需手动编辑配置文件。
@@ -17,8 +17,9 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | 百度千帆 | 复用 `qianfan_api_key` | [千帆控制台](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | 智谱 Zhipu | 复用 `zhipu_ai_api_key` | [智谱开放平台](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | 复用 `linkai_api_key` | [LinkAI 控制台](https://link-ai.tech/console/interface) |
+| AnySearch | 复用 `anysearch_api_key` | [AnySearch 控制台](https://anysearch.com/) |
 
-除博查需要单独的 `bocha_api_key` 外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
+除博查、AnySearch需要单独配置专用密钥（bocha_api_key / anysearch_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
 
 ## 路由策略
 
@@ -47,5 +48,5 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | `provider` | string | 否 | `auto` 策略下配置了多个厂商时可见，用于单次切换厂商 |
 
 <Note>
-  四家凭证均未配置时，该工具不会注册到 Agent。
+  五家凭证均未配置时，该工具不会注册到 Agent。
 </Note>

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,0 +1,178 @@
+# encoding:utf-8
+"""
+Unit tests for the web_search tool, focused on the AnySearch backend.
+
+Covers key resolution (config file + environment fallback), the canonical
+provider fallback order, result normalization into the unified output shape,
+the AnySearch-specific count clamp (the shared tool schema allows 1-50 while
+the API accepts 1-20), HTTP and business-level error mapping, and the
+anonymous mode contract (no Authorization header without a key).
+
+No real network is used: ``requests.post`` is stubbed throughout.
+"""
+import json
+import os
+import sys
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from agent.tools.web_search import web_search as web_search_module
+
+
+def _fake_response(status_code=200, payload=None):
+    """Build a minimal stand-in for a requests Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    body = payload if payload is not None else {}
+    resp.json = lambda: body
+    resp.text = json.dumps(body)
+    return resp
+
+
+def _anysearch_payload(results, total=None, code=0, message="success"):
+    """Build an AnySearch /v1/search response body in the documented shape."""
+    return {
+        "code": code,
+        "message": message,
+        "request_id": "req-test",
+        "data": {
+            "results": results,
+            "metadata": {"total_results": total if total is not None else len(results)},
+        },
+    }
+
+
+class TestAnySearchKeyResolution(unittest.TestCase):
+    """The anysearch key lives under tools.web_search, falling back to env."""
+
+    def setUp(self):
+        self._prev_env = os.environ.get("ANYSEARCH_API_KEY")
+        os.environ.pop("ANYSEARCH_API_KEY", None)
+
+    def tearDown(self):
+        if self._prev_env is None:
+            os.environ.pop("ANYSEARCH_API_KEY", None)
+        else:
+            os.environ["ANYSEARCH_API_KEY"] = self._prev_env
+
+    def test_anysearch_key_from_tools_config(self):
+        """tools.web_search.anysearch_api_key is resolved, and wins over env."""
+        cfg = {"tools": {"web_search": {"anysearch_api_key": "test-key-123"}}}
+        with patch.object(web_search_module, "conf", lambda: cfg):
+            self.assertEqual(web_search_module._get_api_key("anysearch"), "test-key-123")
+            with patch.dict(os.environ, {"ANYSEARCH_API_KEY": "env-key-456"}):
+                self.assertEqual(web_search_module._get_api_key("anysearch"), "test-key-123")
+
+    def test_anysearch_key_env_fallback(self):
+        """Without a config value, ANYSEARCH_API_KEY is used; both empty -> ''."""
+        with patch.object(web_search_module, "conf", lambda: {}):
+            with patch.dict(os.environ, {"ANYSEARCH_API_KEY": "env-key-456"}):
+                self.assertEqual(web_search_module._get_api_key("anysearch"), "env-key-456")
+            self.assertEqual(web_search_module._get_api_key("anysearch"), "")
+
+
+class TestProviderOrder(unittest.TestCase):
+    """anysearch must be appended last, leaving existing routing untouched."""
+
+    def test_provider_order_appends_anysearch_last(self):
+        self.assertEqual(web_search_module.PROVIDER_ORDER[-1], "anysearch")
+        self.assertEqual(
+            web_search_module.PROVIDER_ORDER[:4],
+            ("bocha", "qianfan", "zhipu", "linkai"),
+        )
+
+
+class TestAnySearchBackend(unittest.TestCase):
+    """Behaviour of WebSearch._search_anysearch with a stubbed HTTP layer."""
+
+    def setUp(self):
+        self.tool = web_search_module.WebSearch()
+
+    def test_search_anysearch_maps_results(self):
+        """Results under data.results map to the unified output shape.
+
+        `total` comes from metadata.total_results; a missing snippet falls
+        back to content, truncated to 200 chars. With a key configured, the
+        Authorization header is sent.
+        """
+        long_content = "x" * 300
+        payload = _anysearch_payload(
+            [
+                {"title": "T1", "url": "https://a.example/1", "snippet": "s1", "content": "c1"},
+                {"title": "T2", "url": "https://a.example/2", "content": long_content},
+            ],
+            total=123,
+        )
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, payload)) as mock_post:
+            result = self.tool._search_anysearch("cowagent", 10)
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.result["backend"], "anysearch")
+        self.assertEqual(result.result["total"], 123)
+        self.assertEqual(result.result["count"], 2)
+        first, second = result.result["results"]
+        self.assertEqual(first, {"title": "T1", "url": "https://a.example/1", "snippet": "s1"})
+        self.assertEqual(second["snippet"], long_content[:200])
+        headers = mock_post.call_args[1]["headers"]
+        self.assertEqual(headers.get("Authorization"), "Bearer test-key-123")
+
+    def test_search_anysearch_clamps_count(self):
+        """count is clamped into AnySearch's documented 1-20 range.
+
+        A falsy count falls back to the default of 10, matching the
+        `count or 10` idiom used by the zhipu/qianfan backends (execute()
+        already normalizes out-of-range values to 10 before dispatch).
+        """
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
+            for count, expected in ((50, 20), (0, 10), (None, 10), (10, 10)):
+                with self.subTest(count=count):
+                    self.tool._search_anysearch("q", count)
+                    self.assertEqual(mock_post.call_args[1]["json"]["max_results"], expected)
+
+    def test_search_anysearch_error_status_mapping(self):
+        """401/402/429 map to specific messages; other statuses are generic."""
+        cases = {
+            401: "Invalid AnySearch API key",
+            402: "quota exhausted",
+            429: "rate limit reached",
+            500: "HTTP 500",
+        }
+        for status_code, fragment in cases.items():
+            with self.subTest(status_code=status_code):
+                with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                        patch.object(web_search_module.requests, "post",
+                                     return_value=_fake_response(status_code)):
+                    result = self.tool._search_anysearch("q", 10)
+                self.assertEqual(result.status, "error")
+                self.assertIn(fragment, result.result)
+
+    def test_search_anysearch_business_error(self):
+        """HTTP 200 with a non-zero business code is surfaced as an error."""
+        payload = {"code": 40001, "message": "invalid api key", "request_id": "req-test"}
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, payload)):
+            result = self.tool._search_anysearch("q", 10)
+        self.assertEqual(result.status, "error")
+        self.assertIn("code=40001", result.result)
+        self.assertIn("invalid api key", result.result)
+
+    def test_search_anysearch_omits_auth_header_without_key(self):
+        """Anonymous mode: without a key, no Authorization header is sent."""
+        with patch.object(web_search_module, "_get_api_key", return_value=""), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
+            result = self.tool._search_anysearch("q", 10)
+        self.assertEqual(result.status, "success")
+        headers = mock_post.call_args[1]["headers"]
+        self.assertNotIn("Authorization", headers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
What does this PR do?
Add AnySearch as a new web search provider to expand the available search backend options.

This PR introduces the AnySearch provider implementation, integrates it into the web search tool selection, adds the corresponding UI elements in the web channel, and updates documentation (EN, ZH, JA) to reflect the new provider. A new test file is also added to cover the web search provider configuration.

Type of change
□ Bug fix
☑ New feature
☑ Docs
□ Refactor / chore
Checklist
☑ I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
☑ I tested this change locally
☑ Code comments and docs are in English
□ Linked related issue (if any): closes #

| Test file | Result |
|---|---|
| `tests/test_web_search.py` (8 cases) | ✅ All passed |

### Manual E2E verification
| Step | Screenshot |
|---|---|
| Web console → Search panel → AnySearch is available as a provider |<img width="1228" height="320" alt="6343f844fc807821cf158d6587c57790" src="https://github.com/user-attachments/assets/0be0bbba-8c1a-467e-9352-708e6a9a787c" />|
| Chat with `auto` strategy → `web_search` tool uses `anysearch` backend |<img width="1337" height="642" alt="8306d82baffa36db4dba1913a17ab172" src="https://github.com/user-attachments/assets/9a080ae3-7fcf-4f55-a0c2-a6ade07dcac5" />|
| Backend log confirms `provider=anysearch` with `reason=auto-fallback` | <img width="1478" height="697" alt="6c1bc6ba2d763933cdb24523e0634d7c" src="https://github.com/user-attachments/assets/a5f70374-713b-40d8-ac85-7cf3151fcc6c" />|

## Related
- AnySearch API docs: https://anysearch.com/docs
- Follow-up candidates: anonymous zero-key mode, `/v1/extract` tool (pending API spec), vertical tag mapping