### PR TITLE
fix(agent): stop a sub agent from clearing the parent run's chat fallback

### DIFF
--- a/agent/protocol/agent_stream.py
+++ b/agent/protocol/agent_stream.py
@@ -693,6 +693,21 @@ class AgentStreamExecutor:
         final_response = ""
         turn = 0
 
+        # Respect a run id an outer scope already set (a subagent spawn or a
+        # delegated task passes one down); only mint a fresh one when this turn
+        # is the top of its own run. Writing through set_agent_run_id keeps the
+        # outbound header-tagging path and RuntimeIdentity on the same id.
+        import uuid as _uuid
+        from common.utils import set_agent_run_id, clear_agent_run_id, current_agent_run_id
+        # Captured before minting: once this run sets its own id, nothing
+        # downstream can tell whether it was nested. A sub agent inherits the
+        # parent's run id through identity_scope, so an id already being
+        # present is exactly what "nested" means.
+        _nested_run = bool(current_agent_run_id())
+        _run_token = None
+        if not _nested_run:
+            _run_token = set_agent_run_id(_uuid.uuid4().hex)
+
         # Reset any fallback routing left over from a *previous* run: a new user
         # message always starts fresh on the primary model. Within this run the
         # fallback is deliberately sticky — once the primary has failed a turn
@@ -701,17 +716,14 @@ class AgentStreamExecutor:
         # outage — dead key, IP block, regional downtime — would otherwise burn
         # one wasted primary call per step). The primary gets a fresh chance on
         # the next user message.
-        self._reset_model_fallback()
+        #
+        # Must run *after* the run id above, not before: the reset is a no-op
+        # for a nested run (see _reset_model_fallback), and only the id tells
+        # the two apart. A nested run keeps the parent's fallback engaged — the
+        # sub agent is running inside the same outage and should inherit the
+        # backup rather than start over on the provider that just failed.
+        self._reset_model_fallback(nested_run=_nested_run)
 
-        # Respect a run id an outer scope already set (a subagent spawn or a
-        # delegated task passes one down); only mint a fresh one when this turn
-        # is the top of its own run. Writing through set_agent_run_id keeps the
-        # outbound header-tagging path and RuntimeIdentity on the same id.
-        import uuid as _uuid
-        from common.utils import set_agent_run_id, clear_agent_run_id, current_agent_run_id
-        _run_token = None
-        if not current_agent_run_id():
-            _run_token = set_agent_run_id(_uuid.uuid4().hex)
         cancelled = False
         try:
             while turn < self.max_turns:
@@ -1154,12 +1166,25 @@ class AgentStreamExecutor:
             logger.debug(f"[ToolRetrieval] full injection (retrieval skipped): {e}")
             return all_tools
 
-    def _reset_model_fallback(self) -> None:
+    def _reset_model_fallback(self, nested_run: bool = False) -> None:
         """Drop any fallback routing so the next call uses the primary model.
 
+        ``nested_run`` marks a run that inherited its run id from an outer
+        scope — a sub agent spawn or a delegated task. Those must leave the
+        parent's routing alone: a sub agent is built with the parent's *same*
+        model object, so resetting here would clear the fallback the parent is
+        mid-way through relying on and send both of them back to the provider
+        that just failed.
+
         Fallback is opt-in and this is a no-op on models that don't support it,
-        so it is safe to call unconditionally at the top of every turn.
+        so it is safe to call unconditionally at the top of a run.
         """
+        # The caller captures this *before* minting its own run id — once that
+        # id is set, nothing downstream can tell a nested run from a top-level
+        # one, so the distinction has to be passed in.
+        if nested_run:
+            return
+
         model = getattr(self, "model", None)
         reset = getattr(model, "reset_fallback", None)
         if not callable(reset):

