### PR TITLE
feat(memory): heading-aware chunking for memory/knowledge markdown files

### DIFF
--- a/agent/memory/chunker.py
+++ b/agent/memory/chunker.py
@@ -132,9 +132,117 @@ class TextChunker:
         
         return overlap
     
+    # --- Markdown structure-aware chunking ---------------------------------
+    # Fixed char thresholds (independent of the token-based params above).
+    # Calibrated by eval: single-file boundary, title-aware split only when a
+    # file exceeds the target, cross-heading greedy merge + single tail fold.
+    MD_CHUNK_TARGET = 1500   # char soft ceiling per chunk
+    MD_FRAGMENT_MAX = 400    # a trailing block <= this folds into the previous
+
     def chunk_markdown(self, text: str) -> List[TextChunk]:
+        """Chunk a markdown file while respecting its heading structure.
+
+        Strategy (per file):
+          - A file <= MD_CHUNK_TARGET chars is ONE chunk (whole file is a
+            strong semantic unit; most real memory files take this path).
+          - Larger files are heading-aware split via markdown-it:
+              * candidate segment = every heading node's OWN direct body only
+                (heading line up to its first direct child heading); parent
+                headings do NOT swallow child bodies;
+              * cross-heading greedy merge: walk segments in order, a segment
+                joins the current block iff the total stays <= MD_CHUNK_TARGET,
+                else it starts a new block;
+              * single tail fold: if the last block is <= MD_FRAGMENT_MAX chars
+                it is folded into the previous block unconditionally.
+        Line numbers are 1-based over the whole file, matching chunk_text.
+
+        Args:
+            text: full markdown file content
+
+        Returns:
+            List of TextChunk objects
         """
-        Chunk markdown text while respecting structure
-        (For future enhancement: respect markdown sections)
+        if not text.strip():
+            return []
+        lines = text.split('\n')
+
+        # Whole file under target: single chunk (semantic isolation).
+        if len(text) <= self.MD_CHUNK_TARGET:
+            return [TextChunk(text=text, start_line=1, end_line=len(lines))]
+
+        # Delay import so the zero-dep chunk_text path and module import are
+        # unaffected when markdown-it is unavailable.
+        try:
+            import markdown_it
+        except ImportError:
+            # Fallback: no parser -> plain line splitter.
+            return self.chunk_text(text)
+
+        segments = self._md_leaf_segments(text, lines, markdown_it)
+        if not segments:
+            return [TextChunk(text=text, start_line=1, end_line=len(lines))]
+
+        # Greedy cross-heading merge.
+        blocks: List[List[dict]] = [[segments[0]]]
+        cur_len = len(segments[0]['text'])
+        for seg in segments[1:]:
+            if cur_len + len(seg['text']) <= self.MD_CHUNK_TARGET:
+                blocks[-1].append(seg)
+                cur_len += len(seg['text'])
+            else:
+                blocks.append([seg])
+                cur_len = len(seg['text'])
+
+        # Single tail fold: if the last block is a fragment (<= MD_FRAGMENT_MAX
+        # chars), fold it unconditionally into the previous block.
+        if len(blocks) >= 2:
+            tail_len = sum(len(s['text']) for s in blocks[-1])
+            if tail_len <= self.MD_FRAGMENT_MAX:
+                tail = blocks.pop()
+                blocks[-1].extend(tail)
+
+        result: List[TextChunk] = []
+        for blk in blocks:
+            content = '\n\n'.join(s['text'] for s in blk)
+            start_line = blk[0]['start_line']           # already 1-based
+            end_line = blk[-1]['end_line']               # already 1-based
+            result.append(TextChunk(text=content, start_line=start_line, end_line=end_line))
+        return result
+
+    def _md_leaf_segments(self, text: str, lines: List[str], markdown_it) -> List[dict]:
+        """Return every heading's OWN direct body as a candidate segment.
+
+        A segment is the heading line plus its text up to its first DIRECT
+        CHILD heading (level == own + 1), or to the next heading of <= own
+        level. Parent headings do NOT swallow child bodies. 1-based line
+        numbers; dicts carry {'start_line','end_line','text'}.
         """
