### PR TITLE
fix(memory): keep blank text out of the embeddings API

### DIFF
--- a/agent/memory/chunker.py
+++ b/agent/memory/chunker.py
@@ -109,7 +109,11 @@ class TextChunker:
                 end_line=len(lines)
             ))
         
-        return chunks
+        # A blank line sitting next to an over-long line is flushed as its own
+        # chunk whose text is empty. Such chunks carry nothing, and embedding
+        # APIs reject an empty string inside a batch by failing the whole
+        # request, so they must not reach the index.
+        return [c for c in chunks if c.text.strip()]
     
     def _split_long_line(self, line: str, max_chars: int) -> List[str]:
         """Split a single long line into multiple chunks"""

--- a/agent/memory/embedding/provider.py
+++ b/agent/memory/embedding/provider.py
@@ -31,6 +31,15 @@ from urllib.parse import urlparse
 # endpoints hang forever.
 EMBEDDING_HTTP_TIMEOUT = 90
 
+# OpenAI-compatible endpoints reject an empty string inside an `input` array
+# and fail the entire batch on it, so blank texts are substituted rather than
+# dropped: the returned vectors must stay aligned with the caller's texts.
+BLANK_INPUT_PLACEHOLDER = " "
+
+
+def _is_blank(text) -> bool:
+    return not text or not text.strip()
+
 
 class EmbeddingProvider(ABC):
     """Base class for embedding providers"""
@@ -241,6 +250,20 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
                 pass
         return headers
 
+    @staticmethod
+    def _sanitize_input(input_data):
+        """Swap blank texts for a placeholder before they hit the wire."""
+        texts = [input_data] if isinstance(input_data, str) else list(input_data)
+        blanks = sum(1 for t in texts if _is_blank(t))
+        if blanks:
+            from common.log import logger
+            logger.warning(
+                f"[Embedding] {blanks}/{len(texts)} blank input(s) replaced with a "
+                f"placeholder; the caller should not embed empty texts"
+            )
+        cleaned = [BLANK_INPUT_PLACEHOLDER if _is_blank(t) else t for t in texts]
+        return cleaned[0] if isinstance(input_data, str) else cleaned
+
     def _call_api(self, input_data):
         """Call OpenAI-compatible /embeddings endpoint"""
         import requests
@@ -252,7 +275,7 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
             **self._request_headers(),
         }
         data = {
-            "input": input_data,
+            "input": self._sanitize_input(input_data),
             "model": self.model,
         }
         if self.supports_dim_param and self._dimensions:
@@ -376,7 +399,7 @@ class DoubaoEmbeddingProvider(EmbeddingProvider):
         }
         payload = {
             "model": self.model,
-            "input": [{"type": "text", "text": text}],
+            "input": [{"type": "text", "text": BLANK_INPUT_PLACEHOLDER if _is_blank(text) else text}],
             "dimensions": self._dimensions,
             "encoding_format": "float",
         }

--- a/tests/test_embedding_blank_input.py
+++ b/tests/test_embedding_blank_input.py
@@ -1,0 +1,82 @@
+# encoding: utf-8
+"""
+Tests for the two guards that keep blank text out of the embeddings API.
+
+An OpenAI-compatible /embeddings endpoint answers 400 ("'$.input' is invalid")
+when any element of the input array is an empty string, which fails the whole
+batch and, in memory sync, aborts the entire index build. Blank text therefore
+must never leave the chunker, and must never leave the provider either.
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from agent.memory.chunker import TextChunker
+from agent.memory.embedding.provider import BLANK_INPUT_PLACEHOLDER, OpenAIEmbeddingProvider
+
+
+class TestChunkTextBlankChunks(unittest.TestCase):
+    """chunk_text flushes the accumulated lines when it meets an over-long
+    line; a lone blank line at that boundary used to be emitted as an empty
+    chunk."""
+
+    def setUp(self):
+        self.c = TextChunker()
+        # max_chars = max_tokens(500) * chars_per_token(4)
+        self.long_a = "A" * 2500
+        self.long_b = "B" * 2500
+
+    def _assert_no_blank(self, chunks):
+        self.assertTrue(chunks)
+        for ch in chunks:
+            self.assertTrue(ch.text.strip(), "chunk_text must not emit blank chunks")
+
+    def test_blank_line_between_two_long_lines(self):
+        chunks = self.c.chunk_text(f"{self.long_a}\n\n{self.long_b}")
+        self._assert_no_blank(chunks)
+
+    def test_long_line_with_trailing_newline(self):
+        chunks = self.c.chunk_text(f"{self.long_a}\n")
+        self._assert_no_blank(chunks)
+
+    def test_leading_blank_line_before_long_line(self):
+        chunks = self.c.chunk_text(f"\n{self.long_a}")
+        self._assert_no_blank(chunks)
+
+    def test_content_is_preserved(self):
+        text = f"{self.long_a}\n\n{self.long_b}"
+        joined = "".join(ch.text for ch in self.c.chunk_text(text))
+        self.assertEqual(joined.count("A"), len(self.long_a))
+        self.assertEqual(joined.count("B"), len(self.long_b))
+
+    def test_normal_text_is_untouched(self):
+        chunks = self.c.chunk_text("第一行\n第二行\n第三行")
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].text, "第一行\n第二行\n第三行")
+
+
+class TestSanitizeEmbeddingInput(unittest.TestCase):
+    """The provider is the last stop before the wire, so it substitutes rather
+    than drops: callers index the returned vectors positionally."""
+
+    def setUp(self):
+        self.sanitize = OpenAIEmbeddingProvider._sanitize_input
+
+    def test_blank_items_replaced_in_place(self):
+        self.assertEqual(
+            self.sanitize(["hello", "", "  \n ", "world"]),
+            ["hello", BLANK_INPUT_PLACEHOLDER, BLANK_INPUT_PLACEHOLDER, "world"],
+        )
+
+    def test_single_blank_string_replaced(self):
+        self.assertEqual(self.sanitize(""), BLANK_INPUT_PLACEHOLDER)
+
+    def test_non_blank_input_untouched(self):
+        self.assertEqual(self.sanitize(["a", "b"]), ["a", "b"])
+        self.assertEqual(self.sanitize("a"), "a")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
An OpenAI-compatible /embeddings endpoint answers 400 ("'$.input' is invalid") when any element of the input array is an empty string. One such element fails the whole batch, and in memory sync that aborts the entire index build: sync() embeds all pending chunks in one call and returns without touching storage on failure, so file hashes stay stale and every later sync retries the same bad text forever. The user sees memory silently stuck on keyword-only search.

chunk_text produced those empty chunks. It flushes the accumulated lines before splitting an over-long line (> max_tokens * 4 chars), and again at the end, without checking that what it flushes has content -- a lone blank line at either boundary becomes a chunk whose text is "". A markdown file shaped "long paragraph / blank line / long paragraph" hits this, which is ordinary for Chinese memory notes. Blank chunks are worthless in the index anyway, so they are now dropped.

chunk_markdown (used for .md since heading-aware chunking landed) already filtered blanks, but chunk_text is still reached by non-.md files, by the markdown-it ImportError fallback, and by add_memory -- and by any client on a build that predates that change.

The provider is the last stop before the wire and cannot trust its callers, so blanks are also substituted there with a single space, logging a warning so a caller's bug is not silently masked. Substituting rather than dropping keeps returned vectors aligned with the caller's texts.

