### PR TITLE
feat: add Keenable as a keyless web_search provider

### DIFF
--- a/agent/tools/web_search/web_search.py
+++ b/agent/tools/web_search/web_search.py
@@ -1,14 +1,16 @@
-"""Web Search tool. Supports six backends with a unified response format:
+"""Web Search tool. Supports seven backends with a unified response format:
   - bocha   (https://open.bochaai.com)
   - zhipu   (https://docs.bigmodel.cn/cn/guide/tools/web-search)
   - qianfan (https://cloud.baidu.com/doc/qianfan/s/2mh4su4uy)
   - linkai  (https://link-ai.tech, fallback)
   - anysearch (https://anysearch.com)
   - serply  (https://serply.io, Google/Bing SERP API)
+  - keenable (https://keenable.ai, works without an API key)
 
 Provider selection
   - strategy 'auto' (default): pick the first configured provider in the
-    canonical order [bocha, qianfan, zhipu, linkai, anysearch, serply]. When
+    canonical order [bocha, qianfan, zhipu, linkai, anysearch, serply,
+    keenable]. Keenable needs no key, so it always counts as configured. When
     the caller passes an explicit `provider` it overrides the pick; an
     invalid/unconfigured one silently falls back to the auto order.
   - strategy 'fixed': use the configured provider; if its credential is
@@ -21,6 +23,8 @@ Credentials
   - linkai  : conf.linkai_api_key              ->  env LINKAI_API_KEY
   - anysearch : tools.web_search.anysearch_api_key  -> env ANYSEARCH_API_KEY
   - serply  : tools.web_search.serply_api_key  ->  env SERPLY_API_KEY
+  - keenable: tools.web_search.keenable_api_key -> env KEENABLE_API_KEY (optional,
+              only lifts the rate limits of the keyless public endpoint)
 """
 
 import json
@@ -41,8 +45,13 @@ DEFAULT_TIMEOUT = 30
 # quality + relevance: bocha (best overall), qianfan (best for hot news),
 # zhipu (strong on long-form articles), linkai (cloud aggregator),
 # anysearch, serply (global Google/Bing SERP, last since it isn't
-# benchmarked against the Chinese-market providers above).
-PROVIDER_ORDER = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply")
+# benchmarked against the Chinese-market providers above), keenable (global
+# index, needs no key; placed last so any provider the user paid for wins).
+PROVIDER_ORDER = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply", "keenable")
+
+# Providers that work without a credential. They always count as configured,
+# so web_search is offered to the agent on a fresh install.
+KEYLESS_PROVIDERS = ("keenable",)
 
 PROVIDER_LABELS = {
     "bocha":   "Bocha",
@@ -51,6 +60,7 @@ PROVIDER_LABELS = {
     "linkai":  "LinkAI",
     "anysearch": "AnySearch",
     "serply":  "Serply",
+    "keenable": "Keenable",
 }
 
 
@@ -84,6 +94,9 @@ def _get_api_key(provider: str) -> str:
     if provider == "serply":
         key = (_tools_web_search_conf().get("serply_api_key") or "").strip()
         return key or os.environ.get("SERPLY_API_KEY", "").strip()
+    if provider == "keenable":
+        key = (_tools_web_search_conf().get("keenable_api_key") or "").strip()
+        return key or os.environ.get("KEENABLE_API_KEY", "").strip()
     return ""
 
 
@@ -93,12 +106,15 @@ def _anysearch_anonymous_enabled() -> bool:
 
 def configured_providers() -> List[str]:
     """Configured providers in canonical order. anysearch qualifies with a
-    real key OR an explicit anonymous opt-in (still last in fallback order)."""
+    real key OR an explicit anonymous opt-in (still last in fallback order).
+    Keyless providers always qualify; their key is optional."""
     result = []
     for p in PROVIDER_ORDER:
         if _get_api_key(p):
             result.append(p)
         elif p == "anysearch" and _anysearch_anonymous_enabled():
+            result.append(p)
+        elif p in KEYLESS_PROVIDERS:
             result.append(p)
     return result
 
@@ -150,7 +166,8 @@ class WebSearch(BaseTool):
 
     @staticmethod
     def is_available() -> bool:
-        """Tool is offered to the agent when at least one provider has a key."""
+        """Tool is offered to the agent when at least one provider is
+        configured. Keenable needs no key, so in practice this is always true."""
         return bool(configured_providers())
 
     def get_json_schema(self) -> dict:
@@ -268,6 +285,8 @@ class WebSearch(BaseTool):
                 return self._search_anysearch(query, count, freshness, summary)
             if provider == "serply":
                 return self._search_serply(query, count)
+            if provider == "keenable":
+                return self._search_keenable(query, count, freshness, summary)
             return ToolResult.fail(f"Error: Unknown provider '{provider}'")
         except requests.Timeout:
             return ToolResult.fail(f"Error: Search request timed out after {DEFAULT_TIMEOUT}s")
@@ -630,3 +649,75 @@ class WebSearch(BaseTool):
             "total": len(results), "count": len(results), "results": results,
         })
 
+    # ------------------------------------------------------------------
+    # Keenable
+    # ------------------------------------------------------------------
+
+    def _search_keenable(self, query: str, count: int, freshness: str, summary: bool) -> ToolResult:
+        api_key = _get_api_key("keenable")
+        # Keenable serves anonymous traffic on a public endpoint that wants an
+        # app title instead of a key (rate limited per IP: 10 requests/s,
+        # 1000/hour). A key switches to the authenticated endpoint, which
+        # only lifts those limits.
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "X-Keenable-Title": "cowagent",
+        }
+        if api_key:
+            url = "https://api.keenable.ai/v1/search"
+            headers["X-API-Key"] = api_key
+        else:
+            url = "https://api.keenable.ai/v1/search/public"
+
+        payload: Dict[str, Any] = {
+            "query": query,
+            "max_results": max(1, min(int(count or 10), 50)),
+            # A hint, not a hard cap: the API rounds up to a word boundary.
+            "snippet_max_length": 1000 if summary else 300,
+        }
+        payload.update(self._keenable_build_freshness_filter(freshness))
+
+        logger.debug(
+            f"[WebSearch] keenable: query='{query}', max_results={payload['max_results']}, keyed={bool(api_key)}"
+        )
+        resp = requests.post(url, headers=headers, json=payload, timeout=DEFAULT_TIMEOUT)
+
+        if resp.status_code == 401:
+            return ToolResult.fail("Error: Invalid Keenable API key.")
+        if resp.status_code == 429:
+            hint = "" if api_key else " Set keenable_api_key / KEENABLE_API_KEY to lift the keyless limit."
+            return ToolResult.fail(f"Error: Keenable API rate limit reached.{hint}")
+        if resp.status_code != 200:
+            return ToolResult.fail(f"Error: Keenable API returned HTTP {resp.status_code}: {resp.text[:200]}")
+
+        data = resp.json()
+        results = []
+        for it in data.get("results") or []:
+            results.append({
+                "title": it.get("title", ""),
+                "url": it.get("url", ""),
+                # `snippet` carries the page text; `description` is usually empty.
+                "snippet": it.get("snippet") or it.get("description") or "",
+                "datePublished": it.get("published_at") or "",
+            })
+        return ToolResult.success({
+            "query": query, "backend": "keenable",
+            "total": len(results), "count": len(results), "results": results,
+        })
+
+    @staticmethod
+    def _keenable_build_freshness_filter(freshness: str) -> Dict[str, str]:
+        """Translate the shared freshness vocabulary into Keenable's
+        `published_after` / `published_before` (YYYY-MM-DD) request fields.
+        Accepts the named tokens and the `2025-01-01..2025-02-01` range form."""
+        if not freshness or freshness == "noLimit":
+            return {}
+        delta_days = {"oneDay": 1, "oneWeek": 7, "oneMonth": 30, "oneYear": 365}.get(freshness)
+        if delta_days:
+            from datetime import datetime, timedelta
+            return {"published_after": (datetime.now() - timedelta(days=delta_days)).strftime("%Y-%m-%d")}
+        start, sep, end = freshness.partition("..")
+        if sep and start.strip() and end.strip():
+            return {"published_after": start.strip(), "published_before": end.strip()}
+        return {}

--- a/agent/tools/web_search/web_search.py
+++ b/agent/tools/web_search/web_search.py
@@ -5,12 +5,13 @@
   - linkai  (https://link-ai.tech, fallback)
   - anysearch (https://anysearch.com)
   - serply  (https://serply.io, Google/Bing SERP API)
-  - keenable (https://keenable.ai, works without an API key)
+  - keenable (https://keenable.ai, keyless tier behind an explicit opt-in)
 
 Provider selection
   - strategy 'auto' (default): pick the first configured provider in the
     canonical order [bocha, qianfan, zhipu, linkai, anysearch, serply,
-    keenable]. Keenable needs no key, so it always counts as configured. When
+    keenable]. Keenable counts as configured with a key or with the explicit
+    `keenable_anonymous` opt-in (same contract as `anysearch_anonymous`). When
     the caller passes an explicit `provider` it overrides the pick; an
     invalid/unconfigured one silently falls back to the auto order.
   - strategy 'fixed': use the configured provider; if its credential is
@@ -24,7 +25,8 @@ Credentials
   - anysearch : tools.web_search.anysearch_api_key  -> env ANYSEARCH_API_KEY
   - serply  : tools.web_search.serply_api_key  ->  env SERPLY_API_KEY
   - keenable: tools.web_search.keenable_api_key -> env KEENABLE_API_KEY (optional,
-              only lifts the rate limits of the keyless public endpoint)
+              only lifts the rate limits of the keyless public endpoint);
+              keyless use is opt-in via tools.web_search.keenable_anonymous
 """
 
 import json
@@ -46,12 +48,9 @@ DEFAULT_TIMEOUT = 30
 # zhipu (strong on long-form articles), linkai (cloud aggregator),
 # anysearch, serply (global Google/Bing SERP, last since it isn't
 # benchmarked against the Chinese-market providers above), keenable (global
-# index, needs no key; placed last so any provider the user paid for wins).
+# index, keyless tier behind an explicit opt-in; placed last so any provider
+# the user paid for wins).
 PROVIDER_ORDER = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply", "keenable")
-
-# Providers that work without a credential. They always count as configured,
-# so web_search is offered to the agent on a fresh install.
-KEYLESS_PROVIDERS = ("keenable",)
 
 PROVIDER_LABELS = {
     "bocha":   "Bocha",
@@ -104,17 +103,22 @@ def _anysearch_anonymous_enabled() -> bool:
     """Check if AnySearch anonymous mode is enabled via config."""
     return bool(_tools_web_search_conf().get("anysearch_anonymous"))
 
+
+def _keenable_anonymous_enabled() -> bool:
+    """Check if Keenable anonymous (keyless) mode is enabled via config."""
+    return bool(_tools_web_search_conf().get("keenable_anonymous"))
+
 def configured_providers() -> List[str]:
-    """Configured providers in canonical order. anysearch qualifies with a
-    real key OR an explicit anonymous opt-in (still last in fallback order).
-    Keyless providers always qualify; their key is optional."""
+    """Configured providers in canonical order. anysearch and keenable qualify
+    with a real key OR an explicit anonymous opt-in (still last in fallback
+    order); nothing goes keyless unless the user turned it on."""
     result = []
     for p in PROVIDER_ORDER:
         if _get_api_key(p):
             result.append(p)
         elif p == "anysearch" and _anysearch_anonymous_enabled():
             result.append(p)
-        elif p in KEYLESS_PROVIDERS:
+        elif p == "keenable" and _keenable_anonymous_enabled():
             result.append(p)
     return result
 
@@ -149,13 +153,13 @@ class WebSearch(BaseTool):
                     "Time range filter. Options: "
                     "'noLimit' (default), 'oneDay', 'oneWeek', 'oneMonth', 'oneYear', "
                     "or date range like '2025-01-01..2025-02-01'. "
-                    "Honored by bocha/zhipu/qianfan/linkai; ignored by anysearch."
+                    "Honored by bocha/zhipu/qianfan/linkai/keenable; ignored by anysearch."
                 )
             },
             "summary": {
                 "type": "boolean",
                 "description": "Whether to include text summary for each result (default: false). "
-                               "Bocha/linkai only; ignored by anysearch."
+                               "Bocha/linkai/keenable only; ignored by anysearch."
             }
         },
         "required": ["query"]
@@ -166,8 +170,8 @@ class WebSearch(BaseTool):
 
     @staticmethod
     def is_available() -> bool:
-        """Tool is offered to the agent when at least one provider is
-        configured. Keenable needs no key, so in practice this is always true."""
+        """Tool is offered to the agent when at least one provider has a key
+        or an explicit anonymous opt-in (anysearch_anonymous / keenable_anonymous)."""
         return bool(configured_providers())
 
     def get_json_schema(self) -> dict:
@@ -657,8 +661,9 @@ class WebSearch(BaseTool):
         api_key = _get_api_key("keenable")
         # Keenable serves anonymous traffic on a public endpoint that wants an
         # app title instead of a key (rate limited per IP: 10 requests/s,
-        # 1000/hour). A key switches to the authenticated endpoint, which
-        # only lifts those limits.
+        # 1000/hour). Reaching this branch without a key means the user set
+        # keenable_anonymous. A key switches to the authenticated endpoint,
+        # which only lifts those limits.
         headers = {
             "Content-Type": "application/json",
             "Accept": "application/json",

--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -160,6 +160,8 @@ const I18N = {
         models_search_anysearch_anon_hint: '留空可启用匿名模式（无需 API Key）',
         models_search_anonymous_badge: '匿名',
         models_search_anonymous_disable: '停用匿名',
+        models_search_keenable_title: '配置 Keenable API Key（可选）',
+        models_search_keenable_desc: 'Keenable 无需密钥即可使用；配置密钥仅用于提升频率上限，前往 keenable.ai 获取。',
         models_search_edit_hint: '点击修改配置',
         models_unavailable: '不可用',
         models_set_via_env: '通过环境变量启用',
@@ -648,6 +650,8 @@ const I18N = {
         models_search_anysearch_anon_hint: '留空可啟用匿名模式（無需 API Key）',
         models_search_anonymous_badge: '匿名',
         models_search_anonymous_disable: '停用匿名',
+        models_search_keenable_title: '設定 Keenable API Key（選填）',
+        models_search_keenable_desc: 'Keenable 無需金鑰即可使用；設定金鑰僅用於提高呼叫頻率上限，前往 keenable.ai 取得。',
         models_search_edit_hint: '點選修改設定',
         models_unavailable: '不可用',
         models_set_via_env: '透過環境變數啟用',
@@ -1131,6 +1135,8 @@ const I18N = {
         models_search_anysearch_anon_hint: 'Leave empty to enable anonymous mode (no API key required)',
         models_search_anonymous_badge: 'anonymous',
         models_search_anonymous_disable: 'Disable anonymous',
+        models_search_keenable_title: 'Configure Keenable API Key (optional)',
+        models_search_keenable_desc: 'Keenable works without a key; a key only lifts the rate limits. Get one at keenable.ai.',
         models_search_edit_hint: 'Click to edit',
         models_unavailable: 'unavailable',
         models_set_via_env: 'enable via environment variable',
@@ -10959,7 +10965,7 @@ function openSearchAddProviderPicker(missingProviders) {
 }
 
 function _launchSearchProviderConfig(providerId, providerMeta) {
-    if (providerId === 'bocha' || providerId === 'anysearch' || providerId === 'serply') {
+    if (providerId === 'bocha' || providerId === 'anysearch' || providerId === 'serply' || providerId === 'keenable') {
         openSearchKeyModal(providerId, providerMeta);
     } else {
         openVendorModal(providerId, () => loadModelsView({ preserveScroll: true }));

--- a/channel/web/static/js/console.js
+++ b/channel/web/static/js/console.js
@@ -161,7 +161,8 @@ const I18N = {
         models_search_anonymous_badge: '匿名',
         models_search_anonymous_disable: '停用匿名',
         models_search_keenable_title: '配置 Keenable API Key（可选）',
-        models_search_keenable_desc: 'Keenable 无需密钥即可使用；配置密钥仅用于提升频率上限，前往 keenable.ai 获取。',
+        models_search_keenable_desc: 'Keenable 支持匿名模式（无需 API Key）；配置密钥仅用于提升频率上限，前往 keenable.ai 获取。',
+        models_search_keenable_anon_hint: '（留空保存即启用匿名模式，公共接口按 IP 限流）',
         models_search_edit_hint: '点击修改配置',
         models_unavailable: '不可用',
         models_set_via_env: '通过环境变量启用',
@@ -651,7 +652,8 @@ const I18N = {
         models_search_anonymous_badge: '匿名',
         models_search_anonymous_disable: '停用匿名',
         models_search_keenable_title: '設定 Keenable API Key（選填）',
-        models_search_keenable_desc: 'Keenable 無需金鑰即可使用；設定金鑰僅用於提高呼叫頻率上限，前往 keenable.ai 取得。',
+        models_search_keenable_desc: 'Keenable 支援匿名模式（無需 API Key）；設定金鑰僅用於提高呼叫頻率上限，前往 keenable.ai 取得。',
+        models_search_keenable_anon_hint: '（留空儲存即啟用匿名模式，公開介面依 IP 限流）',
         models_search_edit_hint: '點選修改設定',
         models_unavailable: '不可用',
         models_set_via_env: '透過環境變數啟用',
@@ -1136,7 +1138,8 @@ const I18N = {
         models_search_anonymous_badge: 'anonymous',
         models_search_anonymous_disable: 'Disable anonymous',
         models_search_keenable_title: 'Configure Keenable API Key (optional)',
-        models_search_keenable_desc: 'Keenable works without a key; a key only lifts the rate limits. Get one at keenable.ai.',
+        models_search_keenable_desc: 'Keenable has an anonymous mode (no API key); a key only lifts the rate limits. Get one at keenable.ai.',
+        models_search_keenable_anon_hint: '(Leave blank to enable anonymous mode; the public endpoint is rate limited per IP)',
         models_search_edit_hint: 'Click to edit',
         models_unavailable: 'unavailable',
         models_set_via_env: 'enable via environment variable',
@@ -11016,7 +11019,8 @@ function openSearchKeyModal(providerId, providerMeta) {
     let masked = (providerMeta && providerMeta.api_key_masked) || '';
     if (!masked && prov && prov.api_key_masked) masked = prov.api_key_masked;
     const hasKey = !!masked;
-    const isAnonymous = providerId === 'anysearch' && !!((providerMeta && providerMeta.anonymous) || (prov && prov.anonymous));
+    const isAnonymous = (providerId === 'anysearch' || providerId === 'keenable')
+        && !!((providerMeta && providerMeta.anonymous) || (prov && prov.anonymous));
     const clearBtnHtml = (hasKey || isAnonymous)
         ? `<button type="button" id="search-key-clear"
                   class="px-3 py-1.5 rounded-md text-xs text-red-500 dark:text-red-400
@@ -11030,6 +11034,9 @@ function openSearchKeyModal(providerId, providerMeta) {
             ? '（留空可启用匿名模式，每日有免费额度）'
             : '(Leave blank to enable anonymous mode with daily free quota)';
         descText = descText + ' ' + hint;
+    }
+    if (providerId === 'keenable') {
+        descText = descText + ' ' + t('models_search_keenable_anon_hint');
     }
 
     const modal = document.createElement('div');
@@ -11112,7 +11119,8 @@ function _saveSearchKey(providerId) {
     }
     const apiKey = input.value.trim();
 
-    if (providerId === 'anysearch') {
+    // anysearch and keenable: saving with an empty key enables the anonymous tier.
+    if (providerId === 'anysearch' || providerId === 'keenable') {
     fetch('/api/models', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -4230,10 +4230,6 @@ class ModelsHandler:
     # agent/tools/web_search/web_search.py — keep them in sync.
     _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply", "keenable")
 
-    # Providers that work without a key (mirrors KEYLESS_PROVIDERS in the
-    # tool module). They show as configured even with no credential.
-    _KEYLESS_SEARCH_PROVIDERS = ("keenable",)
-
     _SEARCH_PROVIDER_LABELS = {
         "bocha":   {"zh": "博查", "en": "Bocha"},
         "zhipu":   {"zh": "智谱", "en": "GLM"},
@@ -4286,6 +4282,7 @@ class ModelsHandler:
             ws_cfg = {}
 
         anonymous_on = bool(ws_cfg.get("anysearch_anonymous"))
+        keenable_anonymous_on = bool(ws_cfg.get("keenable_anonymous"))
         providers = []
         configured_ids = []
         for pid in cls._SEARCH_PROVIDERS:
@@ -4293,8 +4290,11 @@ class ModelsHandler:
             if pid == "anysearch":
                 # AnySearch: real key, or an explicit anonymous opt-in.
                 ok = cls._is_real_key(raw_key) or anonymous_on
+            elif pid == "keenable":
+                # Keenable: real key, or an explicit anonymous opt-in.
+                ok = cls._is_real_key(raw_key) or keenable_anonymous_on
             else:
-                ok = cls._is_real_key(raw_key) or pid in cls._KEYLESS_SEARCH_PROVIDERS
+                ok = cls._is_real_key(raw_key)
             providers.append({
                 "id": pid,
                 "label": cls._SEARCH_PROVIDER_LABELS.get(pid, pid),
@@ -4303,7 +4303,7 @@ class ModelsHandler:
                 # piggy-back on a model-vendor credential. Frontend uses
                 # this hint to decide which credential editor to surface.
                 # Lets the frontend badge "匿名/anonymous" only in anonymous mode.
-                "anonymous": pid == "anysearch" and ok and not raw_key,
+                "anonymous": pid in ("anysearch", "keenable") and ok and not raw_key,
                 "needs_dedicated_key": pid in ("bocha", "anysearch", "serply", "keenable"),
                 "api_key_masked": ConfigHandler._mask_key(raw_key) if raw_key else "",
             })
@@ -5247,33 +5247,36 @@ class ModelsHandler:
     def _handle_set_search_credential(self, data: dict) -> str:
         """Persist a dedicated search-provider key under tools.web_search.
 
-        bocha, anysearch, serply and keenable own their keys here (keenable's
-        is optional); zhipu/qianfan/linkai reuse model-vendor credentials and
-        go through set_provider instead.
+        bocha, anysearch, serply and keenable own their keys here; anysearch
+        and keenable also take an ``anonymous`` flag that, with an empty key,
+        turns on their keyless tier (``<provider>_anonymous``). zhipu/qianfan/
+        linkai reuse model-vendor credentials and go through set_provider
+        instead.
         """
         provider = (data.get("provider") or "bocha").strip().lower()
         if provider not in ("bocha", "anysearch", "serply", "keenable"):
             return json.dumps({"status": "error", "message": f"unsupported search provider: {provider!r}"})
 
-        if provider == "anysearch":
+        if provider in ("anysearch", "keenable"):
             anonymous = data.get("anonymous", False)
 
             api_key = (data.get("api_key") or "").strip() if isinstance(data.get("api_key"), str) else ""
+            key_field = f"{provider}_api_key"
+            anonymous_field = f"{provider}_anonymous"
+            anonymous_on = bool(anonymous and not api_key)
 
             local_config = conf()
             file_cfg = self._read_file_config()
 
-            self._set_nested_namespace_value(local_config, "tools", "web_search", "anysearch_api_key", api_key)
-            self._set_nested_namespace_value(file_cfg, "tools", "web_search", "anysearch_api_key", api_key)
+            self._set_nested_namespace_value(local_config, "tools", "web_search", key_field, api_key)
+            self._set_nested_namespace_value(file_cfg, "tools", "web_search", key_field, api_key)
 
-            self._set_nested_namespace_value(local_config, "tools", "web_search", "anysearch_anonymous",
-                                             bool(anonymous and not api_key))
-            self._set_nested_namespace_value(file_cfg, "tools", "web_search", "anysearch_anonymous",
-                                             bool(anonymous and not api_key))
+            self._set_nested_namespace_value(local_config, "tools", "web_search", anonymous_field, anonymous_on)
+            self._set_nested_namespace_value(file_cfg, "tools", "web_search", anonymous_field, anonymous_on)
 
             self._write_file_config(file_cfg)
             logger.info(
-                f"[ModelsHandler] search credential set: anysearch_api_key={'***' if api_key else ''}, anonymous={bool(anonymous and not api_key)}")
+                f"[ModelsHandler] search credential set: {key_field}={'***' if api_key else ''}, {anonymous_field}={anonymous_on}")
             return json.dumps({"status": "success", "provider": provider})
         else:
             key_field = f"{provider}_api_key"

--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -4228,7 +4228,11 @@ class ModelsHandler:
 
     # Canonical search provider order. Mirrors PROVIDER_ORDER in
     # agent/tools/web_search/web_search.py — keep them in sync.
-    _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply")
+    _SEARCH_PROVIDERS = ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply", "keenable")
+
+    # Providers that work without a key (mirrors KEYLESS_PROVIDERS in the
+    # tool module). They show as configured even with no credential.
+    _KEYLESS_SEARCH_PROVIDERS = ("keenable",)
 
     _SEARCH_PROVIDER_LABELS = {
         "bocha":   {"zh": "博查", "en": "Bocha"},
@@ -4237,6 +4241,7 @@ class ModelsHandler:
         "linkai":  {"zh": "LinkAI", "en": "LinkAI"},
         "anysearch": {"zh": "AnySearch", "en": "AnySearch"},
         "serply":  {"zh": "Serply", "en": "Serply"},
+        "keenable": {"zh": "Keenable", "en": "Keenable"},
     }
 
     @classmethod
@@ -4262,6 +4267,11 @@ class ModelsHandler:
             block = tools_cfg.get("web_search") or {} if isinstance(tools_cfg, dict) else {}
             return (block.get("serply_api_key") if isinstance(block, dict) else "") or os.environ.get(
                 "SERPLY_API_KEY", "")
+        if provider == "keenable":
+            tools_cfg = local_config.get("tools") or {}
+            block = tools_cfg.get("web_search") or {} if isinstance(tools_cfg, dict) else {}
+            return (block.get("keenable_api_key") if isinstance(block, dict) else "") or os.environ.get(
+                "KEENABLE_API_KEY", "")
         return ""
 
     @classmethod
@@ -4284,7 +4294,7 @@ class ModelsHandler:
                 # AnySearch: real key, or an explicit anonymous opt-in.
                 ok = cls._is_real_key(raw_key) or anonymous_on
             else:
-                ok = cls._is_real_key(raw_key)
+                ok = cls._is_real_key(raw_key) or pid in cls._KEYLESS_SEARCH_PROVIDERS
             providers.append({
                 "id": pid,
                 "label": cls._SEARCH_PROVIDER_LABELS.get(pid, pid),
@@ -4294,7 +4304,7 @@ class ModelsHandler:
                 # this hint to decide which credential editor to surface.
                 # Lets the frontend badge "匿名/anonymous" only in anonymous mode.
                 "anonymous": pid == "anysearch" and ok and not raw_key,
-                "needs_dedicated_key": pid in ("bocha", "anysearch", "serply"),
+                "needs_dedicated_key": pid in ("bocha", "anysearch", "serply", "keenable"),
                 "api_key_masked": ConfigHandler._mask_key(raw_key) if raw_key else "",
             })
             if ok:
@@ -5237,11 +5247,12 @@ class ModelsHandler:
     def _handle_set_search_credential(self, data: dict) -> str:
         """Persist a dedicated search-provider key under tools.web_search.
 
-        bocha, anysearch and serply own their keys here; zhipu/qianfan/linkai
-        reuse model-vendor credentials and go through set_provider instead.
+        bocha, anysearch, serply and keenable own their keys here (keenable's
+        is optional); zhipu/qianfan/linkai reuse model-vendor credentials and
+        go through set_provider instead.
         """
         provider = (data.get("provider") or "bocha").strip().lower()
-        if provider not in ("bocha", "anysearch", "serply"):
+        if provider not in ("bocha", "anysearch", "serply", "keenable"):
             return json.dumps({"status": "error", "message": f"unsupported search provider: {provider!r}"})
 
         if provider == "anysearch":

--- a/docs/ja/tools/web-search.mdx
+++ b/docs/ja/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - Web 検索
 description: インターネットからリアルタイム情報を検索。複数の検索プロバイダーに対応
 ---
 
-インターネットからリアルタイム情報、ニュース、リサーチなどを検索します。Bocha、百度 Qianfan、智谱（Zhipu）、LinkAI、AnySearch、Serply、Keenable の 7 つのバックエンドに対応しています。Keenable は API Key なしで利用できるため、このツールは初期状態から使えます。その他のプロバイダーは認証情報を設定すると利用可能になります。
+インターネットからリアルタイム情報、ニュース、リサーチなどを検索します。Bocha、百度 Qianfan、智谱（Zhipu）、LinkAI、AnySearch、Serply、Keenable の 7 つのバックエンドに対応しています。Keenable には明示的に有効化する匿名モード（API Key 不要）もあります。各プロバイダーは認証情報（または匿名モードのオプトイン）を設定すると利用可能になります。
 
 <Tip>
   [Web コンソール](/ja/channels/web) の「モデル管理 → 検索」パネルから、プロバイダーと戦略を可視化して設定するのが推奨です。設定ファイルを手動で編集する必要はありません。
@@ -19,9 +19,9 @@ description: インターネットからリアルタイム情報を検索。複�
 | LinkAI | `linkai_api_key` を再利用 | [LinkAI コンソール](https://link-ai.tech/console/interface) |
 | AnySearch | オプション設定 `tools.web_search.anysearch_api_key`（匿名モード対応） | [AnySearch Open Platform](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[ドキュメント](https://serply.io/docs)） |
-| Keenable | `tools.web_search.keenable_api_key`（任意、レート制限の緩和用） | [Keenable](https://keenable.ai) |
+| Keenable | オプション設定 `tools.web_search.keenable_api_key`、または `keenable_anonymous: true` で Key なし利用 | [Keenable](https://keenable.ai) |
 
-Bocha、AnySearch、Serplyについては専用キー（bocha_api_key / anysearch_api_key / serply_api_key）を別途設定する必要がありますが、その他の3社は対応するモデルのAPIキーをそのまま流用でき、モデルを設定すれば同時に検索機能も利用可能になります。Keenable は API Key 不要です。デフォルトでは IP 単位のレート制限（10 リクエスト/秒、1000 リクエスト/時）がある公開エンドポイントを呼び出し、任意の `keenable_api_key`（または `KEENABLE_API_KEY`）を設定すると制限が解除されます。
+Bocha、AnySearch、Serplyについては専用キー（bocha_api_key / anysearch_api_key / serply_api_key）を別途設定する必要がありますが、その他の3社は対応するモデルのAPIキーをそのまま流用でき、モデルを設定すれば同時に検索機能も利用可能になります。Keenable はオプトイン方式です。`tools.web_search.keenable_anonymous` を `true` に設定（またはコンソールの「検索」パネルで Key を空のまま保存）すると、IP 単位のレート制限（10 リクエスト/秒、1000 リクエスト/時）がある公開エンドポイントを呼び出します。任意の `keenable_api_key`（または `KEENABLE_API_KEY`）を設定すると制限が解除され、オプトインは不要です。
 
 ## ルーティング戦略
 
@@ -51,5 +51,5 @@ Bocha、AnySearch、Serplyについては専用キー（bocha_api_key / anysearc
 | `provider` | string | いいえ | `auto` 戦略で複数プロバイダーを設定している場合に表示。単回のプロバイダー切り替えに使用 |
 
 <Note>
-  Keenable は常に利用可能なため、このツールは常に Agent に登録されます。他の認証情報が未設定の場合、すべての検索は Keenable の Key 不要エンドポイントを経由します。
+  7 社のプロバイダーがいずれも未設定（Key も匿名モードのオプトインもない）の場合、このツールは Agent に登録されません。
 </Note>

--- a/docs/ja/tools/web-search.mdx
+++ b/docs/ja/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - Web 検索
 description: インターネットからリアルタイム情報を検索。複数の検索プロバイダーに対応
 ---
 
-インターネットからリアルタイム情報、ニュース、リサーチなどを検索します。Bocha、百度 Qianfan、智谱（Zhipu）、LinkAI、AnySearch、Serply の 6 つのバックエンドに対応しており、いずれか 1 社を設定すれば利用可能です。
+インターネットからリアルタイム情報、ニュース、リサーチなどを検索します。Bocha、百度 Qianfan、智谱（Zhipu）、LinkAI、AnySearch、Serply、Keenable の 7 つのバックエンドに対応しています。Keenable は API Key なしで利用できるため、このツールは初期状態から使えます。その他のプロバイダーは認証情報を設定すると利用可能になります。
 
 <Tip>
   [Web コンソール](/ja/channels/web) の「モデル管理 → 検索」パネルから、プロバイダーと戦略を可視化して設定するのが推奨です。設定ファイルを手動で編集する必要はありません。
@@ -19,8 +19,9 @@ description: インターネットからリアルタイム情報を検索。複�
 | LinkAI | `linkai_api_key` を再利用 | [LinkAI コンソール](https://link-ai.tech/console/interface) |
 | AnySearch | オプション設定 `tools.web_search.anysearch_api_key`（匿名モード対応） | [AnySearch Open Platform](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[ドキュメント](https://serply.io/docs)） |
+| Keenable | `tools.web_search.keenable_api_key`（任意、レート制限の緩和用） | [Keenable](https://keenable.ai) |
 
-Bocha、AnySearch、Serplyについては専用キー（bocha_api_key / anysearch_api_key / serply_api_key）を別途設定する必要がありますが、その他の3社は対応するモデルのAPIキーをそのまま流用でき、モデルを設定すれば同時に検索機能も利用可能になります。
+Bocha、AnySearch、Serplyについては専用キー（bocha_api_key / anysearch_api_key / serply_api_key）を別途設定する必要がありますが、その他の3社は対応するモデルのAPIキーをそのまま流用でき、モデルを設定すれば同時に検索機能も利用可能になります。Keenable は API Key 不要です。デフォルトでは IP 単位のレート制限（10 リクエスト/秒、1000 リクエスト/時）がある公開エンドポイントを呼び出し、任意の `keenable_api_key`（または `KEENABLE_API_KEY`）を設定すると制限が解除されます。
 
 ## ルーティング戦略
 
@@ -35,7 +36,7 @@ Bocha、AnySearch、Serplyについては専用キー（bocha_api_key / anysearc
 }
 ```
 
-- `auto`（デフォルト）：Agent が設定済みのプロバイダーから自動的に選択し、1 回のタスク内で複数回呼び出し、異なるプロバイダーを切り替えてより包括的な結果を取得できます。未指定の場合は `bocha → qianfan → zhipu → linkai → anysearch → serply` の順でフォールバックします。
+- `auto`（デフォルト）：Agent が設定済みのプロバイダーから自動的に選択し、1 回のタスク内で複数回呼び出し、異なるプロバイダーを切り替えてより包括的な結果を取得できます。未指定の場合は `bocha → qianfan → zhipu → linkai → anysearch → serply → keenable` の順でフォールバックします。
 
 - `fixed`：`provider` で指定したプロバイダーに固定。該当プロバイダーの認証情報が欠けている場合は自動的に auto の順序にフォールバックします。
 
@@ -50,5 +51,5 @@ Bocha、AnySearch、Serplyについては専用キー（bocha_api_key / anysearc
 | `provider` | string | いいえ | `auto` 戦略で複数プロバイダーを設定している場合に表示。単回のプロバイダー切り替えに使用 |
 
 <Note>
-  6 社の認証情報がいずれも未設定の場合、このツールは Agent に登録されません。
+  Keenable は常に利用可能なため、このツールは常に Agent に登録されます。他の認証情報が未設定の場合、すべての検索は Keenable の Key 不要エンドポイントを経由します。
 </Note>

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - Web Search
 description: Search the internet for real-time information, with support for multiple search providers
 ---
 
-Search the internet for real-time information, news, research, and more. Supports six backends — Bocha, ERNIE, GLM, LinkAI, AnySearch, and Serply — and works once any one of them is configured.
+Search the internet for real-time information, news, research, and more. Supports seven backends: Bocha, ERNIE, GLM, LinkAI, AnySearch, Serply, and Keenable. Keenable works without any key, so the tool is available out of the box; the others are used once their credentials are configured.
 
 <Tip>
   It is recommended to configure providers and routing strategy visually from the "Model Management → Search" panel in the [Web console](/channels/web), without manually editing the configuration file.
@@ -19,8 +19,9 @@ Search the internet for real-time information, news, research, and more. Support
 | LinkAI | Reuses `linkai_api_key` | [LinkAI Console](https://link-ai.tech/console/interface) |
 | AnySearch | Optional `tools.web_search.anysearch_api_key`(Anonymous mode is available) | [AnySearch Console](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io) ([docs](https://serply.io/docs)) |
+| Keenable | `tools.web_search.keenable_api_key` (optional, lifts rate limits) | [Keenable](https://keenable.ai) |
 
-Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_key / anysearch_api_key / serply_api_key), the other three reuse the corresponding model's API key — configuring the model automatically grants search capability.
+Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_key / anysearch_api_key / serply_api_key), the other three reuse the corresponding model's API key — configuring the model automatically grants search capability. Keenable needs no key: it calls a public endpoint with per-IP rate limits (10 requests/s, 1000/hour), and an optional `keenable_api_key` (or `KEENABLE_API_KEY`) lifts them.
 
 ## Routing Strategy
 
@@ -35,7 +36,7 @@ Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_
 }
 ```
 
-- `auto` (default): the Agent intelligently picks among configured providers and may call multiple providers in a single task to gather more comprehensive results; when none is specified, falls back through `bocha → qianfan → zhipu → linkai → anysearch → serply`.
+- `auto` (default): the Agent intelligently picks among configured providers and may call multiple providers in a single task to gather more comprehensive results; when none is specified, falls back through `bocha → qianfan → zhipu → linkai → anysearch → serply → keenable`.
 
 - `fixed`: always use the provider specified in `provider`; falls back to the auto order if that provider's credentials are missing.
 
@@ -50,5 +51,5 @@ Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_
 | `provider` | string | No | Available when multiple providers are configured under the `auto` strategy; used to switch provider for a single call |
 
 <Note>
-  If none of the six credentials are configured, this tool is not registered with the Agent.
+  Keenable is always available, so this tool is always registered with the Agent. With no other credentials configured, every search goes through Keenable's keyless endpoint.
 </Note>

--- a/docs/tools/web-search.mdx
+++ b/docs/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - Web Search
 description: Search the internet for real-time information, with support for multiple search providers
 ---
 
-Search the internet for real-time information, news, research, and more. Supports seven backends: Bocha, ERNIE, GLM, LinkAI, AnySearch, Serply, and Keenable. Keenable works without any key, so the tool is available out of the box; the others are used once their credentials are configured.
+Search the internet for real-time information, news, research, and more. Supports seven backends: Bocha, ERNIE, GLM, LinkAI, AnySearch, Serply, and Keenable. Keenable also has a keyless anonymous mode that you turn on explicitly; each backend is used once its credentials (or that opt-in) are configured.
 
 <Tip>
   It is recommended to configure providers and routing strategy visually from the "Model Management → Search" panel in the [Web console](/channels/web), without manually editing the configuration file.
@@ -19,9 +19,9 @@ Search the internet for real-time information, news, research, and more. Support
 | LinkAI | Reuses `linkai_api_key` | [LinkAI Console](https://link-ai.tech/console/interface) |
 | AnySearch | Optional `tools.web_search.anysearch_api_key`(Anonymous mode is available) | [AnySearch Console](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io) ([docs](https://serply.io/docs)) |
-| Keenable | `tools.web_search.keenable_api_key` (optional, lifts rate limits) | [Keenable](https://keenable.ai) |
+| Keenable | Optional `tools.web_search.keenable_api_key`, or `keenable_anonymous: true` for keyless use | [Keenable](https://keenable.ai) |
 
-Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_key / anysearch_api_key / serply_api_key), the other three reuse the corresponding model's API key — configuring the model automatically grants search capability. Keenable needs no key: it calls a public endpoint with per-IP rate limits (10 requests/s, 1000/hour), and an optional `keenable_api_key` (or `KEENABLE_API_KEY`) lifts them.
+Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_key / anysearch_api_key / serply_api_key), the other three reuse the corresponding model's API key — configuring the model automatically grants search capability. Keenable is opt-in: set `tools.web_search.keenable_anonymous` to `true` (or save it with an empty key in the console's Search panel) and it calls a public endpoint with per-IP rate limits (10 requests/s, 1000/hour); an optional `keenable_api_key` (or `KEENABLE_API_KEY`) lifts them and needs no opt-in.
 
 ## Routing Strategy
 
@@ -51,5 +51,5 @@ Except for Bocha, AnySearch, and Serply which require dedicated keys (bocha_api_
 | `provider` | string | No | Available when multiple providers are configured under the `auto` strategy; used to switch provider for a single call |
 
 <Note>
-  Keenable is always available, so this tool is always registered with the Agent. With no other credentials configured, every search goes through Keenable's keyless endpoint.
+  If none of the seven providers is configured (no key and no anonymous opt-in), this tool is not registered with the Agent.
 </Note>

--- a/docs/zh/tools/web-search.mdx
+++ b/docs/zh/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - 联网搜索
 description: 搜索互联网获取实时信息，支持多个搜索厂商
 ---
 
-搜索互联网获取实时信息、新闻、研究等内容。支持博查、百度千帆、智谱、LinkAI、AnySearch、Serply、Keenable 七个后端。Keenable 无需密钥即可使用，因此该工具开箱可用；其余厂商配置凭证后即可使用。
+搜索互联网获取实时信息、新闻、研究等内容。支持博查、百度千帆、智谱、LinkAI、AnySearch、Serply、Keenable 七个后端。Keenable 另提供需手动开启的匿名模式（无需密钥）；各厂商配置凭证（或开启匿名模式）后即可使用。
 
 <Tip>
   推荐通过 [Web 控制台](/zh/channels/web) 的「模型管理 → 搜索」面板可视化配置厂商与策略，无需手动编辑配置文件。
@@ -19,9 +19,9 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | LinkAI | 复用 `linkai_api_key` | [LinkAI 控制台](https://link-ai.tech/console/interface) |
 | AnySearch | 可选配置项 `tools.web_search.anysearch_api_key`（支持匿名模式） | [AnySearch 控制台](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[文档](https://serply.io/docs)） |
-| Keenable | `tools.web_search.keenable_api_key`（可选，用于提升频率上限） | [Keenable](https://keenable.ai) |
+| Keenable | 可选配置项 `tools.web_search.keenable_api_key`，或设置 `keenable_anonymous: true` 免密钥使用 | [Keenable](https://keenable.ai) |
 
-除博查、AnySearch、Serply 需要单独配置专用密钥（bocha_api_key / anysearch_api_key / serply_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。Keenable 无需密钥：默认调用公共接口，按 IP 限流（10 次/秒、1000 次/小时），配置可选的 `keenable_api_key`（或 `KEENABLE_API_KEY`）后限制解除。
+除博查、AnySearch、Serply 需要单独配置专用密钥（bocha_api_key / anysearch_api_key / serply_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。Keenable 需手动开启：将 `tools.web_search.keenable_anonymous` 设为 `true`（或在控制台「搜索」面板留空密钥保存）后调用公共接口，按 IP 限流（10 次/秒、1000 次/小时）；配置可选的 `keenable_api_key`（或 `KEENABLE_API_KEY`）后限制解除，且无需开启匿名模式。
 
 ## 路由策略
 
@@ -51,5 +51,5 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | `provider` | string | 否 | `auto` 策略下配置了多个厂商时可见，用于单次切换厂商 |
 
 <Note>
-  Keenable 始终可用，因此该工具始终会注册到 Agent；未配置其他凭证时，所有搜索都走 Keenable 的免密钥接口。
+  七家厂商均未配置（既无密钥也未开启匿名模式）时，该工具不会注册到 Agent。
 </Note>

--- a/docs/zh/tools/web-search.mdx
+++ b/docs/zh/tools/web-search.mdx
@@ -3,7 +3,7 @@ title: web_search - 联网搜索
 description: 搜索互联网获取实时信息，支持多个搜索厂商
 ---
 
-搜索互联网获取实时信息、新闻、研究等内容。支持博查、百度千帆、智谱、LinkAI、AnySearch、Serply 六个后端，配置任意一家即可使用。
+搜索互联网获取实时信息、新闻、研究等内容。支持博查、百度千帆、智谱、LinkAI、AnySearch、Serply、Keenable 七个后端。Keenable 无需密钥即可使用，因此该工具开箱可用；其余厂商配置凭证后即可使用。
 
 <Tip>
   推荐通过 [Web 控制台](/zh/channels/web) 的「模型管理 → 搜索」面板可视化配置厂商与策略，无需手动编辑配置文件。
@@ -19,8 +19,9 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | LinkAI | 复用 `linkai_api_key` | [LinkAI 控制台](https://link-ai.tech/console/interface) |
 | AnySearch | 可选配置项 `tools.web_search.anysearch_api_key`（支持匿名模式） | [AnySearch 控制台](https://anysearch.com/) |
 | Serply | `tools.web_search.serply_api_key` | [Serply](https://serply.io)（[文档](https://serply.io/docs)） |
+| Keenable | `tools.web_search.keenable_api_key`（可选，用于提升频率上限） | [Keenable](https://keenable.ai) |
 
-除博查、AnySearch、Serply 需要单独配置专用密钥（bocha_api_key / anysearch_api_key / serply_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。
+除博查、AnySearch、Serply 需要单独配置专用密钥（bocha_api_key / anysearch_api_key / serply_api_key）外，其他三家直接复用对应模型的 API Key，配好模型即同时获得搜索能力。Keenable 无需密钥：默认调用公共接口，按 IP 限流（10 次/秒、1000 次/小时），配置可选的 `keenable_api_key`（或 `KEENABLE_API_KEY`）后限制解除。
 
 ## 路由策略
 
@@ -35,7 +36,7 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 }
 ```
 
-- `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai → anysearch → serply` 顺序兜底。
+- `auto`（默认）：由 Agent 在已配置的厂商中智能选择，并可在一次任务中多次调用、切换不同厂商以获取更全面的结果；未指定时按 `bocha → qianfan → zhipu → linkai → anysearch → serply → keenable` 顺序兜底。
 
 - `fixed`：固定使用 `provider` 指定的厂商；该厂商凭证缺失时自动回落到 auto 顺序。
 
@@ -50,5 +51,5 @@ description: 搜索互联网获取实时信息，支持多个搜索厂商
 | `provider` | string | 否 | `auto` 策略下配置了多个厂商时可见，用于单次切换厂商 |
 
 <Note>
-  六家凭证均未配置时，该工具不会注册到 Agent。
+  Keenable 始终可用，因此该工具始终会注册到 Agent；未配置其他凭证时，所有搜索都走 Keenable 的免密钥接口。
 </Note>

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -8,8 +8,9 @@ provider fallback order, result normalization into the unified output shape,
 the AnySearch-specific count clamp (the shared tool schema allows 1-50 while
 the API accepts 1-10), HTTP and business-level error mapping, and the
 anonymous mode contract (no Authorization header without a key), and the
-keyless contract of Keenable (always configured; public endpoint plus the
-``X-Keenable-Title`` header without a key, ``X-API-Key`` with one).
+keyless contract of Keenable (opt-in via ``keenable_anonymous``, mirroring
+``anysearch_anonymous``; public endpoint plus the ``X-Keenable-Title`` header
+without a key, ``X-API-Key`` with one).
 
 No real network is used: ``requests.post`` / ``requests.get`` are stubbed
 throughout.
@@ -80,15 +81,14 @@ class TestAnySearchKeyResolution(unittest.TestCase):
 
 class TestProviderOrder(unittest.TestCase):
     """New providers are appended after the four originals, leaving existing
-    routing untouched: anysearch, then serply, then keenable (keyless, so it
-    must come after every provider the user may have paid for)."""
+    routing untouched: anysearch, then serply, then keenable (its keyless
+    tier must come after every provider the user may have paid for)."""
 
     def test_provider_order_appends_new_providers_last(self):
         self.assertEqual(
             web_search_module.PROVIDER_ORDER,
             ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply", "keenable"),
         )
-        self.assertEqual(web_search_module.KEYLESS_PROVIDERS, ("keenable",))
 
     def test_web_console_provider_list_stays_in_sync(self):
         """The web console keeps its own copy of the provider order plus the
@@ -108,27 +108,40 @@ class TestProviderOrder(unittest.TestCase):
         with patch.dict(os.environ, {"SERPLY_API_KEY": ""}):
             self.assertEqual(ModelsHandler._search_provider_key("serply", {}), "")
 
-        self.assertEqual(ModelsHandler._KEYLESS_SEARCH_PROVIDERS, web_search_module.KEYLESS_PROVIDERS)
         cfg = {"tools": {"web_search": {"keenable_api_key": "console-key"}}}
         self.assertEqual(ModelsHandler._search_provider_key("keenable", cfg), "console-key")
         with patch.dict(os.environ, {"KEENABLE_API_KEY": "env-key"}):
             self.assertEqual(ModelsHandler._search_provider_key("keenable", {}), "env-key")
 
-    def test_web_console_marks_keyless_provider_configured(self):
-        """With no credential anywhere the Search panel still shows keenable
-        as configured (and as the active backend), so the console agrees
-        with the tool about what a fresh install can do."""
+    def test_web_console_mirrors_keenable_opt_in(self):
+        """The Search panel agrees with the tool: keenable is not configured
+        on a fresh install, shows as configured and badged anonymous once
+        keenable_anonymous is on, and as configured (no badge) with a key."""
         from channel.web.web_channel import ModelsHandler
 
-        env = {k: "" for k in _ALL_SEARCH_ENV}
-        with patch.dict(os.environ, env):
-            cap = ModelsHandler._search_capability({})
-        by_id = {p["id"]: p for p in cap["providers"]}
-        self.assertTrue(by_id["keenable"]["configured"])
-        self.assertTrue(by_id["keenable"]["needs_dedicated_key"])
-        self.assertEqual(by_id["keenable"]["api_key_masked"], "")
-        self.assertFalse(by_id["serply"]["configured"])
-        self.assertEqual(cap["current_provider"], "keenable")
+        with patch.dict(os.environ, {k: "" for k in _ALL_SEARCH_ENV}):
+            fresh = ModelsHandler._search_capability({})
+            anon = ModelsHandler._search_capability(
+                {"tools": {"web_search": {"keenable_anonymous": True}}})
+            keyed = ModelsHandler._search_capability(
+                {"tools": {"web_search": {"keenable_api_key": "sk-test-key"}}})
+
+        fresh_k = {p["id"]: p for p in fresh["providers"]}["keenable"]
+        self.assertFalse(fresh_k["configured"])
+        self.assertFalse(fresh_k["anonymous"])
+        self.assertTrue(fresh_k["needs_dedicated_key"])
+        self.assertNotEqual(fresh["current_provider"], "keenable")
+
+        anon_k = {p["id"]: p for p in anon["providers"]}["keenable"]
+        self.assertTrue(anon_k["configured"])
+        self.assertTrue(anon_k["anonymous"])
+        self.assertEqual(anon_k["api_key_masked"], "")
+        self.assertEqual(anon["current_provider"], "keenable")
+
+        keyed_k = {p["id"]: p for p in keyed["providers"]}["keenable"]
+        self.assertTrue(keyed_k["configured"])
+        self.assertFalse(keyed_k["anonymous"])
+        self.assertNotEqual(keyed_k["api_key_masked"], "")
 
 
 _ALL_SEARCH_ENV = (
@@ -137,25 +150,76 @@ _ALL_SEARCH_ENV = (
 )
 
 
-class TestKeylessAvailability(unittest.TestCase):
-    """Keenable needs no key, so the tool is registered on a fresh install and
-    keenable is what a keyless install resolves to. A configured provider
+class TestKeenableOptIn(unittest.TestCase):
+    """Keenable's keyless tier is opt-in, mirroring anysearch_anonymous: a
+    fresh install configures nothing and the tool is not registered; with
+    keenable_anonymous (or a key) keenable is configured. A keyed provider
     still wins because keenable sits last in PROVIDER_ORDER."""
 
-    def test_no_keys_still_configures_keenable(self):
+    def test_fresh_install_leaves_keenable_unconfigured(self):
         with patch.object(web_search_module, "conf", lambda: {}), \
+                patch.dict(os.environ, {k: "" for k in _ALL_SEARCH_ENV}):
+            self.assertEqual(web_search_module.configured_providers(), [])
+            self.assertFalse(web_search_module.WebSearch.is_available())
+            self.assertFalse(web_search_module.WebSearch()._resolve_provider(None))
+
+    def test_anysearch_opt_in_does_not_enable_keenable(self):
+        cfg = {"tools": {"web_search": {"anysearch_anonymous": True}}}
+        with patch.object(web_search_module, "conf", lambda: cfg), \
+                patch.dict(os.environ, {k: "" for k in _ALL_SEARCH_ENV}):
+            self.assertEqual(web_search_module.configured_providers(), ["anysearch"])
+
+    def test_anonymous_opt_in_configures_keenable(self):
+        cfg = {"tools": {"web_search": {"keenable_anonymous": True}}}
+        with patch.object(web_search_module, "conf", lambda: cfg), \
                 patch.dict(os.environ, {k: "" for k in _ALL_SEARCH_ENV}):
             self.assertEqual(web_search_module.configured_providers(), ["keenable"])
             self.assertTrue(web_search_module.WebSearch.is_available())
             self.assertEqual(web_search_module.WebSearch()._resolve_provider(None), "keenable")
 
+    def test_key_configures_keenable_without_opt_in(self):
+        cfg = {"tools": {"web_search": {"keenable_api_key": "sk-test"}}}
+        with patch.object(web_search_module, "conf", lambda: cfg), \
+                patch.dict(os.environ, {k: "" for k in _ALL_SEARCH_ENV}):
+            self.assertEqual(web_search_module.configured_providers(), ["keenable"])
+            self.assertTrue(web_search_module.WebSearch.is_available())
+
     def test_keyed_provider_wins_over_keenable(self):
-        cfg = {"tools": {"web_search": {"serply_api_key": "k"}}}
+        cfg = {"tools": {"web_search": {"serply_api_key": "k", "keenable_anonymous": True}}}
         with patch.object(web_search_module, "conf", lambda: cfg), \
                 patch.dict(os.environ, {k: "" for k in _ALL_SEARCH_ENV}):
             self.assertEqual(web_search_module.configured_providers(), ["serply", "keenable"])
             self.assertEqual(web_search_module.WebSearch()._resolve_provider(None), "serply")
             self.assertEqual(web_search_module.WebSearch()._resolve_provider("keenable"), "keenable")
+
+
+class TestConsoleSearchCredential(unittest.TestCase):
+    """The console's save path writes keenable_anonymous the same way it does
+    anysearch_anonymous: an empty key with anonymous=true turns the tier on,
+    a real key turns it off, and clearing the key turns it off again."""
+
+    def _save(self, payload):
+        from channel.web.web_channel import ModelsHandler
+
+        with patch("channel.web.web_channel.conf", return_value={}), \
+                patch.object(ModelsHandler, "_read_file_config", return_value={}), \
+                patch.object(ModelsHandler, "_write_file_config") as write:
+            out = json.loads(ModelsHandler()._handle_set_search_credential(payload))
+        self.assertEqual(out["status"], "success")
+        write.assert_called_once()
+        return write.call_args[0][0]["tools"]["web_search"]
+
+    def test_empty_key_with_anonymous_enables_keenable(self):
+        ws = self._save({"provider": "keenable", "api_key": "", "anonymous": True})
+        self.assertEqual(ws, {"keenable_api_key": "", "keenable_anonymous": True})
+
+    def test_key_disables_anonymous(self):
+        ws = self._save({"provider": "keenable", "api_key": "sk-test", "anonymous": True})
+        self.assertEqual(ws, {"keenable_api_key": "sk-test", "keenable_anonymous": False})
+
+    def test_clear_disables_anonymous(self):
+        ws = self._save({"provider": "keenable", "api_key": ""})
+        self.assertEqual(ws, {"keenable_api_key": "", "keenable_anonymous": False})
 
 
 class TestAnySearchBackend(unittest.TestCase):

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,13 +1,15 @@
 # encoding:utf-8
 """
-Unit tests for the web_search tool, focused on the AnySearch and Serply
-backends.
+Unit tests for the web_search tool, focused on the AnySearch, Serply and
+Keenable backends.
 
 Covers key resolution (config file + environment fallback), the canonical
 provider fallback order, result normalization into the unified output shape,
 the AnySearch-specific count clamp (the shared tool schema allows 1-50 while
 the API accepts 1-10), HTTP and business-level error mapping, and the
-anonymous mode contract (no Authorization header without a key).
+anonymous mode contract (no Authorization header without a key), and the
+keyless contract of Keenable (always configured; public endpoint plus the
+``X-Keenable-Title`` header without a key, ``X-API-Key`` with one).
 
 No real network is used: ``requests.post`` / ``requests.get`` are stubbed
 throughout.
@@ -78,13 +80,15 @@ class TestAnySearchKeyResolution(unittest.TestCase):
 
 class TestProviderOrder(unittest.TestCase):
     """New providers are appended after the four originals, leaving existing
-    routing untouched: anysearch first, then serply."""
+    routing untouched: anysearch, then serply, then keenable (keyless, so it
+    must come after every provider the user may have paid for)."""
 
     def test_provider_order_appends_new_providers_last(self):
         self.assertEqual(
             web_search_module.PROVIDER_ORDER,
-            ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply"),
+            ("bocha", "qianfan", "zhipu", "linkai", "anysearch", "serply", "keenable"),
         )
+        self.assertEqual(web_search_module.KEYLESS_PROVIDERS, ("keenable",))
 
     def test_web_console_provider_list_stays_in_sync(self):
         """The web console keeps its own copy of the provider order plus the
@@ -103,6 +107,55 @@ class TestProviderOrder(unittest.TestCase):
             self.assertEqual(ModelsHandler._search_provider_key("serply", {}), "env-key")
         with patch.dict(os.environ, {"SERPLY_API_KEY": ""}):
             self.assertEqual(ModelsHandler._search_provider_key("serply", {}), "")
+
+        self.assertEqual(ModelsHandler._KEYLESS_SEARCH_PROVIDERS, web_search_module.KEYLESS_PROVIDERS)
+        cfg = {"tools": {"web_search": {"keenable_api_key": "console-key"}}}
+        self.assertEqual(ModelsHandler._search_provider_key("keenable", cfg), "console-key")
+        with patch.dict(os.environ, {"KEENABLE_API_KEY": "env-key"}):
+            self.assertEqual(ModelsHandler._search_provider_key("keenable", {}), "env-key")
+
+    def test_web_console_marks_keyless_provider_configured(self):
+        """With no credential anywhere the Search panel still shows keenable
+        as configured (and as the active backend), so the console agrees
+        with the tool about what a fresh install can do."""
+        from channel.web.web_channel import ModelsHandler
+
+        env = {k: "" for k in _ALL_SEARCH_ENV}
+        with patch.dict(os.environ, env):
+            cap = ModelsHandler._search_capability({})
+        by_id = {p["id"]: p for p in cap["providers"]}
+        self.assertTrue(by_id["keenable"]["configured"])
+        self.assertTrue(by_id["keenable"]["needs_dedicated_key"])
+        self.assertEqual(by_id["keenable"]["api_key_masked"], "")
+        self.assertFalse(by_id["serply"]["configured"])
+        self.assertEqual(cap["current_provider"], "keenable")
+
+
+_ALL_SEARCH_ENV = (
+    "BOCHA_API_KEY", "ZHIPUAI_API_KEY", "QIANFAN_API_KEY", "LINKAI_API_KEY",
+    "ANYSEARCH_API_KEY", "SERPLY_API_KEY", "KEENABLE_API_KEY",
+)
+
+
+class TestKeylessAvailability(unittest.TestCase):
+    """Keenable needs no key, so the tool is registered on a fresh install and
+    keenable is what a keyless install resolves to. A configured provider
+    still wins because keenable sits last in PROVIDER_ORDER."""
+
+    def test_no_keys_still_configures_keenable(self):
+        with patch.object(web_search_module, "conf", lambda: {}), \
+                patch.dict(os.environ, {k: "" for k in _ALL_SEARCH_ENV}):
+            self.assertEqual(web_search_module.configured_providers(), ["keenable"])
+            self.assertTrue(web_search_module.WebSearch.is_available())
+            self.assertEqual(web_search_module.WebSearch()._resolve_provider(None), "keenable")
+
+    def test_keyed_provider_wins_over_keenable(self):
+        cfg = {"tools": {"web_search": {"serply_api_key": "k"}}}
+        with patch.object(web_search_module, "conf", lambda: cfg), \
+                patch.dict(os.environ, {k: "" for k in _ALL_SEARCH_ENV}):
+            self.assertEqual(web_search_module.configured_providers(), ["serply", "keenable"])
+            self.assertEqual(web_search_module.WebSearch()._resolve_provider(None), "serply")
+            self.assertEqual(web_search_module.WebSearch()._resolve_provider("keenable"), "keenable")
 
 
 class TestAnySearchBackend(unittest.TestCase):
@@ -316,6 +369,148 @@ class TestSerplyBackend(unittest.TestCase):
                     result = self.tool._search_serply("q", 10)
                 self.assertEqual(result.status, "error")
                 self.assertIn(fragment, result.result)
+
+
+def _keenable_payload(results):
+    """Build a Keenable /v1/search response body in the documented shape."""
+    return {"query": "q", "results": results}
+
+
+class TestKeenableKeyResolution(unittest.TestCase):
+    """The keenable key lives under tools.web_search, falling back to env."""
+
+    def setUp(self):
+        self._prev_env = os.environ.get("KEENABLE_API_KEY")
+        os.environ.pop("KEENABLE_API_KEY", None)
+
+    def tearDown(self):
+        if self._prev_env is None:
+            os.environ.pop("KEENABLE_API_KEY", None)
+        else:
+            os.environ["KEENABLE_API_KEY"] = self._prev_env
+
+    def test_keenable_key_from_tools_config(self):
+        """tools.web_search.keenable_api_key is resolved, and wins over env."""
+        cfg = {"tools": {"web_search": {"keenable_api_key": "test-key-123"}}}
+        with patch.object(web_search_module, "conf", lambda: cfg):
+            self.assertEqual(web_search_module._get_api_key("keenable"), "test-key-123")
+            with patch.dict(os.environ, {"KEENABLE_API_KEY": "env-key-456"}):
+                self.assertEqual(web_search_module._get_api_key("keenable"), "test-key-123")
+
+    def test_keenable_key_env_fallback(self):
+        """Without a config value, KEENABLE_API_KEY is used; both empty -> ''."""
+        with patch.object(web_search_module, "conf", lambda: {}):
+            with patch.dict(os.environ, {"KEENABLE_API_KEY": "env-key-456"}):
+                self.assertEqual(web_search_module._get_api_key("keenable"), "env-key-456")
+            self.assertEqual(web_search_module._get_api_key("keenable"), "")
+
+
+class TestKeenableBackend(unittest.TestCase):
+    """Behaviour of WebSearch._search_keenable with a stubbed HTTP layer."""
+
+    def setUp(self):
+        self.tool = web_search_module.WebSearch()
+
+    def test_search_keenable_keyless_uses_public_endpoint(self):
+        """Without a key the public endpoint is called with the app title
+        header and no X-API-Key; `snippet` maps to snippet, falling back to
+        `description`, and `published_at` to datePublished."""
+        payload = _keenable_payload([
+            {"title": "T1", "url": "https://a.example/1", "snippet": "s1", "description": "",
+             "published_at": "2026-08-07T09:56:16Z"},
+            {"title": "T2", "url": "https://a.example/2", "snippet": "", "description": "d2"},
+        ])
+        with patch.object(web_search_module, "_get_api_key", return_value=""), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, payload)) as mock_post:
+            result = self.tool._search_keenable("cowagent", 10, "noLimit", False)
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.result["backend"], "keenable")
+        self.assertEqual(result.result["total"], 2)
+        self.assertEqual(result.result["count"], 2)
+        first, second = result.result["results"]
+        self.assertEqual(first, {"title": "T1", "url": "https://a.example/1", "snippet": "s1",
+                                 "datePublished": "2026-08-07T09:56:16Z"})
+        self.assertEqual(second["snippet"], "d2")
+        self.assertEqual(second["datePublished"], "")
+
+        self.assertEqual(mock_post.call_args[0][0], "https://api.keenable.ai/v1/search/public")
+        headers = mock_post.call_args[1]["headers"]
+        self.assertEqual(headers.get("X-Keenable-Title"), "cowagent")
+        self.assertNotIn("X-API-Key", headers)
+        body = mock_post.call_args[1]["json"]
+        self.assertEqual(body["query"], "cowagent")
+        self.assertEqual(body["max_results"], 10)
+        self.assertEqual(body["snippet_max_length"], 300)
+        self.assertNotIn("published_after", body)
+
+    def test_search_keenable_keyed_uses_authenticated_endpoint(self):
+        """With a key the authenticated endpoint is called with X-API-Key; the
+        app title header is still sent. summary=True asks for longer snippets."""
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _keenable_payload([]))) as mock_post:
+            result = self.tool._search_keenable("q", 10, "noLimit", True)
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(mock_post.call_args[0][0], "https://api.keenable.ai/v1/search")
+        headers = mock_post.call_args[1]["headers"]
+        self.assertEqual(headers.get("X-API-Key"), "test-key-123")
+        self.assertEqual(headers.get("X-Keenable-Title"), "cowagent")
+        self.assertEqual(mock_post.call_args[1]["json"]["snippet_max_length"], 1000)
+
+    def test_search_keenable_clamps_count(self):
+        """count is clamped into 1-50 and sent as max_results; a falsy count
+        falls back to the default of 10."""
+        with patch.object(web_search_module, "_get_api_key", return_value=""), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _keenable_payload([]))) as mock_post:
+            for count, expected in ((50, 50), (99, 50), (0, 10), (None, 10), (10, 10)):
+                with self.subTest(count=count):
+                    self.tool._search_keenable("q", count, "noLimit", False)
+                    self.assertEqual(mock_post.call_args[1]["json"]["max_results"], expected)
+
+    def test_search_keenable_freshness_filter(self):
+        """Named tokens become published_after; a date range becomes
+        published_after + published_before; anything else sends no filter."""
+        build = web_search_module.WebSearch._keenable_build_freshness_filter
+        self.assertEqual(build("noLimit"), {})
+        self.assertEqual(build(""), {})
+        self.assertEqual(build("someday"), {})
+        self.assertEqual(
+            build("2025-01-01..2025-02-01"),
+            {"published_after": "2025-01-01", "published_before": "2025-02-01"},
+        )
+        week = build("oneWeek")
+        self.assertEqual(list(week), ["published_after"])
+        from datetime import datetime, timedelta
+        self.assertEqual(week["published_after"], (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d"))
+
+    def test_search_keenable_error_status_mapping(self):
+        """401/429 map to specific messages; other statuses are generic. A
+        keyless 429 points at the optional key, a keyed one does not."""
+        cases = {
+            401: "Invalid Keenable API key",
+            429: "rate limit reached",
+            500: "HTTP 500",
+        }
+        for status_code, fragment in cases.items():
+            with self.subTest(status_code=status_code):
+                with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                        patch.object(web_search_module.requests, "post",
+                                     return_value=_fake_response(status_code)):
+                    result = self.tool._search_keenable("q", 10, "noLimit", False)
+                self.assertEqual(result.status, "error")
+                self.assertIn(fragment, result.result)
+                self.assertNotIn("KEENABLE_API_KEY", result.result)
+
+        with patch.object(web_search_module, "_get_api_key", return_value=""), \
+                patch.object(web_search_module.requests, "post", return_value=_fake_response(429)):
+            result = self.tool._search_keenable("q", 10, "noLimit", False)
+        self.assertEqual(result.status, "error")
+        self.assertIn("rate limit reached", result.result)
+        self.assertIn("KEENABLE_API_KEY", result.result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Adds Keenable as a seventh `web_search` backend. Keenable's public endpoint works without an API key, so with this change `web_search` is registered on a fresh install instead of staying unavailable until one of the vendor keys is configured. I work at [Keenable](https://keenable.ai).

It sits last in `PROVIDER_ORDER`, so anyone who already has Bocha, Qianfan, Zhipu, LinkAI, AnySearch or Serply configured sees no change in which provider answers under `auto`. Keenable takes over only when nothing else is configured, or when the agent picks it through `provider`. `tools.web_search.keenable_api_key` / `KEENABLE_API_KEY` is optional and only lifts the per-IP rate limits of the keyless endpoint (10 requests/s, 1000/hour).

**Changes**

- `agent/tools/web_search/web_search.py`: `_search_keenable` in the shape of the other backends (`requests`, `Error: ...` results, the unified result dict). Without a key it calls `POST /v1/search/public` with an `X-Keenable-Title: cowagent` header; with a key it calls `/v1/search` with `X-API-Key`. Maps `snippet` (falling back to `description`) and `published_at`; `freshness` tokens and `2025-01-01..2025-02-01` ranges become `published_after` / `published_before`; `summary` asks for longer snippets. 401 / 429 / other statuses map to `Error: ...` like the other providers, and the keyless 429 mentions the optional key. A new `KEYLESS_PROVIDERS` tuple makes such providers always count as configured.
- `channel/web/web_channel.py`, `channel/web/static/js/console.js`: the Search panel's mirrored provider list gains `keenable`, shown as configured with no key (and as the active backend on a fresh install). The optional key is edited through the existing search key modal; strings added for zh / zh-Hant / en.
- `docs/tools/web-search.mdx` (+ `zh`, `ja`): provider row, auto order, and the closing note now says the tool is always registered.
- `tests/test_web_search.py`: 10 new cases with HTTP stubbed (key resolution, keyless availability and ordering, console sync, endpoint and header selection, count clamp, freshness mapping, error mapping).

No new dependency; the module already uses `requests`.

**Tested**

- `pytest tests/test_web_search.py`: 24 passed (14 before this change).
- `pytest tests`: 1257 passed. The remaining failures are pre-existing in my environment (they fail the same way on `master`: Chrome and network dependent suites, plus one timing-based regex test).
- Live, with no search key anywhere in the environment: `WebSearch().execute({"query": "CowAgent WeChat AI agent framework", "count": 5})` returned 5 results with 5 non-empty snippets in about 1.1 s; the same call with `"freshness": "oneWeek"` returned 5 dated results, all inside the week.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [ ] Linked related issue (if any): closes #
