### PR TITLE
feat: 集成 AnySearch 搜索后端，支持匿名模式

### DIFF
--- a/agent/tools/web_search/web_search.py
+++ b/agent/tools/web_search/web_search.py
@@ -56,6 +56,7 @@ PROVIDER_LABELS = {
 
 def _tools_web_search_conf() -> dict:
     """Return the tools.web_search config block (dict-like)."""
+    
     tools_cfg = conf().get("tools") or {}
     if not isinstance(tools_cfg, dict):
         return {}

--- a/agent/tools/web_search/web_search.py
+++ b/agent/tools/web_search/web_search.py
@@ -8,15 +8,9 @@
 
 Provider selection
   - strategy 'auto' (default): pick the first configured provider in the
-<<<<<<< Updated upstream
     canonical order [bocha, qianfan, zhipu, linkai, anysearch, serply]. When
     the caller passes an explicit `provider` it overrides the pick; an
     invalid/unconfigured one silently falls back to the auto order.
-=======
-    canonical order [bocha, zhipu, qianfan, linkai , anysearch]. When the caller passes
-    an explicit `provider` it overrides the pick; an invalid/unconfigured
-    one silently falls back to the auto order.
->>>>>>> Stashed changes
   - strategy 'fixed': use the configured provider; if its credential is
     missing at call time, silently fall back to auto order (no card hint).
 
@@ -270,13 +264,9 @@ class WebSearch(BaseTool):
             if provider == "linkai":
                 return self._search_linkai(query, count, freshness)
             if provider == "anysearch":
-<<<<<<< Updated upstream
-                return self._search_anysearch(query, count)
+                return self._search_anysearch(query, count, freshness, summary)
             if provider == "serply":
                 return self._search_serply(query, count)
-=======
-                return self._search_anysearch(query, count, freshness, summary)
->>>>>>> Stashed changes
             return ToolResult.fail(f"Error: Unknown provider '{provider}'")
         except requests.Timeout:
             return ToolResult.fail(f"Error: Search request timed out after {DEFAULT_TIMEOUT}s")
@@ -582,11 +572,23 @@ class WebSearch(BaseTool):
                 "snippet": it.get("snippet") or (it.get("content") or "")[:200],
             })
         total = (body.get("metadata") or {}).get("total_results", len(results))
-<<<<<<< Updated upstream
-        return ToolResult.success({
-            "query": query, "backend": "anysearch",
-            "total": total, "count": len(results), "results": results,
-        })
+        request_id = resp.headers.get("X-Request-ID") or data.get("request_id")
+        meta = body.get("metadata") or {}
+
+        result = {
+            "query": query,
+            "backend": "anysearch",
+            "total": total,
+            "count": len(results),
+            "results": results,
+        }
+
+        if request_id:
+            result["request_id"] = request_id
+        if meta.get("search_time_ms") is not None:
+            result["search_time_ms"] = meta["search_time_ms"]
+
+        return ToolResult.success(result)
 
     # ------------------------------------------------------------------
     # Serply
@@ -626,22 +628,4 @@ class WebSearch(BaseTool):
             "query": query, "backend": "serply",
             "total": len(results), "count": len(results), "results": results,
         })
-=======
-        request_id = resp.headers.get("X-Request-ID") or data.get("request_id")
-        meta = body.get("metadata") or {}
 
-        result = {
-            "query": query,
-            "backend": "anysearch",
-            "total": total,
-            "count": len(results),
-            "results": results,
-        }
-
-        if request_id:
-            result["request_id"] = request_id
-        if meta.get("search_time_ms") is not None:
-            result["search_time_ms"] = meta["search_time_ms"]
-
-        return ToolResult.success(result)
->>>>>>> Stashed changes

--- a/agent/tools/web_search/web_search.py
+++ b/agent/tools/web_search/web_search.py
@@ -8,9 +8,15 @@
 
 Provider selection
   - strategy 'auto' (default): pick the first configured provider in the
+<<<<<<< Updated upstream
     canonical order [bocha, qianfan, zhipu, linkai, anysearch, serply]. When
     the caller passes an explicit `provider` it overrides the pick; an
     invalid/unconfigured one silently falls back to the auto order.
+=======
+    canonical order [bocha, zhipu, qianfan, linkai , anysearch]. When the caller passes
+    an explicit `provider` it overrides the pick; an invalid/unconfigured
+    one silently falls back to the auto order.
+>>>>>>> Stashed changes
   - strategy 'fixed': use the configured provider; if its credential is
     missing at call time, silently fall back to auto order (no card hint).
 
@@ -86,10 +92,20 @@ def _get_api_key(provider: str) -> str:
     return ""
 
 
-def configured_providers() -> List[str]:
-    """Return configured providers in canonical order."""
-    return [p for p in PROVIDER_ORDER if _get_api_key(p)]
+def _anysearch_anonymous_enabled() -> bool:
+    """Check if AnySearch anonymous mode is enabled via config."""
+    return bool(_tools_web_search_conf().get("anysearch_anonymous"))
 
+def configured_providers() -> List[str]:
+    """Configured providers in canonical order. anysearch qualifies with a
+    real key OR an explicit anonymous opt-in (still last in fallback order)."""
+    result = []
+    for p in PROVIDER_ORDER:
+        if _get_api_key(p):
+            result.append(p)
+        elif p == "anysearch" and _anysearch_anonymous_enabled():
+            result.append(p)
+    return result
 
 def _configured_strategy() -> str:
     return (_tools_web_search_conf().get("strategy") or "auto").strip().lower()
@@ -121,12 +137,14 @@ class WebSearch(BaseTool):
                 "description": (
                     "Time range filter. Options: "
                     "'noLimit' (default), 'oneDay', 'oneWeek', 'oneMonth', 'oneYear', "
-                    "or date range like '2025-01-01..2025-02-01'"
+                    "or date range like '2025-01-01..2025-02-01'. "
+                    "Honored by bocha/zhipu/qianfan/linkai; ignored by anysearch."
                 )
             },
             "summary": {
                 "type": "boolean",
-                "description": "Whether to include text summary for each result (default: false)"
+                "description": "Whether to include text summary for each result (default: false). "
+                               "Bocha/linkai only; ignored by anysearch."
             }
         },
         "required": ["query"]
