### PR TITLE
fix(web): set Content-Type on /chat so the console renders behind a nosniff proxy

### DIFF
--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -2567,6 +2567,10 @@ class StreamHandler:
 
 class ChatHandler:
     def GET(self):
+        # Content-Type must be explicit: behind a reverse proxy that sends
+        # X-Content-Type-Options: nosniff, a missing type makes browsers
+        # refuse to sniff and render the page as plain text source.
+        web.header('Content-Type', 'text/html; charset=utf-8')
         web.header('Cache-Control', 'no-cache, no-store, must-revalidate')
         web.header('Pragma', 'no-cache')
         file_path = os.path.join(os.path.dirname(__file__), 'chat.html')

--- a/tests/test_web_chat_content_type.py
+++ b/tests/test_web_chat_content_type.py
@@ -1,0 +1,83 @@
+"""The /chat page must declare its Content-Type.
+
+Browsers sniffed the HTML when the header was missing, so direct access looked
+fine and the bug stayed invisible until the console sat behind a reverse proxy
+that sends `X-Content-Type-Options: nosniff` — the usual HTTPS setup. With
+sniffing disabled and no declared type, the page renders as plain text source
+instead of the console.
+
+Every other HTML handler already sets the header; /chat was the only one that
+did not, so this guards the one endpoint that regressed.
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import mock_open, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+if "web" not in sys.modules:
+    web_stub = types.ModuleType("web")
+    web_stub.HTTPError = type("HTTPError", (Exception,), {})
+    web_stub.cookies = lambda: {}
+    web_stub.header = lambda *args, **kwargs: None
+    web_stub.data = lambda: b"{}"
+    web_stub.input = lambda **kwargs: types.SimpleNamespace(**kwargs)
+    web_stub.setcookie = lambda *args, **kwargs: None
+    web_stub.seeother = lambda *args, **kwargs: Exception("seeother")
+    web_stub.notfound = lambda *args, **kwargs: Exception("notfound")
+    web_stub.badrequest = lambda *args, **kwargs: Exception("badrequest")
+    web_stub.application = lambda *args, **kwargs: types.SimpleNamespace(wsgifunc=lambda: None)
+    web_stub.httpserver = types.SimpleNamespace(
+        LogMiddleware=type("LogMiddleware", (), {"log": lambda *args, **kwargs: None}),
+        StaticMiddleware=lambda app: app,
+        WSGIServer=lambda *args, **kwargs: types.SimpleNamespace(serve_forever=lambda: None),
+    )
+    sys.modules["web"] = web_stub
+
+
+def _capture_headers():
+    """Record every web.header call a handler makes outside a request.
+
+    The stub above is skipped when the real web.py is already imported, which
+    depends on what else ran first. Patching the name the handler resolves
+    keeps these cases independent of that.
+    """
+    import channel.web.web_channel as web_channel
+
+    sent = []
+
+    def _header(name, value=None):
+        sent.append((name, value))
+
+    return patch.object(web_channel.web, "header", _header), sent
+
+
+class TestChatHandlerContentType(unittest.TestCase):
+
+    def test_chat_page_declares_html_content_type(self):
+        """A nosniff proxy cannot sniff, so the type has to be explicit."""
+        from channel.web.web_channel import ChatHandler
+
+        patcher, sent = _capture_headers()
+        with patcher:
+            with patch("channel.web.web_channel._require_auth", lambda: None):
+                with patch("builtins.open", mock_open(read_data="<!doctype html><html></html>")):
+                    ChatHandler().GET()
+
+        content_types = [value for name, value in sent if name.lower() == "content-type"]
+        self.assertTrue(
+            content_types,
+            "ChatHandler.GET sent no Content-Type; behind a nosniff proxy the "
+            "page renders as plain text source",
+        )
+        self.assertIn("text/html", content_types[0])
+        # The console is UTF-8; without the charset the browser guesses and
+        # non-ASCII UI copy mojibakes.
+        self.assertIn("charset=utf-8", content_types[0].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

`ChatHandler.GET` (`GET /chat`, the web console page) returned HTML without a
`Content-Type` header — the one HTML endpoint that forgot to declare its type.

Direct access worked fine, which is why this stayed invisible: with no declared
type the browser sniffs the `<!DOCTYPE html>` and renders the page. But behind a
reverse proxy that sends `X-Content-Type-Options: nosniff` — the usual HTTPS
setup — sniffing is disabled, so the browser renders the console as plain text
source instead of running it.

The fix is one line plus a comment:

```python
web.header('Content-Type', 'text/html; charset=utf-8')
```

Every other HTML handler in `web_channel.py` already sets this (`/config` and
the MCP OAuth callback, among others); `/chat` was the only one missing it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): none found — searched for existing reports
      about `nosniff` / plain-text rendering and found none, so no issue to link.

## Testing

Added `tests/test_web_chat_content_type.py`, which calls `ChatHandler().GET()`
with `web.header` captured and asserts a `text/html` + `charset=utf-8` type is
sent.

I verified the test actually catches the bug rather than passing vacuously: with
the one-line fix reverted it fails with `AssertionError: [] is not true`, and
passes again once restored.

Full related suite (the new file plus the three other `web_channel` test
modules):

```
66 passed
```

## Scope

Deliberately kept to this one bug — it is unrelated to the chat-fallback work in
#3099 and is not included in that branch.