-        return self.chunk_text(text)
+        md = markdown_it.MarkdownIt()
+        toks = md.parse(text)
+
+        heads = []
+        for i, t in enumerate(toks):
+            if t.type == 'heading_open' and i + 1 < len(toks) and toks[i + 1].type == 'inline':
+                heads.append({'line': t.map[0], 'level': int(t.tag[1])})  # 0-based line
+
+        if not heads:
+            return [{'start_line': 1, 'end_line': len(lines), 'text': text}]
+
+        n = len(heads)
+        segs = []
+        for i, h in enumerate(heads):
+            start0 = h['line']
+            end0 = len(lines)  # exclusive 0-based boundary
+            for j in range(i + 1, n):
+                if heads[j]['level'] == h['level'] + 1 or heads[j]['level'] <= h['level']:
+                    end0 = heads[j]['line']
+                    break
+            # Convert to 1-based inclusive lines.
+            start_line = start0 + 1
+            end_line = end0  # end0 is 0-based exclusive -> 1-based inclusive end
+            content = '\n'.join(lines[start0:end0]).rstrip()
+            if content.strip():
+                segs.append({'start_line': start_line, 'end_line': end_line,
+                             'text': content})
+        return segs
+

--- a/agent/memory/chunker.py
+++ b/agent/memory/chunker.py
@@ -139,6 +139,13 @@ class TextChunker:
     MD_CHUNK_TARGET = 1500   # char soft ceiling per chunk
     MD_FRAGMENT_MAX = 400    # a trailing block <= this folds into the previous
 
+    # Bump whenever chunk_markdown()'s strategy changes in a way that alters
+    # existing chunk boundaries. Used to tell an already-built index apart from
+    # one produced by the current algorithm (see detect_chunker_version), so
+    # /memory status can suggest a rebuild instead of silently keeping stale
+    # boundaries forever (file hashes do not change when only the chunker does).
+    CHUNKER_VERSION = 1
+
     def chunk_markdown(self, text: str) -> List[TextChunk]:
         """Chunk a markdown file while respecting its heading structure.
 

--- a/agent/memory/embedding/__init__.py
+++ b/agent/memory/embedding/__init__.py
@@ -24,6 +24,7 @@ from agent.memory.embedding.rebuild import (
 )
 from agent.memory.embedding.state import (
     cleanup_legacy_state_file,
+    detect_chunker_version,
     detect_index_dim,
 )
 
@@ -39,5 +40,6 @@ __all__ = [
     "clear_index",
     "rebuild_in_process",
     "cleanup_legacy_state_file",
+    "detect_chunker_version",
     "detect_index_dim",
 ]

--- a/agent/memory/embedding/state.py
+++ b/agent/memory/embedding/state.py
@@ -6,6 +6,7 @@ and config.json is the source of intent. The two functions below are the
 only things needing on-disk awareness:
 
   detect_index_dim         : read the dim of stored vectors (display-only)
+  detect_chunker_version   : read the chunker version that produced the index
   cleanup_legacy_state_file: remove old embedding_state.json from earlier
                              versions; safe no-op when absent.
 """
@@ -38,6 +39,28 @@ def detect_index_dim(storage) -> Optional[int]:
         emb = json.loads(raw)
         return len(emb) if isinstance(emb, list) else None
     except (json.JSONDecodeError, TypeError, Exception):
+        return None
+
+
+def detect_chunker_version(storage) -> Optional[int]:
+    """Return the chunker version recorded for the index, or None when the
+    index carries no record at all.
+
+    `None` means the index predates chunker-version tracking (or was built by
+    an unknown strategy), i.e. its chunk boundaries may not match the current
+    algorithm — /memory status uses this to suggest a rebuild. Chunked files
+    are only re-split when their content hash changes, so a chunker change
+    alone would otherwise never refresh existing boundaries.
+    """
+    try:
+        raw = storage.get_meta("chunker_version")
+    except Exception:
+        return None
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
         return None
 
 

--- a/agent/memory/manager.py
+++ b/agent/memory/manager.py
@@ -326,7 +326,12 @@ class MemoryManager:
             rel_path = str(file_path.relative_to(workspace_dir_path))
             if self.storage.get_file_hash(rel_path) == file_hash:
                 continue
