### PR TITLE
feat: AnySearch vertical domain search + domain discovery + web_extract tool

### DIFF
--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -72,6 +72,24 @@ def _import_optional_tools():
     except Exception as e:
         logger.error(f"[Tools] WebFetch failed to load: {e}")
 
+    # WebSearchDomains Tool
+    try:
+        from agent.tools.web_search_domains import WebSearchDomains
+        tools['WebSearchDomains'] = WebSearchDomains
+    except ImportError as e:
+        logger.error(f"[Tools] WebSearchDomains not loaded - missing dependency: {e}")
+    except Exception as e:
+        logger.error(f"[Tools] WebSearchDomains failed to load: {e}")
+
+    # WebExtract Tool
+    try:
+        from agent.tools.web_extract.web_extract import WebExtract
+        tools['WebExtract'] = WebExtract
+    except ImportError as e:
+        logger.error(f"[Tools] WebExtract not loaded - missing dependency: {e}")
+    except Exception as e:
+        logger.error(f"[Tools] WebExtract failed to load: {e}")
+
     # Vision Tool (conditionally loaded based on API key availability)
     try:
         from agent.tools.vision.vision import Vision
@@ -89,6 +107,8 @@ EnvConfig = _optional_tools.get('EnvConfig')
 SchedulerTool = _optional_tools.get('SchedulerTool')
 WebSearch = _optional_tools.get('WebSearch')
 WebFetch = _optional_tools.get('WebFetch')
+WebSearchDomains = _optional_tools.get('WebSearchDomains')
+WebExtract = _optional_tools.get('WebExtract')
 Vision = _optional_tools.get('Vision')
 GoogleSearch = _optional_tools.get('GoogleSearch')
 FileSave = _optional_tools.get('FileSave')
