### PR TITLE
feat(vision): add DeepSeek V4 Flash vision model to vision routing

### DIFF
--- a/agent/tools/vision/vision.py
+++ b/agent/tools/vision/vision.py
@@ -60,6 +60,7 @@ _DISCOVERABLE_MODELS = [
     ("zhipu_ai_api_key", const.ZHIPU_AI, const.GLM_4_7, "ZhipuAI"),
     ("minimax_api_key", const.MiniMax, const.MINIMAX_M2_7, "MiniMax"),
     ("mimo_api_key", const.MIMO, const.MIMO_V2_5_PRO, "MiMo"),
+    ("deepseek_api_key", const.DEEPSEEK, const.DEEPSEEK_V4_FLASH_VISION_EXP, "DeepSeek"),
 ]
 
 # Model name prefix → discoverable provider display_name.
@@ -77,6 +78,7 @@ _MODEL_PREFIX_TO_PROVIDER = [
     ("minimax-", "MiniMax"),
     ("abab", "MiniMax"),
     ("mimo-", "MiMo"),
+    ("deepseek-", "DeepSeek"),
 ]
 
 # Model prefixes that natively belong to OpenAI / LinkAI (raw HTTP providers).
@@ -97,6 +99,7 @@ _PROVIDER_ID_TO_DISPLAY = {
     "zhipu": "ZhipuAI",
     "minimax": "MiniMax",
     "mimo": "MiMo",
+    "deepseek": "DeepSeek",
 }
 
 

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -2530,7 +2530,7 @@ class ConfigHandler:
             "api_base_key": "deepseek_api_base",
             "api_base_default": "https://api.deepseek.com/v1",
             "api_base_placeholder": _PLACEHOLDER_V1,
-            "models": [const.DEEPSEEK_V4_FLASH, const.DEEPSEEK_V4_PRO],
+            "models": [const.DEEPSEEK_V4_FLASH_VISION_EXP, const.DEEPSEEK_V4_FLASH, const.DEEPSEEK_V4_PRO],
         }),
         ("claudeAPI", {
             "label": "Claude",
@@ -3230,6 +3230,8 @@ class ModelsHandler:
         "minimax":   [const.MINIMAX_TEXT_01],
         # MiMo 原生全模态模型：v2.5-pro / v2.5 支持图像/音频/视频输入
         "mimo":      [const.MIMO_V2_5_PRO, const.MIMO_V2_5],
+        # DeepSeek 视觉模型：V4 Flash vision（experimental, multimodal）
+        "deepseek":  [const.DEEPSEEK_V4_FLASH_VISION_EXP],
         # LinkAI proxies the underlying vendor; surface a curated set of
         # multimodal models. Order: gpt-4.1-mini → gpt-5.4-mini as the
         # cross-vendor baselines, then each vendor's recommended default.
@@ -3590,7 +3592,7 @@ class ModelsHandler:
         # 2. Main bot — only when it natively supports vision. We approximate
         #    "natively supports" by membership in _VISION_PROVIDER_MODELS,
         #    which is the same set vision.py's _DISCOVERABLE_MODELS covers
-        #    (minus the chat-only DeepSeek family).
+        #    (the DeepSeek family is included since V4 Flash vision).
         if main_provider in cls._VISION_PROVIDER_MODELS:
             hit = _try(main_provider, main_model)
             if hit:

--- a/common/const.py
+++ b/common/const.py
@@ -97,6 +97,7 @@ DEEPSEEK_CHAT = "deepseek-chat"  # DeepSeek-V3 chat model
 DEEPSEEK_REASONER = "deepseek-reasoner"  # DeepSeek-R1 model
 DEEPSEEK_V4_FLASH = "deepseek-v4-flash"  # DeepSeek V4 Flash - default recommendation (thinking + tool calls)
 DEEPSEEK_V4_PRO = "deepseek-v4-pro"  # DeepSeek V4 Pro - stronger on complex tasks (thinking + tool calls)
+DEEPSEEK_V4_FLASH_VISION_EXP = "deepseek-v4-flash-vision-exp"  # DeepSeek V4 Flash vision (experimental, multimodal)
 
 # Baidu Qianfan / ERNIE
 ERNIE_5_1 = "ernie-5.1"  # ERNIE 5.1 - default recommendation, latest flagship


### PR DESCRIPTION
- const: add DEEPSEEK_V4_FLASH_VISION_EXP for deepseek-v4-flash-vision-exp
- vision: register deepseek- prefix and a discoverable DeepSeek provider
- web: surface the DeepSeek vision model in chat and vision model catalogs