--- a/tests/test_subagent_fallback_scope.py
+++ b/tests/test_subagent_fallback_scope.py
@@ -1,0 +1,136 @@
+"""A sub agent must not reset the parent run's engaged fallback.
+
+The fallback is sticky for a whole run: once the primary model has failed a turn
+for good, the remaining steps stay on the backup instead of re-probing a
+provider we already know is down. It is cleared once, at the top of a run.
+
+That breaks when the parent delegates. A sub agent is built with
+``model=parent.model`` — the *same* ``AgentLLMModel`` object, not a copy — and
+its ``run_stream`` runs that same reset at its top. The child therefore clears
+the fallback the parent is currently relying on: when the child returns, the
+parent goes back to the primary model that just failed and burns the full retry
+budget again on every remaining step. The child loses the backup too, since it
+is running inside the same outage and starts on the dead primary itself.
+
+The reset has to be scoped to a *top-level* run: an outer scope that already set
+a run id means this run is nested and must leave the parent's routing alone.
+"""
+
+import pytest
+
+from bridge.agent_bridge import AgentLLMModel
+
+FALLBACK = {
+    "enabled": True,
+    "provider": "openai",
+    "model": "backup-model",
+    "max_switches": 1,
+}
+
+
+def _model(monkeypatch, chat_fallback, **extra_conf):
+    """An AgentLLMModel with a stubbed config (no bridge, no real bot)."""
+    conf = {"model": "primary-model", "chat_fallback": chat_fallback}
+    conf.update(extra_conf)
+    monkeypatch.setattr("bridge.agent_bridge.conf", lambda: conf, raising=False)
+    return AgentLLMModel.__new__(AgentLLMModel)
+
+
+@pytest.fixture
+def executor_cls():
+    from agent.protocol.agent_stream import AgentStreamExecutor
+
+    return AgentStreamExecutor
+
+
+def _reset_like_a_run(executor_cls, model, ambient_run_id=None):
+    """Run the real reset decision the way a run enters it.
+
+    run_stream mints a run id only when no outer scope set one, and the reset
+    follows the same scope. Driving the executor's real method under the same
+    identity_scope a sub agent spawn uses keeps this honest: it breaks if
+    either contract changes.
+    """
+    from common.runtime_identity import identity_scope
+    from common.utils import (
+        set_agent_run_id,
+        clear_agent_run_id,
+        current_agent_run_id,
+    )
+    import uuid as _uuid
+
+    executor = executor_cls.__new__(executor_cls)
+    executor.model = model
+
+    def _body():
+        # Mirrors run_stream: capture "am I nested?" BEFORE minting a run id,
+        # then hand that to the reset.
+        nested = bool(current_agent_run_id())
+        token = None
+        if not nested:
+            token = set_agent_run_id(_uuid.uuid4().hex)
+        try:
+            executor._reset_model_fallback(nested_run=nested)
+        finally:
+            if token is not None:
+                clear_agent_run_id(token)
+
+    if ambient_run_id:
+        with identity_scope(run_id=ambient_run_id):
+            _body()
+    else:
+        _body()
+
+
+class TestSubAgentDoesNotClearParentFallback:
+
+    def test_a_nested_run_keeps_the_parents_engaged_fallback(
+        self, monkeypatch, executor_cls
+    ):
+        """The regression: the child's reset knocked the parent off the backup."""
+        model = _model(monkeypatch, FALLBACK)
+        assert model.use_fallback() is True
+        assert model.model == "backup-model"
+
+        # A sub agent spawning mid-run, with the parent's run id ambient.
+        _reset_like_a_run(executor_cls, model, ambient_run_id="parent-run-123")
+
+        assert model.model == "backup-model", (
+            "the sub agent cleared the fallback the parent is still relying on; "
+            "the parent will re-probe the failed primary on its next step"
+        )
+
+    def test_a_top_level_run_still_resets(self, monkeypatch, executor_cls):
+        """The fix must not break the normal case: a new run starts fresh."""
+        model = _model(monkeypatch, FALLBACK)
+        assert model.use_fallback() is True
+        assert model.model == "backup-model"
+
+        # No ambient run id: this run is the top of its own run.
+        _reset_like_a_run(executor_cls, model)
+
+        assert model.model == "primary-model"
+
+    def test_the_reset_still_bounds_switches_per_run(self, monkeypatch, executor_cls):
+        """After a top-level reset the run earns a fresh switch."""
+        model = _model(monkeypatch, FALLBACK)
+        model.use_fallback()
+        _reset_like_a_run(executor_cls, model)
+
+        assert model.model == "primary-model"
+        assert model.fallback_available() is True
+        assert model.use_fallback() is True
+        assert model.model == "backup-model"
+
+    def test_a_nested_run_leaves_the_switch_budget_alone(
+        self, monkeypatch, executor_cls
+    ):
+        """A nested run must not hand the parent extra switches either."""
+        model = _model(monkeypatch, FALLBACK)
+        model.use_fallback()
+
+        _reset_like_a_run(executor_cls, model, ambient_run_id="parent-run-123")
+
+        # Still on the backup and out of switches, so it cannot ping-pong.
+        assert model.model == "backup-model"
+        assert model.fallback_available() is False


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where **a sub agent clears the fallback model its parent is
currently relying on**.