@@ -145,6 +165,8 @@ __all__ = [
     'SchedulerTool',
     'WebSearch',
     'WebFetch',
+    'WebSearchDomains',
+    'WebExtract',
     'Vision',
     'BrowserTool',
     'McpTool',

--- a/agent/tools/web_extract/web_extract.py
+++ b/agent/tools/web_extract/web_extract.py
@@ -1,0 +1,158 @@
+"""Web extract tool - full readable text extraction via AnySearch API.
+
+Use as a fallback when web_fetch fails (403/anti-bot/JS-rendered pages)
+or the local network cannot reach the site. HTML pages only.
+"""
+
+import os
+
+import requests
+
+from agent.tools.base_tool import BaseTool, ToolResult
+from common.log import logger
+from agent.tools.utils.truncate import truncate_head
+
+
+# NOTE: keep this key resolution in sync with web_search.py's _get_api_key("anysearch").
+def _get_anysearch_api_key() -> str:
+    from config import conf
+    tools_cfg = conf().get("tools") or {}
+    if not isinstance(tools_cfg, dict):
+        return ""
+    block = tools_cfg.get("web_search") or {}
+    if not isinstance(block, dict):
+        return ""
+    key = (block.get("anysearch_api_key") or "").strip()
+    return key or os.environ.get("ANYSEARCH_API_KEY", "").strip()
+
+
+# NOTE: keep this in sync with web_search_domains.py's _anysearch_anonymous_enabled().
+def _anysearch_anonymous_enabled() -> bool:
+    from config import conf
+    tools_cfg = conf().get("tools") or {}
+    if not isinstance(tools_cfg, dict):
+        return False
+    block = tools_cfg.get("web_search") or {}
+    if not isinstance(block, dict):
+        return False
+    return bool(block.get("anysearch_anonymous"))
+
+
+def _error_body(resp) -> dict:
+    """Best-effort parse of an error response body; {} when it is not a JSON object."""
+    try:
+        body = resp.json()
+    except (ValueError, TypeError):
+        return {}
+    return body if isinstance(body, dict) else {}
+
+
+def _api_detail(body: dict) -> str:
+    """': <message>' suffix built from an AnySearch error body, '' when absent."""
+    detail = (body.get("message") or "").strip()
+    return f": {detail}" if detail else ""
+
+
+DEFAULT_TIMEOUT = 30
+
+
+class WebExtract(BaseTool):
+    """Tool for extracting full readable text from a web page URL."""
+
+    name: str = "web_extract"
+    description: str = (
+        "Extract full readable text from a web page URL via the AnySearch extraction API. "
+        "Use as a fallback when web_fetch fails (403/anti-bot/JS-rendered pages) or the local "
+        "network cannot reach the site. HTML pages only - PDF/DOCX and other binaries are not "
+        "supported (use web_fetch for those)."
+    )
+
+    params: dict = {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "The HTTP/HTTPS URL to extract readable text from"
+            }
+        },
+        "required": ["url"],
+    }
+
+    @staticmethod
+    def is_available() -> bool:
+        """Available when AnySearch is usable: key configured OR anonymous enabled.
+
+        Mirrors web_search_domains.is_available() - registering the tool
+        unconditionally would silently burn anonymous quota for users who
+        never opted into AnySearch.
+        """
+        return bool(_get_anysearch_api_key()) or _anysearch_anonymous_enabled()
+
+    def execute(self, args: dict) -> ToolResult:
+        url = (args.get("url") or "").strip()
+        if not url:
+            return ToolResult.fail("Error: 'url' parameter is required")
+        if not url.lower().startswith(("http://", "https://")):
+            return ToolResult.fail("Error: URL must start with http:// or https://")
+
+        api_key = _get_anysearch_api_key()
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        payload = {"url": url}
+        endpoint = "https://api.anysearch.com/v1/extract"
+
+        try:
+            resp = requests.post(endpoint, headers=headers, json=payload, timeout=DEFAULT_TIMEOUT)
+        except requests.Timeout:
+            return ToolResult.fail(f"Error: extract request timed out after {DEFAULT_TIMEOUT}s")
+        except requests.ConnectionError:
+            return ToolResult.fail("Error: Failed to connect to AnySearch extraction API")
+        except Exception as e:
+            logger.error(f"[WebExtract] Unexpected error: {e}", exc_info=True)
+            return ToolResult.fail(f"Error: extract failed - {str(e)}")
+
+        # Error mapping per spec (8.5f). The AnySearch error envelope carries the
+        # machine-readable reason in `error_code` (`code` is -1 on every failure),
+        # so branch on `error_code`; on a mismatch surface the API `message`.
+        if resp.status_code == 400:
+            body = _error_body(resp)
+            if body.get("error_code") == "invalid_extract_url":
+                return ToolResult.fail("Error: invalid URL for extraction")
+            return ToolResult.fail(f"Error: invalid URL for extraction{_api_detail(body)}")
+        if resp.status_code == 401:
+            return ToolResult.fail("Error: Invalid AnySearch API key.")
+        if resp.status_code == 402:
+            if api_key:
+                return ToolResult.fail("Error: AnySearch quota exhausted. Check usage at https://anysearch.com")
+            return ToolResult.fail(
+                "Error: AnySearch anonymous quota exhausted. Configure an API key at https://anysearch.com for higher limits.")
+        if resp.status_code == 422:
+            body = _error_body(resp)
+            if body.get("error_code") == "extract_failed":
+                return ToolResult.fail("Error: extraction failed (page empty or blocked)")
+            return ToolResult.fail(f"Error: extraction failed{_api_detail(body)}")
+        if resp.status_code == 429:
+            return ToolResult.fail("Error: AnySearch API rate limit reached.")
+        if resp.status_code != 200:
+            return ToolResult.fail(f"Error: AnySearch API returned HTTP {resp.status_code}")
+
+        data = resp.json()
+        api_code = data.get("code")
+        if api_code not in (0, None):
+            msg = data.get("message") or "Unknown error"
+            return ToolResult.fail(f"Error: AnySearch API error (code={api_code}): {msg}")
+
+        # Success path: same plain-text shape as web_fetch ("Title: ...\n\nContent: ..."),
+        # so the agent can fall back from web_fetch to web_extract without any
+        # output-format handling of its own.
+        inner = data.get("data") or {}
+        title = inner.get("title") or ""
+        content = inner.get("content") or ""
+        truncation = truncate_head(content)
+        text = f"Title: {title}\n\nContent:\n{truncation.content}"
+        if truncation.truncated:
+            text += (f"\n\n[Content truncated: showing {truncation.output_lines} of "
+                     f"{truncation.total_lines} lines]")
+        return ToolResult.success(text)

