### PR TITLE
fix(web): scope workspace selector default-workspace hint to active Agent

### DIFF
--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -4410,7 +4410,12 @@ function _wsToast(msg) {
 async function refreshWorkspaceSelector() {
     const label = document.getElementById('workspace-selector-label');
     try {
-        const res = await fetch(`/api/projects?session=${encodeURIComponent(sessionId)}`);
+        // Scope the request to the active Agent so the default-workspace hint
+        // matches the file panel's real root in multi-Agent setups.
+        let url = `/api/projects?session=${encodeURIComponent(sessionId)}`;
+        const aid = (typeof activeAgentId !== 'undefined') ? activeAgentId : '';
+        if (aid) url += `&agent=${encodeURIComponent(aid)}`;
+        const res = await fetch(url);
         const data = await res.json();
         if (data.status !== 'success') return;
         _wsSelState = {

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -8012,12 +8012,17 @@ def _project_state(session_id: str, agent_id: str = None) -> dict:
     from common.state_dir import state_root_str
 
     current = project_store.get_project_dir(session_id, agent_id) if session_id else None
+    # Resolve the default workspace against the Agent this session belongs to,
+    # so the selector hint matches the file panel's real root in multi-Agent
+    # setups instead of always pointing at the default Agent's workspace.
+    from common.runtime_identity import RuntimeIdentity
+    default_workspace = state_root_str(RuntimeIdentity(agent_id=agent_id))
     return {
         "current": (
             {"path": current, "name": os.path.basename(current) or current}
             if current else None
         ),
-        "default_workspace": state_root_str(),
+        "default_workspace": default_workspace,
         "projects_root": project_store.projects_root(),
         "recents": project_store.list_recents(),
     }


### PR DESCRIPTION
## Summary

Fixes #3117 — the workspace selector's "default workspace" hint pointed at the default Agent's workspace in multi-Agent setups, while the session actually operates under the selected Agent's own workspace.

## Root cause

- **Frontend** (`console.js`): `refreshWorkspaceSelector()` called `/api/projects?session=...` without the active Agent id.
- **Backend** (`web_channel.py`): `_project_state()` computed `default_workspace` with the no-arg `state_root_str()`, which resolves to the default Agent's workspace regardless of the session's Agent.

Meanwhile the real working root (`_get_workspace_root()`) correctly honors the active Agent, so the hint and the file panel disagreed.

## Changes

- **`channel/web/static/js/console.js`**: include `&agent=<activeAgentId>` in the `/api/projects` request so the hint is scoped to the active Agent.
- **`channel/web/web_channel.py`**: resolve `default_workspace` per Agent via `state_root_str(RuntimeIdentity(agent_id=agent_id))`.

Single-Agent installs are unaffected: when `agent_id` is unset, `state_root_str(RuntimeIdentity(agent_id=None))` falls back to the default Agent's workspace, identical to the previous no-arg call.

## Verification

- `python3 -c "import ast; ast.parse(...)"` passes on `web_channel.py`.
- `node --check` passes on `console.js`.
- Traced `state_root()` in `common/state_dir.py`: absent `agent_id` resolves to `registry.get(require_enabled=False).workspace` (the default Agent), so the no-Agent path is unchanged.
