### PR TITLE
test: add minimal Agent trajectory evaluation pipeline

### DIFF
--- a/tests/test_trajectory_eval.py
+++ b/tests/test_trajectory_eval.py
@@ -1,0 +1,145 @@
+"""Deterministic trajectory evaluation scenarios for the Agent tool loop."""
+
+from types import SimpleNamespace
+
+from agent.protocol.agent_stream import AgentStreamExecutor
+from agent.tools.base_tool import BaseTool, ToolResult
+
+from tests.trajectory_eval import EvalCase, run_eval_case
+
+
+class _LookupTool(BaseTool):
+    name = "lookup"
+    params = {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    }
+
+    def __init__(self, results):
+        self.results = list(results)
+
+    def execute(self, params):
+        result = self.results.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+class _TestAgent:
+    def effective_permission_mode(self):
+        return "full-access"
+
+
+class _ScriptedExecutor(AgentStreamExecutor):
+    """Drive the real Agent loop with deterministic model responses."""
+
+    def __init__(self, responses, tool, on_event):
+        super().__init__(
+            agent=_TestAgent(),
+            model=SimpleNamespace(model="trajectory-test-model"),
+            system_prompt="",
+            tools=[tool] if tool else [],
+            max_turns=8,
+            on_event=on_event,
+            messages=[],
+        )
+        self.responses = list(responses)
+
+    def _is_thinking_enabled(self):
+        return False
+
+    def _trim_messages(self):
+        return None
+
+    def _validate_and_fix_messages(self):
+        return None
+
+    def _call_llm_stream(self, retry_on_empty=True):
+        text, tool_calls = self.responses.pop(0)
+        content = []
+        if text:
+            content.append({"type": "text", "text": text})
+        content.extend({
+            "type": "tool_use",
+            "id": call["id"],
+            "name": call["name"],
+            "input": call.get("arguments", {}),
+        } for call in tool_calls)
+        self.messages.append({"role": "assistant", "content": content})
+        return text, tool_calls, "stop"
+
+
+def _call(index=1):
+    return {
+        "id": "lookup-%s" % index,
+        "name": "lookup",
+        "arguments": {"query": "status"},
+    }
+
+
+def _run(case, responses, results=None):
+    tool = _LookupTool(results or []) if results is not None else None
+
+    def make_executor(recorder):
+        return _ScriptedExecutor(responses, tool, recorder)
+
+    return run_eval_case(case, make_executor)
+
+
+def test_direct_answer_has_no_tool_trajectory():
+    result = _run(
+        EvalCase("direct_answer", "Say hello"),
+        [("Hello", [])],
+    )
+
+    assert result.final_status == "done"
+    assert result.turn_count == 1
+    assert result.tool_call_count == 0
+    assert result.selected_tools == []
+
+
+def test_successful_tool_call_is_recorded():
+    result = _run(
+        EvalCase("successful_tool_call", "Look up status", ("lookup",)),
+        [("", [_call()]), ("Status is ready", [])],
+        [ToolResult.success("ready")],
+    )
+
+    assert result.final_status == "done"
+    assert result.turn_count == 2
+    assert result.tool_call_count == 1
+    assert result.successful_tool_calls == 1
+    assert result.failed_tool_calls == 0
+    assert result.selected_tools == ["lookup"]
+
+
+def test_failed_tool_call_is_distinguished_from_runtime_error():
+    result = _run(
+        EvalCase("failed_tool_call", "Look up status"),
+        [("", [_call()]), ("I could not look it up", [])],
+        [ToolResult.fail("service unavailable")],
+    )
+
+    assert result.final_status == "done"
+    assert result.tool_call_count == 1
+    assert result.successful_tool_calls == 0
+    assert result.failed_tool_calls == 1
+    assert result.error_count == 0
+
+
+def test_recorder_handles_incomplete_tool_events():
+    from tests.trajectory_eval import TrajectoryRecorder
+
+    recorder = TrajectoryRecorder()
+    recorder({"type": "turn_start", "timestamp": 1, "data": {"turn": 1}})
+    recorder({
+        "type": "tool_execution_start",
+        "timestamp": 2,
+        "data": {"tool_call_id": "unfinished", "tool_name": "lookup"},
+    })
+
+    result = recorder.result("incomplete")
+    assert result.final_status == "incomplete"
+    assert result.tool_call_count == 1
+    assert result.failed_tool_calls == 0

