### PR TITLE
fix(modelscope): IMAGE_CREATE 必然 TypeError —— create_img 没有 retry_count 形参

### DIFF
--- a/models/modelscope/modelscope_bot.py
+++ b/models/modelscope/modelscope_bot.py
@@ -102,7 +102,7 @@ class ModelScopeBot(Bot):
             return reply
             
         elif context.type == ContextType.IMAGE_CREATE:
-            ok, retstring = self.create_img(query, 0)
+            ok, retstring = self.create_img(query)
             return Reply(ReplyType.IMAGE_URL, retstring) if ok else Reply(ReplyType.ERROR, retstring)
         else:
             return Reply(ReplyType.ERROR, "Bot 不支持处理{}类型的消息".format(context.type))


### PR DESCRIPTION
### 问题

`models/modelscope/modelscope_bot.py` 的 `ModelScopeBot.reply()` 在处理画图请求时：

```python
elif context.type == ContextType.IMAGE_CREATE:
    ok, retstring = self.create_img(query, 0)          # line 105
```

但同文件里 `create_img` 只接受一个参数：

```python
def create_img(self, query):                            # line 242
```

所以只要用户对 ModelScope bot 发起 `IMAGE_CREATE`（`$画` 等），必然抛：

```
TypeError: ModelScopeBot.create_img() takes 2 positional arguments but 3 were given
```

### 为什么是调用点写错了

`self.create_img(query, 0)` 是各家 bot 共用的模板写法，那些 bot 的 `create_img` 确实带 `retry_count`：

| 文件 | 签名 |
|---|---|
| `models/chatgpt/chat_gpt_bot.py:364` | `create_img(self, query, retry_count=0, api_key=None)` |
| `models/linkai/link_ai_bot.py:373` | `create_img(self, query, retry_count=0, api_key=None)` |
| `models/openai/open_ai_image.py:26` | `create_img(self, query, retry_count=0, api_key=None, api_base=None)` |
| `models/zhipuai/zhipu_ai_image.py:19` | `create_img(self, query, retry_count=0, api_key=None, api_base=None)` |
| **`models/modelscope/modelscope_bot.py:242`** | **`create_img(self, query)`** ← 唯一没有 `retry_count` 的 |

ModelScope 的实现走的是异步任务轮询，本身没有 retry 分支；而**同一个文件里另外 4 处调用早就是单参数形式**：

```
$ grep -n "self.create_img(" models/modelscope/modelscope_bot.py
105:            ok, retstring = self.create_img(query, 0)   ← 唯一多传一个 0 的
391:                    ok, result = self.create_img(query)
434:                ok, result = self.create_img(last_message)
500:                        ok, image_url = self.create_img(prompt)
684:                            ok, result = self.create_img(prompt)
```

所以把 105 行的多余 `0` 去掉，与同文件其余调用点保持一致，而不是给 `create_img` 加一个用不到的形参。

### 验证

用 AST 从仓库文件里重建 `create_img` 的真实签名，再用 `inspect.Signature.bind` 重放两种调用：

```
real signature: create_img(self, query)
  main (line 105)  -> TypeError: too many positional arguments
  fixed            -> OK
```

改动为 1 行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