--- a/agent/tools/web_search/web_search.py
+++ b/agent/tools/web_search/web_search.py
@@ -203,6 +203,23 @@ class WebSearch(BaseTool):
             "description": self.description,
             "parameters": json.loads(json.dumps(self.params)),  # deep copy
         }
+        # P2-1: expose vertical domain fields only when anysearch is guaranteed
+        # to be the backend (fixed=anysearch or auto with only anysearch configured).
+        expose_vertical = (
+            (_configured_strategy() == "fixed" and _configured_provider() == "anysearch")
+            or (_configured_strategy() == "auto" and configured_providers() == ["anysearch"])
+        )
+        if expose_vertical:
+            schema["parameters"]["properties"]["tag"] = {
+                "type": "string",
+                "description": "Optional vertical domain, format '{domain}.{sub_domain}', "
+                               "e.g. 'finance.quote', 'code.doc'. AnySearch backend only.",
+            }
+            schema["parameters"]["properties"]["params"] = {
+                "type": "object",
+                "description": "Optional per-sub-domain parameters (discoverable via GET /v1/sub-domains). "
+                               "AnySearch backend only.",
+            }
         if _configured_strategy() != "auto":
             return schema
         available = configured_providers()
@@ -305,7 +322,15 @@ class WebSearch(BaseTool):
             if provider == "linkai":
                 return self._search_linkai(query, count, freshness)
             if provider == "anysearch":
-                return self._search_anysearch(query, count, freshness, summary)
+                tag = args.get("tag") or (_tools_web_search_conf().get("anysearch_domain") or "").strip() or None
+                search_params = args.get("params")
+                if not isinstance(search_params, dict):
+                    search_params = None
+                zone = (_tools_web_search_conf().get("anysearch_zone") or "").strip().lower()
+                language = (_tools_web_search_conf().get("anysearch_language") or "").strip()
+                return self._search_anysearch(query, count, freshness, summary,
+                                              tag=tag, search_params=search_params,
+                                              zone=zone, language=language)
             if provider == "serply":
                 return self._search_serply(query, count)
             if provider == "tavily":
@@ -568,7 +593,10 @@ class WebSearch(BaseTool):
             "total": 1, "count": 1, "results": [{"content": str(raw)}],
         })
 
-    def _search_anysearch(self, query: str, count: int, freshness: str = "noLimit", summary: bool = False) -> ToolResult:
+    def _search_anysearch(self, query: str, count: int, freshness: str = "noLimit",
+                              summary: bool = False, tag: str = None,
+                              search_params: dict = None, zone: str = None,
+                              language: str = None) -> ToolResult:
         if freshness and freshness != "noLimit":
             logger.warning(f"[WebSearch] anysearch does not support freshness ({freshness!r}); ignoring")
         if summary:
@@ -584,6 +612,14 @@ class WebSearch(BaseTool):
         # AnySearch accepts 1-10 results; the shared tool schema allows 1-10.
         max_results = max(1, min(int(count or 10), 10))
         payload = {"query": query, "max_results": max_results, "format": "json"}
+        if tag:
+            payload["tag"] = tag
+        if search_params:
+            payload["params"] = search_params
+        if zone in ("cn", "intl"):
+            payload["zone"] = zone
+        if language in ("zh-CN", "en"):
+            payload["language"] = language
 
         logger.debug(f"[WebSearch] anysearch: query='{query}', max_results={max_results}, has_key={bool(api_key)}")
         resp = requests.post(url, headers=headers, json=payload, timeout=DEFAULT_TIMEOUT)