The chat fallback (added in #3099) is sticky for a whole run: once the primary
model has failed a turn for good, the remaining steps stay on the backup instead
of re-probing a provider we already know is down. It is cleared once, at the top
of a run.

That breaks whenever the parent delegates. In `agent/subagent/runner.py`:

```python
child = _build_child(parent, template, task)   # model=parent.model
child.run_stream(task.goal, ...)
```

`_build_child` passes `model=parent.model` — the **same `AgentLLMModel` object,
not a copy** — and the child's `run_stream` runs the same reset at its top. So
the child clears the fallback the parent is mid-way through relying on.

Concretely, with `max_switches=1` and a sustained outage:

1. Parent fails on the primary, switches to the backup.
2. Parent delegates a piece of work to a sub agent.
3. The sub agent's `run_stream` resets the shared model back to the primary.
4. The sub agent now runs on the provider that just failed — wasting its own
   retry budget too.
5. On return, the parent is back on the primary and burns the full retry budget
   again on every remaining step.

The reset is now scoped to a **top-level** run. A nested run (one that inherited
its run id from an outer scope via `identity_scope`) leaves the parent's routing
alone.

### Why the flag has to be passed in

The non-obvious part: `run_stream` mints its own run id *before* reaching the
reset, so by the time the reset runs, an id is always present. Checking
`current_agent_run_id()` inside the reset would therefore treat every run as
nested and disable the reset entirely — which is exactly what my first attempt
did, and the tests caught it.

The caller captures "was a run id already set?" **before** minting its own and
passes that down:

```python
_nested_run = bool(current_agent_run_id())      # before minting
if not _nested_run:
    _run_token = set_agent_run_id(_uuid.uuid4().hex)
...
self._reset_model_fallback(nested_run=_nested_run)
```

`run_stream` already used this same test to decide whether to mint an id, so
this reuses an existing, proven notion of "top-level run" rather than inventing
a new one.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): none — found while reviewing the fallback
      change in #3099, not reported separately.

## Testing

Added `tests/test_subagent_fallback_scope.py` (4 tests) covering: a nested run
keeps the parent's engaged fallback, a top-level run still resets, the switch
budget is still refilled per run, and a nested run doesn't hand out extra
switches.

Verified the tests actually catch the bug rather than passing vacuously:

| Stage | Result |
|---|---|
| Before the fix | 2 nested tests **fail** |
| After the fix | 4 **pass** |
| Guard removed again | 2 nested tests **fail** again |

Also drove the real `AgentLLMModel` + `identity_scope` path outside pytest to
confirm the behaviour end to end, including that a nested run does not get stuck
on the backup — the next user message still returns to the primary:

```
parent engaged:                     backup-model
  after subagent 1/2/3:             backup-model
next user message (top-level):      primary-model
```

Regression run: the fallback- and delegation-related suites together are
**65 passed**. Full suite compared against a clean `origin/master` worktree
shows **no new failures** — the ~20 failures present are pre-existing and
identical on both (several are order-dependent/flaky: `test_shared_db_recovery`
fails the same way on the unmodified baseline).

## Scope

Deliberately separate from #3110 (an unrelated `/chat` Content-Type fix). This
branch touches only `agent/protocol/agent_stream.py` and its test.
