### PR TITLE
feat: support MCP tool prefixes and Parallel Search setup

### DIFF
--- a/agent/tools/mcp/mcp_tool.py
+++ b/agent/tools/mcp/mcp_tool.py
@@ -8,7 +8,7 @@ class McpTool(BaseTool):
     一个 MCP Server 可以提供多个工具，每个工具对应一个 McpTool 实例。
     """
 
-    def __init__(self, client, tool_schema: dict, server_name: str):
+    def __init__(self, client, tool_schema: dict, server_name: str, name_prefix: str = ""):
         """
         :param client: 该工具所属的 McpClient 实例
         :param tool_schema: MCP 返回的工具描述，格式：
@@ -17,14 +17,16 @@ class McpTool(BaseTool):
         """
         self.client = client
         self.server_name = server_name
-        self.name = tool_schema["name"]
+        # Prefix only the local name; the server still expects its original name.
+        self._remote_name = tool_schema["name"]
+        self.name = name_prefix + self._remote_name
         self.description = tool_schema.get("description", "")
         self.params = tool_schema.get("inputSchema", {})
 
     def execute(self, params: dict) -> ToolResult:
         logger.info(f"[McpTool] server={self.server_name} tool={self.name} params={params}")
         try:
-            result = self.client.call_tool(self.name, params)
+            result = self.client.call_tool(self._remote_name, params)
             return ToolResult.success(result)
         except Exception as e:
             logger.error(f"[McpTool] server={self.server_name} tool={self.name} error: {e}")

--- a/agent/tools/tool_manager.py
+++ b/agent/tools/tool_manager.py
@@ -542,11 +542,14 @@ class ToolManager:
                         tool_name = schema.get("name", "")
                         if not tool_name:
                             continue
-                        mcp_tool = McpTool(client, schema, server_name)
+                        mcp_tool = McpTool(
+                            client, schema, server_name,
+                            name_prefix=cfg.get("tool_name_prefix", ""),
+                        )
                         # Atomic dict assignment is GIL-safe; readers iterate
                         # over a list() snapshot to avoid concurrent mutation.
-                        self._mcp_tool_instances[tool_name] = mcp_tool
-                        added.append(tool_name)
+                        self._mcp_tool_instances[mcp_tool.name] = mcp_tool
+                        added.append(mcp_tool.name)
 
                     # Register client into the shared registry only after its
                     # tools are visible, so callers never see a half-loaded server.

--- a/docs/tools/mcp.mdx
+++ b/docs/tools/mcp.mdx
@@ -38,6 +38,7 @@ Fully compatible with the MCP community standard, identical to Claude Desktop / 
 | `type` | Remote | Remote transport type: `sse` or `streamable-http` (defaults to `sse`) |
 | `headers` | No | Extra HTTP headers for remote requests (e.g. `Authorization`); Streamable HTTP only |
 | `scope` | No | OAuth scope, only for remote servers that require OAuth authorization (optional) |
+| `tool_name_prefix` | No | String prepended to this server's tool names in CowAgent, e.g. `parallel_`. Defaults to an empty string. Include any separator in the prefix. Use a unique prefix to avoid collisions with built-in tools or other servers. |
 | `disabled` | No | When `true`, this server is skipped — handy for temporary disabling |
 
 ### Full Example
@@ -79,6 +80,33 @@ The Agent will:
 
 1. Read the existing MCP config and merge the new server entry, preserving existing ones
 2. Hot-reload the new MCP server, so the corresponding tools become available on the next message
+
+## Parallel Search
+
+[Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp) provides public web search and page extraction without a Parallel account or API key. Add this entry to `mcpServers` in `~/cow/mcp.json`, keeping any existing servers:
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "type": "streamable-http",
+      "url": "https://search.parallel.ai/mcp",
+      "tool_name_prefix": "parallel_",
+      "headers": {
+        "User-Agent": "CowAgent"
+      }
+    }
+  }
+}
+```
+
+Keep `type: "streamable-http"`: a URL alone selects the legacy SSE transport. The prefix exposes `parallel_web_search` and `parallel_web_fetch` without replacing CowAgent's built-in `web_search` and `web_fetch`. Calls still use the original tool names on the server.
+
+The `User-Agent` header identifies CowAgent to the service.
+
+After the next message loads the connection, ask the Agent to use `parallel_web_search` to find a public page, then `parallel_web_fetch` to read it. Once configured, the Agent can select these tools during other tasks too. Queries, requested URLs, and any supplied objectives or context are sent to Parallel. Anonymous access is free but rate limited.
+
+To remove the connection, delete only the `parallel-search` entry and send another message so CowAgent reloads the configuration.
 
 ## Web Authorization (OAuth)
 

--- a/tests/test_mcp_tool_prefix.py
+++ b/tests/test_mcp_tool_prefix.py
@@ -1,0 +1,96 @@
+"""MCP aliases must preserve built-ins and the server's original tool names."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from agent.tools.mcp.mcp_client import McpClient
+from agent.tools.mcp.mcp_tool import McpTool
+from agent.tools.tool_manager import ToolManager
+from agent.tools.web_fetch.web_fetch import WebFetch
+from agent.tools.web_search.web_search import WebSearch
+from config import conf
+
+
+@pytest.fixture
+def manager(tmp_path, monkeypatch):
+    monkeypatch.setitem(conf(), "agent_workspace", str(tmp_path))
+    tm = ToolManager()
+    tm.tool_classes = {"web_search": WebSearch, "web_fetch": WebFetch}
+    monkeypatch.setattr(McpClient, "initialize", lambda self: True)
+    monkeypatch.setattr(McpClient, "list_tools", lambda self: [
+        {"name": name, "description": "Remote tool", "inputSchema": {
+            "type": "object", "properties": {"query": {"type": "string"}},
+        }}
+        for name in ("web_search", "web_fetch")
+    ])
+    yield tm
+    tm.shutdown_mcp()
+
+
+def load_server(manager, **options):
+    from pathlib import Path
+
+    Path(manager.workspace_root, "mcp.json").write_text(json.dumps({
+        "mcpServers": {"search-server": {
+            "type": "streamable-http", "url": "https://example.com/mcp",
+            **options,
+        }},
+    }))
+    manager._load_mcp_tools_async(manager._load_mcp_configs())
+    assert manager.list_mcp_status() == {"search-server": "ready"}
+
+
+@pytest.mark.parametrize("as_dict", [True, False])
+def test_prefixed_tools_coexist_with_builtins_and_dispatch_remote_names(manager, as_dict):
+    load_server(manager, tool_name_prefix="remote_")
+    builtins = [manager.create_tool(name) for name in ("web_search", "web_fetch")]
+    agent = SimpleNamespace(tools={t.name: t for t in builtins} if as_dict else builtins[:])
+
+    assert manager.sync_mcp_into_agent(agent) == (["remote_web_fetch", "remote_web_search"], [])
+    tools = agent.tools if as_dict else {t.name: t for t in agent.tools}
+    assert set(tools) == {"web_search", "web_fetch", "remote_web_search", "remote_web_fetch"}
+    for builtin in builtins:
+        assert tools[builtin.name] is builtin
+        remote = tools["remote_" + builtin.name]
+        assert remote is manager.create_tool(remote.name)
+        assert isinstance(remote, McpTool)
+        assert remote.get_json_schema()["name"] == remote.name
+        assert manager.list_tools()[remote.name]["parameters"] == remote.params
+        remote.client.call_tool = Mock(return_value="remote result")
+        arguments = {"query": "public information"}
+        result = remote.execute(arguments)
+        assert result.status == "success"
+        assert result.result == "remote result"
+        remote.client.call_tool.assert_called_once_with(builtin.name, arguments)
+
+    manager._teardown_mcp_server("search-server")
+    assert manager.sync_mcp_into_agent(agent) == ([], ["remote_web_fetch", "remote_web_search"])
+    remaining = list(agent.tools.values()) if as_dict else agent.tools
+    assert remaining == builtins
+
+
+def test_prefix_change_removes_old_aliases(manager):
+    load_server(manager, tool_name_prefix="first_")
+    builtin = manager.create_tool("web_fetch")
+    agent = SimpleNamespace(tools={"web_fetch": builtin})
+    manager.sync_mcp_into_agent(agent)
+    manager._teardown_mcp_server("search-server")
+    load_server(manager, tool_name_prefix="second_")
+    manager.sync_mcp_into_agent(agent)
+    assert set(agent.tools) == {"web_fetch", "second_web_fetch", "second_web_search"}
+    assert agent.tools["web_fetch"] is builtin
+
+
+@pytest.mark.parametrize("options", [{}, {"tool_name_prefix": ""}])
+def test_omitted_or_empty_prefix_preserves_existing_names(manager, options):
+    load_server(manager, **options)
+    agent = SimpleNamespace(tools={})
+    manager.sync_mcp_into_agent(agent)
+    assert set(agent.tools) == {"web_search", "web_fetch"}
+    tool = agent.tools["web_search"]
+    tool.client.call_tool = Mock(return_value="unchanged")
+    assert tool.execute({}).result == "unchanged"
+    tool.client.call_tool.assert_called_once_with("web_search", {})