--- a/agent/tools/web_search_domains.py
+++ b/agent/tools/web_search_domains.py
@@ -1,0 +1,118 @@
+"""Web search domains discovery tool.
+
+Queries the AnySearch domain discovery endpoints:
+  - GET /v1/domains             -> list top-level domains
+  - GET /v1/sub-domains?domain= -> list sub-domains for a given domain
+Free endpoints, do not consume quota.
+"""
+
+import json
+import os
+
+import requests
+
+from agent.tools.base_tool import BaseTool, ToolResult
+from common.log import logger
+from agent.tools.utils.truncate import truncate_head
+
+
+DEFAULT_TIMEOUT = 30
+
+
+# NOTE: keep this key resolution in sync with web_search.py's _get_api_key("anysearch").
+def _get_anysearch_api_key() -> str:
+    from config import conf
+    tools_cfg = conf().get("tools") or {}
+    if not isinstance(tools_cfg, dict):
+        return ""
+    block = tools_cfg.get("web_search") or {}
+    if not isinstance(block, dict):
+        return ""
+    key = (block.get("anysearch_api_key") or "").strip()
+    return key or os.environ.get("ANYSEARCH_API_KEY", "").strip()
+
+
+def _anysearch_anonymous_enabled() -> bool:
+    from config import conf
+    tools_cfg = conf().get("tools") or {}
+    if not isinstance(tools_cfg, dict):
+        return False
+    block = tools_cfg.get("web_search") or {}
+    if not isinstance(block, dict):
+        return False
+    return bool(block.get("anysearch_anonymous"))
+
+
+class WebSearchDomains(BaseTool):
+    """Tool for discovering AnySearch vertical search domains."""
+
+    name: str = "web_search_domains"
+    description: str = (
+        "Discover AnySearch vertical search domains. "
+        "Without a domain argument, lists top-level domains. "
+        "With a domain argument (e.g. 'finance'), lists its sub-domains "
+        "like 'finance.quote' or 'finance.news'. "
+        "Free endpoint, does not consume quota."
+    )
+
+    params: dict = {
+        "type": "object",
+        "properties": {
+            "domain": {
+                "type": "string",
+                "description": "Optional. Top-level domain to inspect (e.g. 'finance', 'code'). "
+                               "If omitted, lists all top-level domains."
+            }
+        },
+        "required": [],
+    }
+
+    @staticmethod
+    def is_available() -> bool:
+        """Available when anysearch is usable: key configured OR anonymous enabled."""
+        return bool(_get_anysearch_api_key()) or _anysearch_anonymous_enabled()
+
+    def execute(self, args: dict = None) -> ToolResult:
+        args = args or {}
+        domain = (args.get("domain") or "").strip()
+        api_key = _get_anysearch_api_key()
+        headers = {"Accept": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        if domain:
+            url = f"https://api.anysearch.com/v1/sub-domains?domain={domain}"
+        else:
+            url = "https://api.anysearch.com/v1/domains"
+
+        try:
+            resp = requests.get(url, headers=headers, timeout=DEFAULT_TIMEOUT)
+        except requests.Timeout:
+            return ToolResult.fail(f"Error: domains request timed out after {DEFAULT_TIMEOUT}s")
+        except requests.ConnectionError:
+            return ToolResult.fail("Error: Failed to connect to AnySearch API")
+        except Exception as e:
+            logger.error(f"[WebSearchDomains] Unexpected error: {e}", exc_info=True)
+            return ToolResult.fail(f"Error: domains request failed - {str(e)}")
+
+        if resp.status_code == 401:
+            return ToolResult.fail("Error: Invalid AnySearch API key.")
+        if resp.status_code == 429:
+            return ToolResult.fail("Error: AnySearch API rate limit reached.")
+        if resp.status_code != 200:
+            return ToolResult.fail(f"Error: AnySearch API returned HTTP {resp.status_code}: {resp.text[:200]}")
+
+        data = resp.json()
+        api_code = data.get("code")
+        if api_code not in (0, None):
+            msg = data.get("message") or "Unknown error"
+            return ToolResult.fail(f"Error: AnySearch API error (code={api_code}): {msg}")
+
+        inner = data.get("data") or {}
+        domains = inner.get("domains") or []
+        text = json.dumps(domains, ensure_ascii=False, indent=2)
+        truncation = truncate_head(text)
+        return ToolResult.success({
+            "backend": "anysearch",
+            "domains": truncation.content,
+        })

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -341,6 +341,90 @@ class TestAnySearchBackend(unittest.TestCase):
         )
         self.assertNotIn("summary", mock_post.call_args[1]["json"])
 