@@ -173,6 +191,8 @@ class WebSearch(BaseTool):
         Priority: caller-supplied (if configured) > fixed strategy (if
         configured) > first configured in PROVIDER_ORDER. Silent fallback
         when the desired one has no key.
+
+        For anysearch: considered "available" even without a key (anonymous).
         """
         available = configured_providers()
         if not available:
@@ -191,6 +211,7 @@ class WebSearch(BaseTool):
             if pinned:
                 logger.warning(f"[WebSearch] pinned provider '{pinned}' unavailable, falling back to auto")
 
+        # anysearch 始终在 available 中，所以会作为末位 fallback
         return available[0]
 
     @staticmethod
@@ -220,6 +241,8 @@ class WebSearch(BaseTool):
 
         requested = args.get("provider")
         provider = self._resolve_provider(requested)
+        # This branch is technically unreachable because anysearch is always available
+        # (anonymous tier). It's kept as a defensive guard for future modifications.
         if not provider:
             return ToolResult.fail(
                 "Error: No search provider configured. "
@@ -247,9 +270,13 @@ class WebSearch(BaseTool):
             if provider == "linkai":
                 return self._search_linkai(query, count, freshness)
             if provider == "anysearch":
+<<<<<<< Updated upstream
                 return self._search_anysearch(query, count)
             if provider == "serply":
                 return self._search_serply(query, count)
+=======
+                return self._search_anysearch(query, count, freshness, summary)
+>>>>>>> Stashed changes
             return ToolResult.fail(f"Error: Unknown provider '{provider}'")
         except requests.Timeout:
             return ToolResult.fail(f"Error: Search request timed out after {DEFAULT_TIMEOUT}s")
@@ -504,7 +531,11 @@ class WebSearch(BaseTool):
             "total": 1, "count": 1, "results": [{"content": str(raw)}],
         })
 
-    def _search_anysearch(self, query: str, count: int) -> ToolResult:
+    def _search_anysearch(self, query: str, count: int, freshness: str = "noLimit", summary: bool = False) -> ToolResult:
+        if freshness and freshness != "noLimit":
+            logger.warning(f"[WebSearch] anysearch does not support freshness ({freshness!r}); ignoring")
+        if summary:
+            logger.warning("[WebSearch] anysearch does not support summary; ignoring")
         api_key = _get_api_key("anysearch")
         url = "https://api.anysearch.com/v1/search"
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
@@ -513,24 +544,30 @@ class WebSearch(BaseTool):
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
-        # AnySearch accepts 1-20 results; the shared tool schema allows 1-50.
-        max_results = max(1, min(int(count or 10), 20))
+        # AnySearch accepts 1-10 results; the shared tool schema allows 1-10.
+        max_results = max(1, min(int(count or 10), 10))
         payload = {"query": query, "max_results": max_results, "format": "json"}
 
-        logger.debug(f"[WebSearch] anysearch: query='{query}', max_results={max_results}")
+        logger.debug(f"[WebSearch] anysearch: query='{query}', max_results={max_results}, has_key={bool(api_key)}")
         resp = requests.post(url, headers=headers, json=payload, timeout=DEFAULT_TIMEOUT)
 
         if resp.status_code == 401:
-            return ToolResult.fail("Error: Invalid AnySearch API key.")
+            if api_key:
+                return ToolResult.fail("Error: Invalid AnySearch API key.")
+            return ToolResult.fail(
+                "Error: AnySearch authentication failed. Try configuring an API key at https://anysearch.com")
         if resp.status_code == 402:
-            return ToolResult.fail("Error: AnySearch quota exhausted. Check usage at https://anysearch.com")
+            if api_key:
+                return ToolResult.fail("Error: AnySearch quota exhausted. Check usage at https://anysearch.com")
+            return ToolResult.fail(
+                "Error: AnySearch anonymous quota exhausted. Configure an API key at https://anysearch.com for higher limits.")
         if resp.status_code == 429:
             return ToolResult.fail("Error: AnySearch API rate limit reached.")
         if resp.status_code != 200:
             return ToolResult.fail(f"Error: AnySearch API returned HTTP {resp.status_code}")
 
         data = resp.json()
-        # AnySearch signals success with business code 0 (not 200).
+        # AnySearch signals success with business code 0.
         api_code = data.get("code")
         if api_code not in (0, None):
             msg = data.get("message") or "Unknown error"
@@ -545,6 +582,7 @@ class WebSearch(BaseTool):
                 "snippet": it.get("snippet") or (it.get("content") or "")[:200],
             })
         total = (body.get("metadata") or {}).get("total_results", len(results))
+<<<<<<< Updated upstream
         return ToolResult.success({
             "query": query, "backend": "anysearch",
             "total": total, "count": len(results), "results": results,
@@ -588,3 +626,22 @@ class WebSearch(BaseTool):
             "query": query, "backend": "serply",
             "total": len(results), "count": len(results), "results": results,
         })
+=======
+        request_id = resp.headers.get("X-Request-ID") or data.get("request_id")
+        meta = body.get("metadata") or {}
+
+        result = {
+            "query": query,
+            "backend": "anysearch",
+            "total": total,
+            "count": len(results),
+            "results": results,
+        }
+
+        if request_id:
+            result["request_id"] = request_id
+        if meta.get("search_time_ms") is not None:
+            result["search_time_ms"] = meta["search_time_ms"]
+
+        return ToolResult.success(result)
+>>>>>>> Stashed changes

--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -155,14 +155,11 @@ const I18N = {
         models_search_bocha_desc: '前往博查开放平台创建 API Key',
         models_search_anysearch_title: '配置 AnySearch API Key',
         models_search_anysearch_desc: '前往 anysearch.com 控制台创建 API Key。',
-<<<<<<< Updated upstream
         models_search_serply_title: '配置 Serply API Key',
         models_search_serply_desc: '前往 serply.io 控制台创建 API Key。',
-=======
         models_search_anysearch_anon_hint: '留空可启用匿名模式（无需 API Key）',
         models_search_anonymous_badge: '匿名',
         models_search_anonymous_disable: '停用匿名',
->>>>>>> Stashed changes
         models_search_edit_hint: '点击修改配置',
         models_unavailable: '不可用',
         models_set_via_env: '通过环境变量启用',
@@ -607,14 +604,11 @@ const I18N = {
         models_search_bocha_desc: '前往博查開放平臺建立 API Key',
         models_search_anysearch_title: '設定 AnySearch API Key',
         models_search_anysearch_desc: '前往 anysearch.com 控制台建立 API Key',
-<<<<<<< Updated upstream
         models_search_serply_title: '設定 Serply API Key',
         models_search_serply_desc: '前往 serply.io 控制台建立 API Key',
-=======
         models_search_anysearch_anon_hint: '留空可啟用匿名模式（無需 API Key）',
         models_search_anonymous_badge: '匿名',
         models_search_anonymous_disable: '停用匿名',
->>>>>>> Stashed changes
         models_search_edit_hint: '點選修改設定',
         models_unavailable: '不可用',
         models_set_via_env: '透過環境變數啟用',
@@ -1054,14 +1048,11 @@ const I18N = {
         models_search_bocha_desc: 'Create a key at the Bocha open platform.',
         models_search_anysearch_title: 'Configure AnySearch API Key',
         models_search_anysearch_desc: 'Create a key at the AnySearch console (anysearch.com).',
-<<<<<<< Updated upstream
         models_search_serply_title: 'Configure Serply API Key',
         models_search_serply_desc: 'Create a key at the Serply console (serply.io).',
-=======
         models_search_anysearch_anon_hint: 'Leave empty to enable anonymous mode (no API key required)',
         models_search_anonymous_badge: 'anonymous',
         models_search_anonymous_disable: 'Disable anonymous',
->>>>>>> Stashed changes
         models_search_edit_hint: 'Click to edit',
         models_unavailable: 'unavailable',
         models_set_via_env: 'enable via environment variable',

--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -155,8 +155,14 @@ const I18N = {
         models_search_bocha_desc: '前往博查开放平台创建 API Key',
         models_search_anysearch_title: '配置 AnySearch API Key',
         models_search_anysearch_desc: '前往 anysearch.com 控制台创建 API Key。',
+<<<<<<< Updated upstream
         models_search_serply_title: '配置 Serply API Key',
         models_search_serply_desc: '前往 serply.io 控制台创建 API Key。',
+=======
+        models_search_anysearch_anon_hint: '留空可启用匿名模式（无需 API Key）',
+        models_search_anonymous_badge: '匿名',
+        models_search_anonymous_disable: '停用匿名',
+>>>>>>> Stashed changes
         models_search_edit_hint: '点击修改配置',
         models_unavailable: '不可用',
         models_set_via_env: '通过环境变量启用',
@@ -601,8 +607,14 @@ const I18N = {
         models_search_bocha_desc: '前往博查開放平臺建立 API Key',
         models_search_anysearch_title: '設定 AnySearch API Key',
         models_search_anysearch_desc: '前往 anysearch.com 控制台建立 API Key',
+<<<<<<< Updated upstream
         models_search_serply_title: '設定 Serply API Key',
         models_search_serply_desc: '前往 serply.io 控制台建立 API Key',
+=======
+        models_search_anysearch_anon_hint: '留空可啟用匿名模式（無需 API Key）',
+        models_search_anonymous_badge: '匿名',
+        models_search_anonymous_disable: '停用匿名',
+>>>>>>> Stashed changes
         models_search_edit_hint: '點選修改設定',
         models_unavailable: '不可用',
         models_set_via_env: '透過環境變數啟用',
@@ -1042,8 +1054,14 @@ const I18N = {
         models_search_bocha_desc: 'Create a key at the Bocha open platform.',
         models_search_anysearch_title: 'Configure AnySearch API Key',
         models_search_anysearch_desc: 'Create a key at the AnySearch console (anysearch.com).',
+<<<<<<< Updated upstream
         models_search_serply_title: 'Configure Serply API Key',
         models_search_serply_desc: 'Create a key at the Serply console (serply.io).',
+=======
+        models_search_anysearch_anon_hint: 'Leave empty to enable anonymous mode (no API key required)',
+        models_search_anonymous_badge: 'anonymous',
+        models_search_anonymous_disable: 'Disable anonymous',
+>>>>>>> Stashed changes
         models_search_edit_hint: 'Click to edit',
         models_unavailable: 'unavailable',
         models_set_via_env: 'enable via environment variable',
@@ -10421,6 +10439,7 @@ function _renderSearchSummary(body, cap) {
     if (!host) return;
     const providers = cap.providers || [];
     const configured = providers.filter(p => p.configured);
+
     const missing = providers.filter(p => !p.configured);
 
     const addBtn = missing.length
@@ -10447,7 +10466,7 @@ function _renderSearchSummary(body, cap) {
                     class="inline-flex items-center gap-1 px-2 py-0.5 text-[11px] rounded-md cursor-pointer
                            bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400
                            hover:bg-emerald-100 dark:hover:bg-emerald-900/50 transition-colors">
-                <i class="fas fa-check text-[10px]"></i>${escapeHtml(localizedLabel(p.label))}
+                <i class="fas fa-check text-[10px]"></i>${escapeHtml(localizedLabel(p.label))}${p.anonymous ? ` · ${t('models_search_anonymous_badge')}` : ''}
             </button>
         `).join('');
         host.innerHTML = `
@@ -10535,10 +10554,12 @@ function _launchSearchProviderConfig(providerId, providerMeta) {
     }
 }
 
+
 function saveSearchCapability() {
     const strategyDd = document.getElementById('cap-search-strategy');
     const providerDd = document.getElementById('cap-search-provider');
-    const strategy = strategyDd ? getDropdownValue(strategyDd) : 'auto';
+    // 如果策略下拉框的值是空（待配置），默认使用 'auto'
+    const strategy = strategyDd ? (getDropdownValue(strategyDd) || 'auto') : 'auto';
     const provider = (strategy === 'fixed' && providerDd) ? getDropdownValue(providerDd) : '';
 
     fetch('/api/models', {
@@ -10555,34 +10576,43 @@ function saveSearchCapability() {
             showStatus('cap-search-status', 'models_save_success', false);
             setTimeout(() => loadModelsView({ preserveScroll: true }), 400);
         } else {
+            console.log('[saveSearchCapability] Error:', data.message);
             showStatus('cap-search-status', 'models_save_failed', true);
         }
     }).catch(() => showStatus('cap-search-status', 'models_save_failed', true));
 }
+
 
 // Minimal bocha API-key modal. Reuses the existing vendor-modal markup
 // helpers would be nice, but bocha isn't in PROVIDER_MODELS (it's not a
 // model vendor), so we render a tiny dedicated dialog.
 // For search vendors that hold their own keys.
 
+
 function openSearchKeyModal(providerId, providerMeta) {
     const existing = document.getElementById('search-key-modal');
     if (existing) existing.remove();
 
+    const searchCap = (modelsState && modelsState.capabilities && modelsState.capabilities.search) || {};
+    const prov = (searchCap.providers || []).find(p => p.id === providerId);
     let masked = (providerMeta && providerMeta.api_key_masked) || '';
-    if (!masked) {
-        const searchCap = (modelsState && modelsState.capabilities && modelsState.capabilities.search) || {};
-        const bocha = (searchCap.providers || []).find(p => p.id === providerId);
-        if (bocha && bocha.api_key_masked) masked = bocha.api_key_masked;
-    }
+    if (!masked && prov && prov.api_key_masked) masked = prov.api_key_masked;
     const hasKey = !!masked;
-    const clearBtnHtml = hasKey
+    const isAnonymous = providerId === 'anysearch' && !!((providerMeta && providerMeta.anonymous) || (prov && prov.anonymous));
+    const clearBtnHtml = (hasKey || isAnonymous)
         ? `<button type="button" id="search-key-clear"
                   class="px-3 py-1.5 rounded-md text-xs text-red-500 dark:text-red-400
                          hover:bg-red-50 dark:hover:bg-red-900/20 cursor-pointer transition-colors">
               ${t('models_clear_credential')}
            </button>`
         : '';
+    let descText = t('models_search_' + providerId + '_desc');
+    if (providerId === 'anysearch') {
+        const hint = currentLang === 'zh'
+            ? '（留空可启用匿名模式，每日有免费额度）'
+            : '(Leave blank to enable anonymous mode with daily free quota)';
+        descText = descText + ' ' + hint;
+    }
 
     const modal = document.createElement('div');
     modal.id = 'search-key-modal';
@@ -10592,7 +10622,7 @@ function openSearchKeyModal(providerId, providerMeta) {
              class="bg-white dark:bg-[#1A1A1A] rounded-xl border border-slate-200 dark:border-white/10
                     w-full max-w-md mx-4 p-6 shadow-xl">
             <h3 class="text-lg font-semibold text-slate-800 dark:text-slate-100 mb-1">${t('models_search_' + providerId + '_title')}</h3>
-            <p class="text-xs text-slate-500 dark:text-slate-400 mb-4">${t('models_search_' + providerId + '_desc')}</p>
+            <p class="text-xs text-slate-500 dark:text-slate-400 mb-4">${descText}</p>
             <label class="block text-sm font-medium text-slate-600 dark:text-slate-400 mb-1.5">API Key</label>
             <input id="search-key-input" type="text" autocomplete="off" data-1p-ignore data-lpignore="true"
                    class="w-full px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-600
@@ -10653,16 +10683,37 @@ function openSearchKeyModal(providerId, providerMeta) {
     document.addEventListener('keydown', onKey);
 }
 
+
 function _saveSearchKey(providerId) {
     const input = document.getElementById('search-key-input');
     if (!input) return;
-    // Untouched masked value => no change requested; close silently.
     if (input.dataset.masked === '1') {
         const modal = document.getElementById('search-key-modal');
         if (modal) modal.remove();
         return;
     }
     const apiKey = input.value.trim();
+
+    if (providerId === 'anysearch') {
+    fetch('/api/models', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            action: 'set_search_credential',
+            provider: providerId,
+            api_key: apiKey,
+            anonymous: !apiKey, // ← 字段名必须是 anonymous；留空保存 = 启用匿名（表第 2 行）
+        }),
+    }).then(r => r.json()).then(data => {
+        if (data.status === 'success') {
+            const modal = document.getElementById('search-key-modal');
+            if (modal) modal.remove();
+            loadModelsView({ preserveScroll: true });
+        }
+    });
+    return;
+}
+
     if (!apiKey) {
         input.focus();
         return;

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -4099,7 +4099,11 @@ class ModelsHandler:
 
     # Canonical search provider order. Mirrors PROVIDER_ORDER in
     # agent/tools/web_search/web_search.py — keep them in sync.
+<<<<<<< Updated upstream
     _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply")
+=======
+    _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai", "anysearch")
+>>>>>>> Stashed changes
 
     _SEARCH_PROVIDER_LABELS = {
         "bocha":   {"zh": "博查", "en": "Bocha"},
@@ -4146,19 +4150,30 @@ class ModelsHandler:
         if not isinstance(ws_cfg, dict):
             ws_cfg = {}
 
+        anonymous_on = bool(ws_cfg.get("anysearch_anonymous"))
         providers = []
         configured_ids = []
         for pid in cls._SEARCH_PROVIDERS:
-            ok = cls._is_real_key(cls._search_provider_key(pid, local_config))
-            raw_key = cls._search_provider_key(pid, local_config) if ok else ""
+            raw_key = cls._search_provider_key(pid, local_config)
+            if pid == "anysearch":
+                # AnySearch: real key, or an explicit anonymous opt-in.
+                ok = cls._is_real_key(raw_key) or anonymous_on
+            else:
+                ok = cls._is_real_key(raw_key)
             providers.append({
                 "id": pid,
                 "label": cls._SEARCH_PROVIDER_LABELS.get(pid, pid),
                 "configured": ok,
+<<<<<<< Updated upstream
                 # bocha owns its key under tools.web_search; the other three
                 # piggy-back on a model-vendor credential. Frontend uses
                 # this hint to decide which credential editor to surface.
                 "needs_dedicated_key": pid in ("bocha", "anysearch", "serply"),
+=======
+                # Lets the frontend badge "匿名/anonymous" only in anonymous mode.
+                "anonymous": pid == "anysearch" and ok and not raw_key,
+                "needs_dedicated_key": pid in ("bocha", "anysearch"),
+>>>>>>> Stashed changes
                 "api_key_masked": ConfigHandler._mask_key(raw_key) if raw_key else "",
             })
             if ok:
@@ -5107,15 +5122,37 @@ class ModelsHandler:
         provider = (data.get("provider") or "bocha").strip().lower()
         if provider not in ("bocha", "anysearch", "serply"):
             return json.dumps({"status": "error", "message": f"unsupported search provider: {provider!r}"})
-        key_field = f"{provider}_api_key"
-        api_key = (data.get("api_key") or "").strip() if isinstance(data.get("api_key"), str) else ""
-        local_config = conf()
-        file_cfg = self._read_file_config()
-        self._set_nested_namespace_value(local_config, "tools", "web_search", key_field, api_key)
-        self._set_nested_namespace_value(file_cfg, "tools", "web_search", key_field, api_key)
-        self._write_file_config(file_cfg)
-        logger.info(f"[ModelsHandler] search credential set: {key_field}={'***' if api_key else ''}")
-        return json.dumps({"status": "success", "provider": provider})
+
+        if provider == "anysearch":
+            anonymous = data.get("anonymous", False)
+
+            api_key = (data.get("api_key") or "").strip() if isinstance(data.get("api_key"), str) else ""
+
+            local_config = conf()
+            file_cfg = self._read_file_config()
+
+            self._set_nested_namespace_value(local_config, "tools", "web_search", "anysearch_api_key", api_key)
+            self._set_nested_namespace_value(file_cfg, "tools", "web_search", "anysearch_api_key", api_key)
+
+            self._set_nested_namespace_value(local_config, "tools", "web_search", "anysearch_anonymous",
+                                             bool(anonymous and not api_key))
+            self._set_nested_namespace_value(file_cfg, "tools", "web_search", "anysearch_anonymous",
+                                             bool(anonymous and not api_key))
+
+            self._write_file_config(file_cfg)
+            logger.info(
+                f"[ModelsHandler] search credential set: anysearch_api_key={'***' if api_key else ''}, anonymous={bool(anonymous and not api_key)}")
+            return json.dumps({"status": "success", "provider": provider})
+        else:
+            key_field = f"{provider}_api_key"
+            api_key = (data.get("api_key") or "").strip() if isinstance(data.get("api_key"), str) else ""
+            local_config = conf()
+            file_cfg = self._read_file_config()
+            self._set_nested_namespace_value(local_config, "tools", "web_search", key_field, api_key)
+            self._set_nested_namespace_value(file_cfg, "tools", "web_search", key_field, api_key)
+            self._write_file_config(file_cfg)
+            logger.info(f"[ModelsHandler] search credential set: {key_field}={'***' if api_key else ''}")
+            return json.dumps({"status": "success", "provider": provider})
 
     @staticmethod
     def _reset_bridge() -> None:

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -4099,11 +4099,7 @@ class ModelsHandler:
 
     # Canonical search provider order. Mirrors PROVIDER_ORDER in
     # agent/tools/web_search/web_search.py — keep them in sync.
-<<<<<<< Updated upstream
     _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply")
-=======
-    _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai", "anysearch")
->>>>>>> Stashed changes
 
     _SEARCH_PROVIDER_LABELS = {
         "bocha":   {"zh": "博查", "en": "Bocha"},
@@ -4164,16 +4160,12 @@ class ModelsHandler:
                 "id": pid,
                 "label": cls._SEARCH_PROVIDER_LABELS.get(pid, pid),
                 "configured": ok,
-<<<<<<< Updated upstream
                 # bocha owns its key under tools.web_search; the other three
                 # piggy-back on a model-vendor credential. Frontend uses
                 # this hint to decide which credential editor to surface.
-                "needs_dedicated_key": pid in ("bocha", "anysearch", "serply"),
-=======
                 # Lets the frontend badge "匿名/anonymous" only in anonymous mode.
                 "anonymous": pid == "anysearch" and ok and not raw_key,
-                "needs_dedicated_key": pid in ("bocha", "anysearch"),
->>>>>>> Stashed changes
+                "needs_dedicated_key": pid in ("bocha", "anysearch", "serply"),
                 "api_key_masked": ConfigHandler._mask_key(raw_key) if raw_key else "",
             })
             if ok:

--- a/docs/ja/tools/web-search.mdx
+++ b/docs/ja/tools/web-search.mdx
@@ -17,16 +17,10 @@ description: インターネットからリアルタイム情報を検索。複�
 | 百度 Qianfan | `qianfan_api_key` を再利用 | [Qianfan コンソール](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | 智谱 Zhipu | `zhipu_ai_api_key` を再利用 | [Zhipu Open Platform](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | `linkai_api_key` を再利用 | [LinkAI コンソール](https://link-ai.tech/console/interface) |
-<<<<<<< Updated upstream
-| AnySearch | `anysearch_api_key` を再利用 | [AnySearch Open Platform](https://anysearch.com/) |
+| AnySearch | オプション設定 `tools.web_search.anysearch_api_key`（匿名モード対応） | [AnySearch Open Platform](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[ドキュメント](https://serply.io/docs)） |
 
-Bocha、AnySearch、Serply のみ独立した `api_key` が必要ですが、他の 3 社は対応するモデルの API Key をそのまま再利用するため、モデルを設定すれば検索機能も同時に利用可能になります。
-=======
-| AnySearch | オプション設定 `tools.web_search.anysearch_api_key`（匿名モード対応） | [AnySearch Open Platform](https://anysearch.com/) |
-
-BochaおよびAnySearchについては専用キー（bocha_api_key / anysearch_api_key）を別途設定する必要がありますが、その他の3社は対応するモデルのAPIキーをそのまま流用でき、モデルを設定すれば同時に検索機能も利用可能になります
->>>>>>> Stashed changes
+Bocha、AnySearch、Serplyについては専用キー（bocha_api_key / anysearch_api_key / serply_api_key）を別途設定する必要がありますが、その他の3社は対応するモデルのAPIキーをそのまま流用でき、モデルを設定すれば同時に検索機能も利用可能になります。
 
 ## ルーティング戦略
 
@@ -41,11 +35,8 @@ BochaおよびAnySearchについては専用キー（bocha_api_key / anysearch_a
 }
 ```
 
-<<<<<<< Updated upstream
 - `auto`（デフォルト）：Agent が設定済みのプロバイダーから自動的に選択し、1 回のタスク内で複数回呼び出し、異なるプロバイダーを切り替えてより包括的な結果を取得できます。未指定の場合は `bocha → qianfan → zhipu → linkai → anysearch → serply` の順でフォールバックします。
-=======
-- `auto`（デフォルト）：Agent が設定済みのプロバイダーから自動的に選択し、1 回のタスク内で複数回呼び出し、異なるプロバイダーを切り替えてより包括的な結果を取得できます。未指定の場合は `bocha → qianfan → zhipu → linkai → anysearch` の順でフォールバックします。
->>>>>>> Stashed changes
+
 - `fixed`：`provider` で指定したプロバイダーに固定。該当プロバイダーの認証情報が欠けている場合は自動的に auto の順序にフォールバックします。
 
 ## ツールパラメータ

--- a/docs/ja/tools/web-search.mdx
+++ b/docs/ja/tools/web-search.mdx
@@ -17,10 +17,16 @@ description: インターネットからリアルタイム情報を検索。複�
 | 百度 Qianfan | `qianfan_api_key` を再利用 | [Qianfan コンソール](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | 智谱 Zhipu | `zhipu_ai_api_key` を再利用 | [Zhipu Open Platform](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | `linkai_api_key` を再利用 | [LinkAI コンソール](https://link-ai.tech/console/interface) |
+<<<<<<< Updated upstream
 | AnySearch | `anysearch_api_key` を再利用 | [AnySearch Open Platform](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[ドキュメント](https://serply.io/docs)） |
 
 Bocha、AnySearch、Serply のみ独立した `api_key` が必要ですが、他の 3 社は対応するモデルの API Key をそのまま再利用するため、モデルを設定すれば検索機能も同時に利用可能になります。
+=======
+| AnySearch | オプション設定 `tools.web_search.anysearch_api_key`（匿名モード対応） | [AnySearch Open Platform](https://anysearch.com/) |
+
+BochaおよびAnySearchについては専用キー（bocha_api_key / anysearch_api_key）を別途設定する必要がありますが、その他の3社は対応するモデルのAPIキーをそのまま流用でき、モデルを設定すれば同時に検索機能も利用可能になります
+>>>>>>> Stashed changes
 
 ## ルーティング戦略
 
@@ -35,7 +41,11 @@ Bocha、AnySearch、Serply のみ独立した `api_key` が必要ですが、他
 }
 ```
 
+<<<<<<< Updated upstream
 - `auto`（デフォルト）：Agent が設定済みのプロバイダーから自動的に選択し、1 回のタスク内で複数回呼び出し、異なるプロバイダーを切り替えてより包括的な結果を取得できます。未指定の場合は `bocha → qianfan → zhipu → linkai → anysearch → serply` の順でフォールバックします。
+=======
+- `auto`（デフォルト）：Agent が設定済みのプロバイダーから自動的に選択し、1 回のタスク内で複数回呼び出し、異なるプロバイダーを切り替えてより包括的な結果を取得できます。未指定の場合は `bocha → qianfan → zhipu → linkai → anysearch` の順でフォールバックします。
+>>>>>>> Stashed changes
 - `fixed`：`provider` で指定したプロバイダーに固定。該当プロバイダーの認証情報が欠けている場合は自動的に auto の順序にフォールバックします。
 
 ## ツールパラメータ

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -17,8 +17,12 @@ Search the internet for real-time information, news, research, and more. Support
 | ERNIE | Reuses `qianfan_api_key` | [Qianfan Console](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | Zhipu | Reuses `zhipu_ai_api_key` | [Zhipu Open Platform](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | Reuses `linkai_api_key` | [LinkAI Console](https://link-ai.tech/console/interface) |
+<<<<<<< Updated upstream
 | AnySearch | Reuses `anysearch_api_key` | [AnySearch Console](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io) ([docs](https://serply.io/docs)) |
+=======
+| AnySearch | Optional `tools.web_search.anysearch_api_key`(Anonymous mode is available) | [AnySearch Console](https://anysearch.com/) |
+>>>>>>> Stashed changes
 
 Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_key / anysearch_api_key / serply_api_key), the other three reuse the corresponding model's API key — configuring the model automatically grants search capability.
 
@@ -35,7 +39,11 @@ Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_
 }
 ```
 
+<<<<<<< Updated upstream
 - `auto` (default): the Agent intelligently picks among configured providers and may call multiple providers in a single task to gather more comprehensive results; when none is specified, falls back through `bocha → qianfan → zhipu → linkai → anysearch → serply`.
+=======
+- `auto` (default): the Agent intelligently picks among configured providers and may call multiple providers in a single task to gather more comprehensive results; when none is specified, falls back through `bocha → qianfan → zhipu → linkai → anysearch`.
+>>>>>>> Stashed changes
 - `fixed`: always use the provider specified in `provider`; falls back to the auto order if that provider's credentials are missing.
 
 ## Tool Parameters

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -17,12 +17,8 @@ Search the internet for real-time information, news, research, and more. Support
 | ERNIE | Reuses `qianfan_api_key` | [Qianfan Console](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | Zhipu | Reuses `zhipu_ai_api_key` | [Zhipu Open Platform](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | Reuses `linkai_api_key` | [LinkAI Console](https://link-ai.tech/console/interface) |
-<<<<<<< Updated upstream
-| AnySearch | Reuses `anysearch_api_key` | [AnySearch Console](https://anysearch.com/) |
-| Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io) ([docs](https://serply.io/docs)) |
-=======
 | AnySearch | Optional `tools.web_search.anysearch_api_key`(Anonymous mode is available) | [AnySearch Console](https://anysearch.com/) |
->>>>>>> Stashed changes
+| Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io) ([docs](https://serply.io/docs)) |
 
 Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_key / anysearch_api_key / serply_api_key), the other three reuse the corresponding model's API key — configuring the model automatically grants search capability.
 
@@ -39,11 +35,8 @@ Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_
 }
 ```
 
-<<<<<<< Updated upstream
 - `auto` (default): the Agent intelligently picks among configured providers and may call multiple providers in a single task to gather more comprehensive results; when none is specified, falls back through `bocha → qianfan → zhipu → linkai → anysearch → serply`.
-=======
-- `auto` (default): the Agent intelligently picks among configured providers and may call multiple providers in a single task to gather more comprehensive results; when none is specified, falls back through `bocha → qianfan → zhipu → linkai → anysearch`.
->>>>>>> Stashed changes
+
 - `fixed`: always use the provider specified in `provider`; falls back to the auto order if that provider's credentials are missing.
 
 ## Tool Parameters

--- a/docs/zh/tools/web-search.mdx
+++ b/docs/zh/tools/web-search.mdx
@@ -17,15 +17,9 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | 百度千帆 | 复用 `qianfan_api_key` | [千帆控制台](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | 智谱 Zhipu | 复用 `zhipu_ai_api_key` | [智谱开放平台](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | 复用 `linkai_api_key` | [LinkAI 控制台](https://link-ai.tech/console/interface) |
-<<<<<<< HEAD
 | AnySearch | 可选配置项 `tools.web_search.anysearch_api_key`（支持匿名模式） | [AnySearch 控制台](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[文档](https://serply.io/docs)） |
 
-=======
-
-| AnySearch | 可选配置项 `tools.web_search.anysearch_api_key`（支持匿名模式） | [AnySearch 控制台](https://anysearch.com/) |
-| Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[文档](https://serply.io/docs)） |
->>>>>>> ec9904c0 (docs: update web-search documentation with Serply and AnySearch)
 除博查、AnySearch、Serply 需要单独配置专用密钥（bocha_api_key / anysearch_api_key / serply_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
 
 ## 路由策略
@@ -40,11 +34,9 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
   }
 }
 ```
-<<<<<<< HEAD
-=======
 
->>>>>>> ec9904c0 (docs: update web-search documentation with Serply and AnySearch)
 - `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai → anysearch → serply` 顺序兜底。
+
 - `fixed`：固定使用 `provider` 指定的厂商；该厂商凭证缺失时自动回落到 auto 顺序。
 
 ## 工具参数

--- a/docs/zh/tools/web-search.mdx
+++ b/docs/zh/tools/web-search.mdx
@@ -17,9 +17,15 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | 百度千帆 | 复用 `qianfan_api_key` | [千帆控制台](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | 智谱 Zhipu | 复用 `zhipu_ai_api_key` | [智谱开放平台](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | 复用 `linkai_api_key` | [LinkAI 控制台](https://link-ai.tech/console/interface) |
+<<<<<<< HEAD
 | AnySearch | 可选配置项 `tools.web_search.anysearch_api_key`（支持匿名模式） | [AnySearch 控制台](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[文档](https://serply.io/docs)） |
 
+=======
+
+| AnySearch | 可选配置项 `tools.web_search.anysearch_api_key`（支持匿名模式） | [AnySearch 控制台](https://anysearch.com/) |
+| Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[文档](https://serply.io/docs)） |
+>>>>>>> ec9904c0 (docs: update web-search documentation with Serply and AnySearch)
 除博查、AnySearch、Serply 需要单独配置专用密钥（bocha_api_key / anysearch_api_key / serply_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
 
 ## 路由策略
@@ -34,6 +40,10 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
   }
 }
 ```
+<<<<<<< HEAD
+=======
+
+>>>>>>> ec9904c0 (docs: update web-search documentation with Serply and AnySearch)
 - `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai → anysearch → serply` 顺序兜底。
 - `fixed`：固定使用 `provider` 指定的厂商；该厂商凭证缺失时自动回落到 auto 顺序。
 

--- a/docs/zh/tools/web-search.mdx
+++ b/docs/zh/tools/web-search.mdx
@@ -17,10 +17,16 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | 百度千帆 | 复用 `qianfan_api_key` | [千帆控制台](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | 智谱 Zhipu | 复用 `zhipu_ai_api_key` | [智谱开放平台](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | 复用 `linkai_api_key` | [LinkAI 控制台](https://link-ai.tech/console/interface) |
+<<<<<<< Updated upstream
 | AnySearch | 复用 `anysearch_api_key` | [AnySearch 控制台](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[文档](https://serply.io/docs)） |
 
 除博查、AnySearch、Serply 需要单独配置专用密钥（bocha_api_key / anysearch_api_key / serply_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
+=======
+| AnySearch | 可选配置项 `tools.web_search.anysearch_api_key`（支持匿名模式） | [AnySearch 控制台](https://anysearch.com/) |
+
+除Bocha、AnySearch需要单独配置专用密钥（bocha_api_key / anysearch_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
+>>>>>>> Stashed changes
 
 ## 路由策略
 
@@ -35,7 +41,11 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 }
 ```
 
+<<<<<<< Updated upstream
 - `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai → anysearch → serply` 顺序兜底。
+=======
+- `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai → anysearch` 顺序兜底。
+>>>>>>> Stashed changes
 - `fixed`：固定使用 `provider` 指定的厂商；该厂商凭证缺失时自动回落到 auto 顺序。
 
 ## 工具参数

--- a/docs/zh/tools/web-search.mdx
+++ b/docs/zh/tools/web-search.mdx
@@ -17,16 +17,10 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | 百度千帆 | 复用 `qianfan_api_key` | [千帆控制台](https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy) |
 | 智谱 Zhipu | 复用 `zhipu_ai_api_key` | [智谱开放平台](https://docs.bigmodel.cn/cn/guide/tools/web-search) |
 | LinkAI | 复用 `linkai_api_key` | [LinkAI 控制台](https://link-ai.tech/console/interface) |
-<<<<<<< Updated upstream
-| AnySearch | 复用 `anysearch_api_key` | [AnySearch 控制台](https://anysearch.com/) |
+| AnySearch | 可选配置项 `tools.web_search.anysearch_api_key`（支持匿名模式） | [AnySearch 控制台](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[文档](https://serply.io/docs)） |
 
 除博查、AnySearch、Serply 需要单独配置专用密钥（bocha_api_key / anysearch_api_key / serply_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
-=======
-| AnySearch | 可选配置项 `tools.web_search.anysearch_api_key`（支持匿名模式） | [AnySearch 控制台](https://anysearch.com/) |
-
-除Bocha、AnySearch需要单独配置专用密钥（bocha_api_key / anysearch_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
->>>>>>> Stashed changes
 
 ## 路由策略
 
@@ -40,12 +34,7 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
   }
 }
 ```
-
-<<<<<<< Updated upstream
 - `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai → anysearch → serply` 顺序兜底。
-=======
-- `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai → anysearch` 顺序兜底。
->>>>>>> Stashed changes
 - `fixed`：固定使用 `provider` 指定的厂商；该厂商凭证缺失时自动回落到 auto 顺序。
 
 ## 工具参数

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -6,7 +6,7 @@ backends.
 Covers key resolution (config file + environment fallback), the canonical
 provider fallback order, result normalization into the unified output shape,
 the AnySearch-specific count clamp (the shared tool schema allows 1-50 while
-the API accepts 1-20), HTTP and business-level error mapping, and the
+the API accepts 1-10), HTTP and business-level error mapping, and the
 anonymous mode contract (no Authorization header without a key).
 
 No real network is used: ``requests.post`` / ``requests.get`` are stubbed
@@ -20,6 +20,7 @@ from unittest.mock import patch, MagicMock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+from agent.tools.web_search import WebSearch
 from agent.tools.web_search import web_search as web_search_module
 
 
@@ -108,7 +109,7 @@ class TestAnySearchBackend(unittest.TestCase):
     """Behaviour of WebSearch._search_anysearch with a stubbed HTTP layer."""
 
     def setUp(self):
-        self.tool = web_search_module.WebSearch()
+        self.tool = WebSearch()
 
     def test_search_anysearch_maps_results(self):
         """Results under data.results map to the unified output shape.