--- a/tests/trajectory_eval.py
+++ b/tests/trajectory_eval.py
@@ -1,0 +1,129 @@
+"""Small, deterministic helpers for evaluating Agent execution trajectories.
+
+The evaluator consumes the existing AgentStreamExecutor event callback.  It is
+intentionally test-only: it does not change runtime behavior or persist data.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Tuple
+
+
+@dataclass
+class EvalCase:
+    """A deterministic scenario and the outcome it should produce."""
+
+    name: str
+    user_message: str
+    expected_tools: Tuple[str, ...] = ()
+    expected_status: str = "done"
+
+
+@dataclass
+class EvaluationResult:
+    """Metrics collected from one Agent execution."""
+
+    case_name: str
+    final_status: str
+    turn_count: int
+    tool_call_count: int
+    successful_tool_calls: int
+    failed_tool_calls: int
+    selected_tools: List[str]
+    error_count: int
+    duration_ms: float
+    final_response: str = ""
+    error: str = ""
+    events: List[Dict[str, Any]] = field(default_factory=list, repr=False)
+
+
+class TrajectoryRecorder:
+    """Collect Agent events and turn them into stable, testable metrics."""
+
+    def __init__(self) -> None:
+        self.events: List[Dict[str, Any]] = []
+
+    def __call__(self, event: Dict[str, Any]) -> None:
+        if isinstance(event, dict):
+            self.events.append(event)
+
+    def result(
+        self,
+        case_name: str,
+        final_response: str = "",
+        error: str = "",
+    ) -> EvaluationResult:
+        starts = []
+        ends = []
+        runtime_errors = 0
+        cancelled = False
+
+        for event in self.events:
+            event_type = event.get("type")
+            data = event.get("data") or {}
+            if event_type == "tool_execution_start":
+                starts.append(data)
+            elif event_type == "tool_execution_end":
+                ends.append(data)
+            elif event_type == "error":
+                runtime_errors += 1
+            elif event_type in ("agent_cancelled", "cancel"):
+                cancelled = True
+
+        if cancelled:
+            status = "cancelled"
+        elif error or runtime_errors:
+            status = "error"
+        elif any(event.get("type") == "agent_end" for event in self.events):
+            status = "done"
+        else:
+            status = "incomplete"
+
+        timestamps = [
+            event.get("timestamp")
+            for event in self.events
+            if isinstance(event.get("timestamp"), (int, float))
+        ]
+        duration_ms = 0.0
+        if len(timestamps) >= 2:
+            duration_ms = max(0.0, (max(timestamps) - min(timestamps)) * 1000)
+
+        selected_tools = []
+        for data in starts:
+            name = data.get("tool_name")
+            if name and name not in selected_tools:
+                selected_tools.append(name)
+
+        successful = sum(data.get("status") == "success" for data in ends)
+        failed = sum(data.get("status") != "success" for data in ends)
+        return EvaluationResult(
+            case_name=case_name,
+            final_status=status,
+            turn_count=sum(event.get("type") == "turn_start" for event in self.events),
+            tool_call_count=len({
+                data.get("tool_call_id")
+                for data in starts + ends
+                if data.get("tool_call_id")
+            }),
+            successful_tool_calls=successful,
+            failed_tool_calls=failed,
+            selected_tools=selected_tools,
+            error_count=runtime_errors,
+            duration_ms=duration_ms,
+            final_response=final_response or "",
+            error=error,
+            events=list(self.events),
+        )
+
+
+def run_eval_case(case: EvalCase, executor_factory: Callable) -> EvaluationResult:
+    """Run one case without letting a runtime exception hide its trajectory."""
+
+    recorder = TrajectoryRecorder()
+    executor = executor_factory(recorder)
+    response = ""
+    error = ""
+    try:
+        response = executor.run_stream(case.user_message)
+    except Exception as exc:  # The result should make failed runs inspectable.
+        error = str(exc)
+    return recorder.result(case.name, response, error)


### PR DESCRIPTION
## What does this PR do?

This PR adds a minimal and deterministic Agent trajectory evaluation pipeline.

It introduces:

- A `TrajectoryRecorder` based on the existing `on_event` callback
- Metrics for turn count, tool-call count, successful and failed tool calls, selected tools, errors, and final status
- Scripted Agent scenarios for direct answers, successful tool calls, and failed tool calls
- Tests for incomplete tool events

This change does not modify the Agent runtime loop, existing public APIs, or production behavior. It also does not add external dependencies or use LLM-as-a-judge.

Tests run locally:

- `tests/test_trajectory_eval.py`: 4 passed
- Related Agent tests: 61 passed
- The full test suite currently reports unrelated Windows environment-dependent failures, including directory symlink tests.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [x] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): closes #ISSUE_NUMBER