+    def test_search_anysearch_tag_params_passthrough(self):
+        """tag and params are passed through to the AnySearch payload."""
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
+            result = self.tool._search_anysearch("q", 10, tag="finance.quote", search_params={"limit": 5})
+
+        self.assertEqual(result.status, "success")
+        sent = mock_post.call_args[1]["json"]
+        self.assertEqual(sent["tag"], "finance.quote")
+        self.assertEqual(sent["params"], {"limit": 5})
+
+    def test_search_anysearch_config_domain_fallback(self):
+        """anysearch_domain config is used when args.tag is absent."""
+        cfg = {"tools": {"web_search": {"anysearch_domain": "code.doc", "anysearch_anonymous": True}}}
+        with patch.object(web_search_module, "conf", lambda: cfg), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
+            result = self.tool.execute({"query": "q", "count": 10})
+
+        self.assertEqual(result.status, "success")
+        sent = mock_post.call_args[1]["json"]
+        self.assertEqual(sent["tag"], "code.doc")
+
+    def test_search_anysearch_zone_language_passthrough(self):
+        """zone and language from config are passed to the payload."""
+        cfg = {"tools": {"web_search": {"anysearch_zone": "cn", "anysearch_language": "zh-CN", "anysearch_anonymous": True}}}
+        with patch.object(web_search_module, "conf", lambda: cfg), \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
+            result = self.tool.execute({"query": "q", "count": 10})
+
+        self.assertEqual(result.status, "success")
+        sent = mock_post.call_args[1]["json"]
+        self.assertEqual(sent["zone"], "cn")
+        self.assertEqual(sent["language"], "zh-CN")
+
+    def test_search_anysearch_ignores_freshness_with_warning(self):
+        """freshness='oneWeek' logs a warning and is not sent in the payload."""
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module, "logger") as mock_logger, \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
+            result = self.tool._search_anysearch("q", 10, freshness="oneWeek")
+
+        self.assertEqual(result.status, "success")
+        mock_logger.warning.assert_called_once_with(
+            "[WebSearch] anysearch does not support freshness ('oneWeek'); ignoring"
+        )
+        sent = mock_post.call_args[1]["json"]
+        self.assertNotIn("freshness", sent)
+
+    def test_search_anysearch_ignores_summary_with_warning(self):
+        """summary=True logs a warning; the request payload keeps its plain shape."""
+        with patch.object(web_search_module, "_get_api_key", return_value="test-key-123"), \
+                patch.object(web_search_module, "logger") as mock_logger, \
+                patch.object(web_search_module.requests, "post",
+                             return_value=_fake_response(200, _anysearch_payload([]))) as mock_post:
+            result = self.tool._search_anysearch("q", 10, summary=True)
+
+        self.assertEqual(result.status, "success")
+        mock_logger.warning.assert_called_once_with(
+            "[WebSearch] anysearch does not support summary; ignoring"
+        )
+        self.assertNotIn("summary", mock_post.call_args[1]["json"])
+
+    def test_schema_exposes_vertical_fields_fixed_anysearch(self):
+        """fixed=anysearch exposes tag/params in schema."""
+        cfg = {"tools": {"web_search": {"strategy": "fixed", "provider": "anysearch", "anysearch_anonymous": True}}}
+        with patch.object(web_search_module, "conf", lambda: cfg):
+            schema = self.tool.get_json_schema()
+        props = schema["parameters"]["properties"]
+        self.assertIn("tag", props)
+        self.assertIn("params", props)
+
+    def test_schema_hides_vertical_fields_auto_multi(self):
+        """auto with multiple providers does NOT expose tag/params."""
+        cfg = {"tools": {"web_search": {"strategy": "auto", "bocha_api_key": "k1", "anysearch_api_key": "k2"}}}
+        with patch.object(web_search_module, "conf", lambda: cfg):
+            schema = self.tool.get_json_schema()
+        props = schema["parameters"]["properties"]
+        self.assertNotIn("tag", props)
+        self.assertNotIn("params", props)
+
 
 def _serply_payload(results):
     """Build a Serply /v1/search response body in the documented shape."""