### PR DESCRIPTION
## What does this PR do?

Adds Parallel Search as a free MCP option, with no Parallel account or API key needed.

The results that made me want to add it are in [Artificial Analysis's Search API leaderboard](https://artificialanalysis.ai/agents/search-api#details), using its August 31, 2026 data. Parallel Fast scores **80 on DeepSearchQA**, ahead of seven of the eight other providers even when each is shown in its best-scoring mode for that benchmark. It also has the **lowest reported time per task across all 19 products: 19.4 seconds**.

| Search API | DeepSearchQA F1, higher is better | Time per task |
| --- | ---: | ---: |
| **Parallel Fast** | **80** | **19.4s** |
| Perplexity Search (medium) | 81 | 28.8s |
| Brave Search (LLM context) | 78 | 24.3s |
| Exa Search (auto) | 78 | 33.2s |
| You.com Search (highlights) | 77 | 20.7s |
| Firecrawl Search | 74 | 63.2s |
| Tavily Search (basic) | 74 | 46.1s |
| Keenable Search (realtime) | 70 | 22.4s |
| TinyFish Search (web) | 67 | 60.4s |

Each competitor is shown in its highest-scoring DeepSearchQA mode, with ties going to the faster mode. These are [Search API tests](https://artificialanalysis.ai/methodology/search-api), not CowAgent or MCP measurements. Time per task combines derived model time and measured search time. Perplexity leads the overall Search Index at 80 versus Parallel Fast's 73. Fast's research quality and speed make it worth offering here, and the [anonymous MCP connection uses fast mode](https://docs.parallel.ai/integrations/mcp/search-mcp).

CowAgent [only enables built-in search after a provider key is configured](https://github.com/zhayujie/CowAgent/blob/95e906eb8950d74f3dcb5e9410b77bb9e12cec9a/agent/tools/web_search/web_search.py#L89-L194). There isn't an enabled search default on a fresh install. Its automatic order is Bocha, Qianfan, Zhipu, LinkAI, AnySearch, then Serply. Those are API integrations, and none is on this leaderboard, so these numbers don't establish a win over CowAgent's existing backends.

The optional `tool_name_prefix` keeps `parallel_web_search` and `parallel_web_fetch` separate from the built-in tools. Remote calls keep their original names, as do existing configurations. The setup example includes `User-Agent: CowAgent`, which resolved the service's rejection of Python's default user agent. It also explains removal, rate limits, and the queries, URLs, and context sent to Parallel when the Agent uses it.

Validation: 29 focused tests passed across `test_mcp_tool_prefix.py`, `test_mcp_session_recovery.py`, and `test_mcp_tool_retrieval.py`. The new collision and prefix-change tests fail on the unmodified base. A live check loaded the documented JSON through `ToolManager`, discovered both tools, searched and fetched through `McpTool`, and kept the real built-in search/fetch instances intact. No Parallel credentials were supplied. The full app and documentation build were not run.

I work at Parallel, which operates this service.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- Related issue: none