@@ -141,7 +142,7 @@ class TestAnySearchBackend(unittest.TestCase):
         self.assertEqual(headers.get("Authorization"), "Bearer test-key-123")
 
     def test_search_anysearch_clamps_count(self):
-        """count is clamped into AnySearch's documented 1-20 range.
+        """count is clamped into AnySearch's documented 1-10 range.
 
         A falsy count falls back to the default of 10, matching the
         `count or 10` idiom used by the zhipu/qianfan backends (execute()
@@ -150,7 +151,7 @@ class TestAnySearchBackend(unittest.TestCase):
         with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
                 patch.object(web_search_module.requests, "post",
                              return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
-            for count, expected in ((50, 20), (0, 10), (None, 10), (10, 10)):
+            for count, expected in ((50, 10), (0, 10), (None, 10), (10, 10)):
                 with self.subTest(count=count):
                     self.tool._search_anysearch("q", count)
                     self.assertEqual(mock_post.call_args[1]["json"]["max_results"], expected)
@@ -192,6 +193,36 @@ class TestAnySearchBackend(unittest.TestCase):
         self.assertEqual(result.status, "success")
         headers = mock_post.call_args[1]["headers"]
         self.assertNotIn("Authorization", headers)
+
+    def test_search_anysearch_ignores_freshness_with_warning(self):
+        """freshness='oneWeek' logs a warning and is not sent in the payload."""
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module, "logger") as mock_logger, \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
+            result = self.tool._search_anysearch("q", 10, freshness="oneWeek")
+
+        self.assertEqual(result.status, "success")
+        mock_logger.warning.assert_called_once_with(
+            "[WebSearch] anysearch does not support freshness ('oneWeek'); ignoring"
+        )
+        sent = mock_post.call_args[1]["json"]
+        self.assertNotIn("freshness", sent)
+        self.assertEqual(sent, {"query": "q", "max_results": 10, "format": "json"})
+
+    def test_search_anysearch_ignores_summary_with_warning(self):
+        """summary=True logs a warning; the request payload keeps its plain shape."""
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module, "logger") as mock_logger, \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
+            result = self.tool._search_anysearch("q", 10, summary=True)
+
+        self.assertEqual(result.status, "success")
+        mock_logger.warning.assert_called_once_with(
+            "[WebSearch] anysearch does not support summary; ignoring"
+        )
+        self.assertNotIn("summary", mock_post.call_args[1]["json"])
 
 
 def _serply_payload(results):