@@ -773,6 +857,244 @@ class TestSearxngBackend(unittest.TestCase):
                 self.assertEqual(result.status, "error")
                 self.assertIn(fragment, result.result)
 
+class TestWebSearchDomains(unittest.TestCase):
+    """Behaviour of WebSearchDomains with a stubbed HTTP layer."""
+
+    def setUp(self):
+        from agent.tools.web_search_domains import WebSearchDomains
+        self.tool = WebSearchDomains()
+
+    def test_domains_list_top_level(self):
+        """Without domain arg, GET /v1/domains returns top-level list."""
+        payload = {"code": 0, "message": "success", "data": {"domains": [{"domain": "finance", "sub_domain_count": 6}]}}
+        with patch("agent.tools.web_search_domains.requests.get",
+                   return_value=_fake_response(200, payload)) as mock_get:
+            result = self.tool.execute({})
+
+        self.assertEqual(result.status, "success")
+        mock_get.assert_called_once()
+        sent_url = mock_get.call_args[0][0]
+        self.assertIn("/v1/domains", sent_url)
+        self.assertIn("finance", result.result["domains"])
+
+    def test_domains_sub_domain_lookup(self):
+        """With domain arg, GET /v1/sub-domains?domain=finance returns sub-domains."""
+        payload = {"code": 0, "message": "success", "data": {"domains": [{"domain": "finance", "sub_domains": [{"sub_domain": "finance.quote"}]}]}}
+        with patch("agent.tools.web_search_domains.requests.get",
+                   return_value=_fake_response(200, payload)) as mock_get:
+            result = self.tool.execute({"domain": "finance"})
+
+        self.assertEqual(result.status, "success")
+        sent_url = mock_get.call_args[0][0]
+        self.assertIn("/v1/sub-domains", sent_url)
+        self.assertIn("domain=finance", sent_url)
+        self.assertIn("finance.quote", result.result["domains"])
+
+    def test_domains_401(self):
+        """401 returns auth error."""
+        with patch("agent.tools.web_search_domains.requests.get",
+                   return_value=_fake_response(401, {})):
+            result = self.tool.execute({})
+        self.assertEqual(result.status, "error")
+        self.assertIn("Invalid AnySearch API key", result.result)
+
+
+class TestWebExtract(unittest.TestCase):
+    """Behaviour of WebExtract with a stubbed HTTP layer.
+
+    Error bodies use the official AnySearch error envelope: ``code`` is -1 on
+    every failure and the machine-readable reason lives in ``error_code``.
+    """
+
+    def setUp(self):
+        from agent.tools.web_extract.web_extract import WebExtract
+        self.tool = WebExtract()
+
+    # ---- success path (方案 B: same text shape as web_fetch) ----
+
+    def test_extract_success_matches_web_fetch_text_shape(self):
+        """Success returns the web_fetch plain-text shape, not a dict."""
+        payload = {"code": 0, "message": "success", "data": {
+            "url": "https://example.com", "title": "Example", "content": "Hello World"}}
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   return_value=_fake_response(200, payload)) as mock_post:
+            result = self.tool.execute({"url": "https://example.com"})
+
+        self.assertEqual(result.status, "success")
+        self.assertIsInstance(result.result, str)
+        self.assertEqual(result.result, "Title: Example\n\nContent:\nHello World")
+        self.assertEqual(mock_post.call_args[1]["json"], {"url": "https://example.com"})
+
+    def test_extract_success_appends_truncation_notice(self):
+        """Over-limit content is truncated and the notice is appended."""
+        long_content = "\n".join(f"line {i}" for i in range(2500))  # over the 2000-line cap
+        payload = {"code": 0, "message": "success", "data": {
+            "url": "https://example.com", "title": "Example", "content": long_content}}
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   return_value=_fake_response(200, payload)):
+            result = self.tool.execute({"url": "https://example.com"})
+
+        self.assertEqual(result.status, "success")
+        self.assertTrue(result.result.startswith("Title: Example\n\nContent:\nline 0"))
+        self.assertIn("[Content truncated: showing 2000 of 2500 lines]", result.result)
+
+    def test_extract_business_error_on_http_200(self):
+        """HTTP 200 with code=-1 surfaces the API message."""
+        payload = {"code": -1, "error_code": "extract_failed", "message": "upstream exploded"}
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   return_value=_fake_response(200, payload)):
+            result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("upstream exploded", result.result)
+
+    # ---- Authorization header contract ----
+
+    def test_extract_no_key_omits_authorization_header(self):
+        """Anonymous mode: no Authorization header is sent."""
+        payload = {"code": 0, "message": "success", "data": {"title": "T", "content": "ok"}}
+        with patch("agent.tools.web_extract.web_extract._get_anysearch_api_key", return_value=""):
+            with patch("agent.tools.web_extract.web_extract.requests.post",
+                       return_value=_fake_response(200, payload)) as mock_post:
+                self.tool.execute({"url": "https://example.com"})
+        headers = mock_post.call_args[1]["headers"]
+        self.assertNotIn("Authorization", headers)
+
+    def test_extract_key_sends_authorization_header(self):
+        """With a configured key, Authorization: Bearer <key> is sent."""
+        payload = {"code": 0, "message": "success", "data": {"title": "T", "content": "ok"}}
+        with patch("agent.tools.web_extract.web_extract._get_anysearch_api_key", return_value="test-key"):
+            with patch("agent.tools.web_extract.web_extract.requests.post",
+                       return_value=_fake_response(200, payload)) as mock_post:
+                self.tool.execute({"url": "https://example.com"})
+        headers = mock_post.call_args[1]["headers"]
+        self.assertEqual(headers["Authorization"], "Bearer test-key")
+
+    # ---- error_code mapping (official envelope: code=-1 + error_code) ----
+
+    def test_extract_400_invalid_extract_url(self):
+        """400 + error_code invalid_extract_url -> canonical message."""
+        body = {"code": -1, "error_code": "invalid_extract_url", "message": "url scheme not supported"}
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   return_value=_fake_response(400, body)):
+            result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertEqual(result.result, "Error: invalid URL for extraction")
+
+    def test_extract_400_unknown_error_code_surfaces_api_message(self):
+        """400 with any other error_code falls through and keeps the API detail.
+
+        Regression guard for the dead-code bug: when the `error_code` branch
+        misses, the API message must still reach the caller.
+        """
+        body = {"code": -1, "error_code": "bad_request", "message": "field url is required"}
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   return_value=_fake_response(400, body)):
+            result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("field url is required", result.result)
+
+    def test_extract_422_extract_failed(self):
+        """422 + error_code extract_failed -> canonical message."""
+        body = {"code": -1, "error_code": "extract_failed", "message": "page empty"}
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   return_value=_fake_response(422, body)):
+            result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertEqual(result.result, "Error: extraction failed (page empty or blocked)")
+
+    def test_extract_422_unknown_error_code_surfaces_api_message(self):
+        """422 with any other error_code keeps the API detail."""
+        body = {"code": -1, "error_code": "unprocessable", "message": "content-type not html"}
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   return_value=_fake_response(422, body)):
+            result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("content-type not html", result.result)
+
+    def test_extract_401(self):
+        """401 returns auth error."""
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   return_value=_fake_response(401, {})):
+            result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("Invalid AnySearch API key", result.result)
+
+    def test_extract_402_keyed(self):
+        """402 with key returns quota exhausted message."""
+        with patch("agent.tools.web_extract.web_extract._get_anysearch_api_key", return_value="test-key"):
+            with patch("agent.tools.web_extract.web_extract.requests.post",
+                       return_value=_fake_response(402, {})):
+                result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("quota exhausted", result.result)
+        self.assertNotIn("anonymous", result.result)
+
+    def test_extract_402_anonymous(self):
+        """402 without key points at configuring an API key."""
+        with patch("agent.tools.web_extract.web_extract._get_anysearch_api_key", return_value=""):
+            with patch("agent.tools.web_extract.web_extract.requests.post",
+                       return_value=_fake_response(402, {})):
+                result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("anonymous quota exhausted", result.result)
+
+    def test_extract_429(self):
+        """429 returns rate limit message."""
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   return_value=_fake_response(429, {})):
+            result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("rate limit", result.result)
+
+    # ---- input validation & network errors ----
+
+    def test_extract_invalid_url(self):
+        """Non-HTTP URL is rejected before any request."""
+        result = self.tool.execute({"url": "ftp://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("http:// or https://", result.result)
+
+    def test_extract_missing_url(self):
+        """Missing url parameter is rejected before any request."""
+        result = self.tool.execute({})
+        self.assertEqual(result.status, "error")
+        self.assertIn("'url' parameter is required", result.result)
+
+    def test_extract_timeout(self):
+        """Timeout returns a timed-out error."""
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   side_effect=__import__("requests").Timeout()):
+            result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("timed out", result.result)
+
+    def test_extract_connection_error(self):
+        """ConnectionError returns a connect failure."""
+        with patch("agent.tools.web_extract.web_extract.requests.post",
+                   side_effect=__import__("requests").ConnectionError()):
+            result = self.tool.execute({"url": "https://example.com"})
+        self.assertEqual(result.status, "error")
+        self.assertIn("Failed to connect", result.result)
+
+    # ---- availability gate ----
+
+    def test_unavailable_without_key_and_without_anonymous(self):
+        """No key and no anonymous opt-in -> tool is not offered."""
+        with patch("agent.tools.web_extract.web_extract._get_anysearch_api_key", return_value=""):
+            with patch("agent.tools.web_extract.web_extract._anysearch_anonymous_enabled", return_value=False):
+                self.assertFalse(self.tool.is_available())
+
+    def test_available_with_key(self):
+        """A configured key makes the tool available."""
+        with patch("agent.tools.web_extract.web_extract._get_anysearch_api_key", return_value="test-key"):
+            with patch("agent.tools.web_extract.web_extract._anysearch_anonymous_enabled", return_value=False):
+                self.assertTrue(self.tool.is_available())
+
+    def test_available_with_anonymous_opt_in(self):
+        """anysearch_anonymous opt-in makes the tool available without a key."""
+        with patch("agent.tools.web_extract.web_extract._get_anysearch_api_key", return_value=""):
+            with patch("agent.tools.web_extract.web_extract._anysearch_anonymous_enabled", return_value=True):
+                self.assertTrue(self.tool.is_available())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
前PR:https://github.com/zhayujie/CowAgent/pull/3083  
## Summary / 概述
Adds AnySearch-specific enhancements to the web_search toolchain.
为 web_search 工具链添加 AnySearch 专属功能增强。

| ID | Feature / 功能 | Status / 状态 |
|----|---------|--------|
| P2-1 | Vertical domain search (tag + params) / 垂直域搜索 | ✅ |
| P2-2 | Domain discovery tool (web_search_domains) / 域发现工具 | ✅ |
| P2-3 | zone/language config passthrough / 区域与语言透传 | ✅ |
| P2-5 | web_extract standalone tool / 网页提取独立工具 | ✅ |


## Changes / 变更内容

- `agent/tools/web_search/web_search.py`: anysearch branch now accepts tag/params/zone/language; schema exposes tag/params only when anysearch is guaranteed to be the backend
  anysearch 分支支持 tag/params/zone/language；仅当 anysearch 为必然后端时 schema 才暴露 tag/params
- `agent/tools/web_search_domains.py`: new tool for discovering AnySearch vertical domains (free endpoint)
  新工具：发现 AnySearch 垂直搜索域（免费端点）
- `agent/tools/web_extract/`: new standalone tool for full text extraction via AnySearch API
  新独立工具：通过 AnySearch API 提取网页全文
- `agent/tools/__init__.py`: register the two new tools
  注册两个新工具
- `tests/test_web_search.py`: 13 new tests covering all new behaviour
  新增 13 条测试覆盖全部新行为

## Testing / 测试

- 13/13 new tests passing / 13/13 新增测试全部通过
- Manual verification: domain discovery (top-level + sub-domain), web_extract success, vertical schema exposure, zone/language passthrough
  手动验证：域发现（顶级域 + 子域）、web_extract 提取成功、垂直域 schema 暴露、区域/语言透传
<img width="1437" height="73" alt="image" src="https://github.com/user-attachments/assets/95f1d791-75bb-4913-9b5c-f1172bdf7548" />

@zhayujie