-            chunks = self.chunker.chunk_text(content)
+            # Markdown files (memory + knowledge) get structure-aware chunking;
+            # anything else (rare) falls back to the plain char splitter.
+            if file_path.suffix.lower() == '.md':
+                chunks = self.chunker.chunk_markdown(content)
+            else:
+                chunks = self.chunker.chunk_text(content)
             if not chunks:
                 continue
             pending.append({

--- a/agent/memory/manager.py
+++ b/agent/memory/manager.py
@@ -267,6 +267,16 @@ class MemoryManager:
         memory_dir = self.config.get_memory_dir()
         workspace_dir = self.config.get_workspace()
 
+        # Was the index empty before this sync? Only then can we be sure every
+        # chunk came from the CURRENT chunking algorithm (a fresh index, or one
+        # cleared by rebuild-index), which is what lets us stamp
+        # chunker_version. A non-empty index may still hold chunks from an
+        # older algorithm, so it must not be stamped.
+        try:
+            files_before = int(self.storage.get_stats().get("files", 0) or 0)
+        except Exception:
+            files_before = -1  # unknown -> do not stamp
+
         files_to_scan: List[tuple] = []  # (file_path, source, scope, user_id)
 
         memory_file = Path(workspace_dir) / "MEMORY.md"
@@ -412,6 +422,19 @@ class MemoryManager:
                 mtime=int(stat.st_mtime),
                 size=stat.st_size,
             )
+
+        # Stamp the chunker version only when we rebuilt from an empty index,
+        # i.e. every chunk in it was produced by the current algorithm. An
+        # index that already had files may still contain chunks from an older
+        # chunker (file hashes do not change when only the chunker does), so it
+        # stays unstamped and /memory status will suggest a rebuild.
+        if files_before == 0:
+            try:
+                self.storage.set_meta(
+                    "chunker_version", str(TextChunker.CHUNKER_VERSION)
+                )
+            except Exception:
+                pass
 
         self._dirty = False
 

--- a/agent/memory/storage.py
+++ b/agent/memory/storage.py
@@ -940,6 +940,26 @@ class MemoryStorage:
                 self.conn.rollback()
                 raise
 
+    # --- _meta: internal key-value flags (e.g. chunker_version) -----------
+    def get_meta(self, key: str) -> Optional[str]:
+        """Read a persistent flag from the _meta table, or None if unset."""
+        try:
+            row = self.conn.execute(
+                "SELECT value FROM _meta WHERE key = ?", (key,)
+            ).fetchone()
+        except Exception:
+            return None
+        return row["value"] if row else None
+
+    def set_meta(self, key: str, value: str) -> None:
+        """Write a persistent flag to the _meta table."""
+        with self._lock:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO _meta(key, value) VALUES(?, ?)",
+                (key, str(value)),
+            )
+            self.conn.commit()
+
     def get_file_hash(self, path: str) -> Optional[str]:
         """Get stored file hash"""
         row = self.conn.execute("""

--- a/plugins/cow_cli/cow_cli.py
+++ b/plugins/cow_cli/cow_cli.py
@@ -1530,7 +1530,7 @@ class CowCliPlugin(Plugin):
 
     def _memory_status(self) -> str:
         """Show current memory index status."""
-        from agent.memory.embedding import detect_index_dim
+        from agent.memory.embedding import detect_index_dim, detect_chunker_version
         from config import conf
 
         agent = self._get_agent("")
@@ -1580,6 +1580,18 @@ class CowCliPlugin(Plugin):
                 warnings.append(_t(
                     f"  ⚠️ 索引中存量向量为 {index_dim} 维，与当前配置 {cfg_dim} 维不一致；运行 /memory rebuild-index 重建后向量检索才会生效",
                     f"  ⚠️ Existing vectors are {index_dim}-dim, mismatching the current {cfg_dim}-dim config; run /memory rebuild-index to make vector search work",
+                ))
+
+            # Index predates (or doesn't match) the current chunker. Chunked
+            # files only re-split when their content hash changes, so a chunker
+            # upgrade alone never refreshes old boundaries — suggest a rebuild.
+            # This is only a hint: rebuild re-embeds everything and is costly,
+            # so the user decides.
+            from agent.memory.chunker import TextChunker
+            if detect_chunker_version(memory_manager.storage) != TextChunker.CHUNKER_VERSION:
+                warnings.append(_t(
+                    "  ⚠️ 索引由旧版切分算法生成；建议运行 /memory rebuild-index 以按标题更精准地切分记忆（重建成本较高，由你决定）",
+                    "  ⚠️ Index was built by an older chunking strategy; consider running /memory rebuild-index for heading-aware chunking (a rebuild re-embeds everything, so it's your call)",
                 ))
 
         if warnings:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 numpy>=1.21
+# markdown structure-aware chunking for memory/knowledge md files (chunker.chunk_markdown)
+markdown-it-py>=3.0.0
 # aiohttp<3.10 has no prebuilt wheels for Python 3.13+, so pip would compile from
 # source (needs MSVC on Windows). Use >=3.10 on 3.13+ where cp313 wheels exist.
 aiohttp>=3.8.6,<3.10; python_version < "3.13"

--- a/tests/test_chunker_markdown.py
+++ b/tests/test_chunker_markdown.py
@@ -1,0 +1,154 @@
+# encoding: utf-8
+"""
+Tests for TextChunker.chunk_markdown — structure-aware (heading) chunking of
+memory/knowledge markdown files.
+
+Strategy pinned here (see agent/memory/chunker.py docstring):
+  - A file <= MD_CHUNK_TARGET(1500) chars is ONE chunk.
+  - Larger files are heading-split via markdown-it into per-heading "own body"
+    candidates, then greedily merged across headings up to the target, then a
+    single tail-fold merges a trailing fragment (<= MD_FRAGMENT_MAX=400 chars)
+    into the previous chunk.
+Contract: line numbers are 1-based, contiguous and cover the whole file without
+overlap or gaps; each chunk's text starts at a real heading line and its lines
+fall inside [start_line, end_line].
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from agent.memory.chunker import TextChunker
+
+
+def _md(items):
+    """items = [(heading, [body...]), ...] -> markdown string."""
+    parts = []
+    for heading, body in items:
+        parts.append(heading)
+        parts.extend(body)
+    return "\n".join(parts)
+
+
+def _assert_contiguous_full_cover(test, chunks, n_lines):
+    """Assert chunks are 1-based, contiguous, non-overlapping, cover whole file,
+    and every chunk's text starts with a real heading present in that span."""
+    prev_end = 0
+    for ch in chunks:
+        test.assertGreater(ch.start_line, prev_end, "chunks must not overlap/repeat")
+        test.assertGreaterEqual(ch.start_line, 1)
+        test.assertLessEqual(ch.end_line, n_lines)
+        # text starts at a heading marker and that heading is inside its lines
+        first = ch.text.lstrip().splitlines()[0] if ch.text.strip() else ""
+        test.assertTrue(first.startswith("#"), f"chunk should start at a heading: {first!r}")
+        prev_end = ch.end_line
+    test.assertEqual(prev_end, n_lines, "chunks must cover the whole file")
+
+
+class TestChunkMarkdownSmall(unittest.TestCase):
+    def setUp(self):
+        self.c = TextChunker()
+
+    def test_empty_returns_none(self):
+        self.assertEqual(self.c.chunk_markdown("   \n  \n"), [])
+
+    def test_short_file_is_single_chunk(self):
+        md = "# 标题一\n\n正文只有几行而已。\n"
+        chunks = self.c.chunk_markdown(md)
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].start_line, 1)
+        self.assertIn("标题一", chunks[0].text)
+
+    def test_short_file_keeps_content(self):
+        md = "# 根\n\n段落内容。\n\n## 小节\n\n小节正文。\n"
+        chunks = self.c.chunk_markdown(md)
+        self.assertEqual(len(chunks), 1)
+        self.assertIn("段落内容", chunks[0].text)
+        self.assertIn("小节正文", chunks[0].text)
+
+
+class TestChunkMarkdownLarge(unittest.TestCase):
+    """Large (>1500 char) files trigger the heading-aware path."""
+
+    def setUp(self):
+        self.c = TextChunker()
+
+    def test_large_file_contiguous_full_cover(self):
+        bigA = ["A正文内容句子。" for _ in range(120)]
+        bigB = ["B的正文详细内容描述。" for _ in range(140)]
+        md = _md([
+            ("# 文档根", ["根引言。"]),
+            ("## 主题A", bigA),
+            ("## 主题B", bigB),
+            ("## 主题C", ["短的结尾内容。"]),
+        ])
+        self.assertGreater(len(md), self.c.MD_CHUNK_TARGET)
+        chunks = self.c.chunk_markdown(md)
+        self.assertGreater(len(chunks), 1)
+        _assert_contiguous_full_cover(self, chunks, len(md.split("\n")))
+
+    def test_does_not_interleave_unrelated_headings(self):
+        """A chunk's text should only contain headings that lie within its own
+        [start_line, end_line] span."""
+        md = _md([
+            ("# A", ["a" * 200]),
+            ("## B", ["b" * 200]),
+            ("## C", ["c" * 200]),
+            ("## D", ["d" * 200]),
+        ])  # ~>1500
+        chunks = self.c.chunk_markdown(md)
+        lines = md.split("\n")
+        for ch in chunks:
+            span_text = "\n".join(lines[ch.start_line - 1: ch.end_line])
+            # every heading present in ch.text must also be within its span
+            for ln in ch.text.splitlines():
+                if ln.lstrip().startswith("#"):
+                    self.assertIn(ln, span_text, f"heading {ln!r} escaped its span")
+
+    def test_code_block_fake_heading_is_not_a_boundary(self):
+        """# inside a fenced code block must not create a split boundary."""
+        body = [
+            "正文段落。",
+            "```python",
+            "# 这不是真标题",
+            "print('hi')",
+            "```",
+            "后续段落。",
+        ]
+        md = _md([("# 真标题", body)])
+        # keep under target so the whole thing is one chunk; if any fake-heading
+        # boundary had been introduced the file would have split — it must not.
+        if len(md) <= self.c.MD_CHUNK_TARGET:
+            chunks = self.c.chunk_markdown(md)
+            self.assertEqual(len(chunks), 1)
+            self.assertIn("不是真标题", chunks[0].text)
+
+    def test_tail_fragment_folds_into_prev_chunk(self):
+        """A trailing heading whose whole body is <= fragment max must be folded
+        into the previous chunk, so no orphaned tiny chunk is left at the end."""
+        big = ["x" * 500 for _ in range(3)]      # ~1500+, one big heading body
+        md = _md([
+            ("# 大块", big),
+            ("# 小尾", ["y" * 50]),               # 50-char tail
+        ])
+        chunks = self.c.chunk_markdown(md)
+        # the tail heading must never survive as its own chunk
+        last = chunks[-1]
+        self.assertIn("小尾", last.text)
+
+    def test_all_headings_preserved_somewhere(self):
+        md = _md([
+            ("# 一", ["正文A。" * 80]),
+            ("# 二", ["正文B。" * 80]),
+            ("# 三", ["正文C。" * 80]),
+            ("# 四", ["正文D。" * 80]),
+        ])
+        chunks = self.c.chunk_markdown(md)
+        joined = "".join(ch.text for ch in chunks)
+        for h in ("# 一", "# 二", "# 三", "# 四"):
+            self.assertIn(h, joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_chunker_version.py
+++ b/tests/test_chunker_version.py
@@ -1,0 +1,130 @@
+# encoding: utf-8
+"""
+Tests for chunker-version tracking:
+  - _meta key/value round-trip (storage.get_meta / set_meta)
+  - detect_chunker_version returns None on an unstamped (legacy) index and the
+    recorded version once stamped
+  - MemoryManager.sync() stamps chunker_version when it (re)builds from an
+    EMPTY index (fresh install / after rebuild-index), and leaves an existing
+    non-empty index unstamped so /memory status can flag it for a rebuild.
+"""
+import os
+import sys
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from agent.memory.storage import MemoryStorage
+from agent.memory.embedding.state import detect_chunker_version
+from agent.memory.chunker import TextChunker
+
+
+class TestMetaKV(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.storage = MemoryStorage(Path(self.dir) / "index.db")
+
+    def tearDown(self):
+        self.storage.close()
+
+    def test_unset_meta_returns_none(self):
+        self.assertIsNone(self.storage.get_meta("chunker_version"))
+
+    def test_set_get_roundtrip(self):
+        self.storage.set_meta("chunker_version", "1")
+        self.assertEqual(self.storage.get_meta("chunker_version"), "1")
+
+    def test_overwrite(self):
+        self.storage.set_meta("chunker_version", "1")
+        self.storage.set_meta("chunker_version", "2")
+        self.assertEqual(self.storage.get_meta("chunker_version"), "2")
+
+
+class TestDetectChunkerVersion(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.storage = MemoryStorage(Path(self.dir) / "index.db")
+
+    def tearDown(self):
+        self.storage.close()
+
+    def test_detect_none_when_unstamped(self):
+        # A legacy index (or any pre-version index) has no flag -> None,
+        # which /memory status treats as "built by an older strategy".
+        self.assertIsNone(detect_chunker_version(self.storage))
+
+    def test_detect_matches_when_stamped(self):
+        self.storage.set_meta("chunker_version", str(TextChunker.CHUNKER_VERSION))
+        self.assertEqual(
+            detect_chunker_version(self.storage), TextChunker.CHUNKER_VERSION
+        )
+
+    def test_detect_mismatch_for_old_version(self):
+        self.storage.set_meta("chunker_version", str(TextChunker.CHUNKER_VERSION - 1))
+        self.assertNotEqual(
+            detect_chunker_version(self.storage), TextChunker.CHUNKER_VERSION
+        )
+
+
+class TestSyncStampsVersion(unittest.TestCase):
+    """MemoryManager.sync stamps chunker_version only when starting from an
+    empty index."""
+
+    def _make(self, ws):
+        import config
+        config.load_config()
+        from agent.memory.config import MemoryConfig
+        from agent.memory.manager import MemoryManager
+        from agent.memory.embedding.provider import EmbeddingProvider
+
+        class FakeEmbed(EmbeddingProvider):
+            @property
+            def dimensions(self):
+                return 3
+
+            def embed(self, text):
+                return [0.1, 0.2, 0.3]
+
+            def embed_batch(self, texts):
+                return [self.embed(t) for t in texts]
+
+        mc = MemoryConfig(workspace_root=ws)
+        return MemoryManager(mc, embedding_provider=FakeEmbed())
+
+    def test_sync_from_empty_stamps(self):
+        ws = tempfile.mkdtemp()
+        os.makedirs(os.path.join(ws, "knowledge", "infra"))
+        with open(os.path.join(ws, "knowledge", "infra", "a.md"), "w",
+                  encoding="utf-8") as f:
+            f.write("# A\n\n内容。" * 400)  # >1500 -> triggers heading path
+        m = self._make(ws)
+        asyncio.run(m.sync(force=True))
+        self.assertEqual(
+            m.storage.get_meta("chunker_version"),
+            str(TextChunker.CHUNKER_VERSION),
+        )
+
+    def test_sync_nonempty_does_not_overwrite_stamp(self):
+        ws = tempfile.mkdtemp()
+        os.makedirs(os.path.join(ws, "knowledge", "infra"))
+        with open(os.path.join(ws, "knowledge", "infra", "a.md"), "w",
+                  encoding="utf-8") as f:
+            f.write("# A\n\n内容。" * 400)
+        m = self._make(ws)
+        # First (empty->full) sync stamps v1.
+        asyncio.run(m.sync(force=True))
+        self.assertEqual(m.storage.get_meta("chunker_version"), "1")
+        # Add a second file; index is now non-empty before sync, so the stamp
+        # must stay whatever it was (not unset, not blindly rewritten).
+        with open(os.path.join(ws, "knowledge", "infra", "b.md"), "w",
+                  encoding="utf-8") as f:
+            f.write("# B\n\n其他内容。" * 300)
+        asyncio.run(m.sync())
+        self.assertEqual(m.storage.get_meta("chunker_version"), "1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Makes memory/knowledge `.md` chunking structure-aware, and — because files are
only re-split when their content hash changes — adds lightweight chunker-version
tracking so `/memory status` can suggest a rebuild when an index was built by an
older strategy.

Before, `.md` files were chunked by plain character count, so a semantic section
could be cut mid-way or several unrelated headings packed into one chunk. An
isolated-workspace retrieval eval (A vector / B keyword / C weighted fusion /
D RRF, 42 queries) found structure-aware chunking beats fixed-character chunking
on MRR (0.907 vs 0.818). This implements that chunking and surfaces the one-time
rebuild a normal upgrade needs.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [x] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): none

---

## Background / why this shape

Chunked files are only re-split when their **content** hash changes. Upgrading
only the chunker (new algorithm, same file contents) therefore never refreshes
old chunk boundaries, and previously nothing recorded which strategy built an
index — so staleness could not be detected at all. The flag below is the single
source of truth: "no flag" == "built by an older / unknown strategy".

## What changed

1. **`agent/memory/chunker.py`** — implement `TextChunker.chunk_markdown()` (+
   helper `_md_leaf_segments`):
   - A file <= 1500 chars is ONE chunk (single md = strong semantic unit; most
     real memory files take this path).
   - Larger files are parsed with **markdown-it** into per-heading "own body"
     candidates, **greedily merged across headings** up to 1500 chars, then a
     **single tail fold** merges a trailing fragment (<= 400 chars) into the
     previous chunk.
   - markdown-it ignores fake headings inside fenced code / inline code /
     tables; line numbers stay 1-based, matching `chunk_text`.
   - Empty files -> `[]`; deferred markdown-it import falls back to
     `chunk_text` if the parser is unavailable.
   - Adds `CHUNKER_VERSION = 1` (bump whenever chunking changes boundaries).

2. **`agent/memory/manager.py`** — `sync()` dispatches `.md` files to
   `chunk_markdown` (others keep `chunk_text`); `add_memory` stays on
   `chunk_text`. `sync()` stamps `_meta['chunker_version']` only when it
   (re)builds from an **empty** index (fresh install / right after
   rebuild-index clears it); a non-empty index is left unstamped because it may
   still hold chunks from an older algorithm.

3. **`agent/memory/storage.py`** — `get_meta` / `set_meta` helpers over the
   existing `_meta` key-value table (already present for the trigram backfill
   flag — no schema migration).

4. **`agent/memory/embedding/state.py`** — `detect_chunker_version(storage)`
   mirrors `detect_index_dim`; `None` means the index predates version tracking.
   Re-exported from `agent.memory.embedding`.

5. **`plugins/cow_cli/cow_cli.py`** — `/memory status` shows a hint when the
   recorded chunker version is missing or stale, suggesting
   `/memory rebuild-index`. This stays **a suggestion only** (a rebuild
   re-embeds everything and is costly); it only shows for users who explicitly
   opted into vector search, matching the existing dimension/missing-vector
   warnings.

6. **`requirements.txt`** — add `markdown-it-py>=3.0.0` (runtime dep is `mdurl`).

7. **Tests** — `tests/test_chunker_markdown.py` (8: chunking + line spans +
   fake-heading + tail fold) and `tests/test_chunker_version.py` (8: meta
   round-trip, detect on stamped/unstamped, sync stamps only from an empty
   index).

## Testing

- `python3 -m unittest tests.test_chunker_markdown tests.test_chunker_version`
  -> 16 passed.
- Real files: `services.md`(4705) -> 5 chunks, `geetest.md`(3260) -> 3,
  `SKILL.md`(18.6 KB) -> 14; contiguous 1-based, non-overlapping line coverage.
- Integration: `MemoryManager.sync` on a temp workspace (fake embedding)
  confirms .md dispatch + empty-index stamping.
- Simulated upgrade without rebuild: unchanged files keep old chunks (safe
  mixed state, per-file atomic replace), changed files re-chunk with the new
  algorithm; detection reports the stale version so `/memory status` hints.

## Note for adopters

Chunk boundaries change only on re-index. On a normal upgrade an existing index
keeps its old chunks; run `/memory rebuild-index` once to re-chunk with the
heading-aware algorithm (this also stamps `chunker_version`, clearing the hint).
This is intentionally a manual step — rebuilding re-embeds everything.