### PR DESCRIPTION
**1.变更概述：**
集成 AnySearch 作为第五个搜索后端，支持匿名模式（无需 API Key，有免费额度）。用户可在控制台显式开启/停用，非默认启用。

**2.主要改动**
1. AnySearch 后端集成

新增 _search_anysearch() 方法，支持 API Key 和匿名两种模式

结果数量自动限制 1-10（符合 API 限制）

作为末位 fallback：bocha → qianfan → zhipu → linkai → anysearch

2. 匿名模式（控制台可配置）

控制台搜索卡片显示三态：未启用 / 匿名模式（带"·匿名"徽标）/ Key 模式

弹窗留空保存即开启匿名，提供"停用匿名"入口

3. 其他增强

AnySearch 不支持的参数（freshness/summary）记录 warning 日志

透出 request_id、search_time_ms 可观测字段

**4.配置方式**
填写 Key → 配额模式

不填 Key + 控制台开启匿名 → 匿名模式（免费日额度）

不填 Key + 未开启匿名 → AnySearch 不启用

**5.破坏性变更**
无。匿名模式需显式开启，不影响现有配置和用户。

**6.测试**
☑ 匿名模式端到端验证
☑ Key 解析（config + env 回退）
☑ 错误处理（401/402/429）
☑ freshness/summary 告警
☑ 可观测字段透出
☑ 现有测试全部通过
<img width="1463" height="147" alt="image" src="https://github.com/user-attachments/assets/1d55e5a5-326a-49cf-9fc8-e6981a9827fb" />

调用日志：
<img width="1445" height="558" alt="image" src="https://github.com/user-attachments/assets/7dd4d080-06e0-4126-8881-cf116b57c5bb" />

配置：
<img width="1137" height="304" alt="image" src="https://github.com/user-attachments/assets/e23cab7b-325c-4038-9515-a61685839f40" />



破坏性变更
无。

