### PR TITLE
fix(models): 七个 bot 的 error_generator 闭包引用已被删除的 except 变量 e，流式报错时抛 NameError

### DIFF
--- a/models/claudeapi/claude_api_bot.py
+++ b/models/claudeapi/claude_api_bot.py
@@ -427,13 +427,14 @@ class ClaudeAPIBot(Bot, OpenAIImage):
             else:
                 return self._handle_sync_response(request_params)
         except Exception as e:
+            error_msg = str(e)
             logger.error(f"Claude API call error: {e}")
             if stream:
                 # Return error generator for stream
                 def error_generator():
                     yield {
                         "error": True,
-                        "message": str(e),
+                        "message": error_msg,
                         "status_code": 500
                     }
 

--- a/models/deepseek/deepseek_bot.py
+++ b/models/deepseek/deepseek_bot.py
@@ -295,12 +295,13 @@ class DeepSeekBot(Bot, OpenAICompatibleBot):
                 return self._handle_sync_response(request_body)
 
         except Exception as e:
+            error_msg = str(e)
             logger.error(f"[DEEPSEEK] call_with_tools error: {e}")
             import traceback
             logger.error(traceback.format_exc())
 
             def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+                yield {"error": True, "message": error_msg, "status_code": 500}
             return error_generator()
 
     # -------------------- streaming --------------------

--- a/models/doubao/doubao_bot.py
+++ b/models/doubao/doubao_bot.py
@@ -261,12 +261,13 @@ class DoubaoBot(Bot):
                 return self._handle_sync_response(request_body)
 
         except Exception as e:
+            error_msg = str(e)
             logger.error(f"[DOUBAO] call_with_tools error: {e}")
             import traceback
             logger.error(traceback.format_exc())
 
             def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+                yield {"error": True, "message": error_msg, "status_code": 500}
             return error_generator()
 
     # -------------------- streaming --------------------

--- a/models/linkai/link_ai_bot.py
+++ b/models/linkai/link_ai_bot.py
@@ -636,12 +636,13 @@ def _linkai_call_with_tools(self, messages, tools=None, stream=False, **kwargs):
             return self._handle_linkai_sync_response(base_url, headers, body)
             
     except Exception as e:
+        error_msg = str(e)
         logger.error(f"[LinkAI] call_with_tools error: {e}")
         if stream:
             def error_generator():
                 yield {
                     "error": True,
-                    "message": str(e),
+                    "message": error_msg,
                     "status_code": 500
                 }
             return error_generator()

--- a/models/mimo/mimo_bot.py
+++ b/models/mimo/mimo_bot.py
@@ -284,12 +284,13 @@ class MimoBot(Bot, OpenAICompatibleBot):
                 return self._handle_sync_response(request_body)
 
         except Exception as e:
+            error_msg = str(e)
             logger.error(f"[MIMO] call_with_tools error: {e}")
             import traceback
             logger.error(traceback.format_exc())
 
             def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+                yield {"error": True, "message": error_msg, "status_code": 500}
             return error_generator()
 
     # -------------------- streaming --------------------

--- a/models/minimax/minimax_bot.py
+++ b/models/minimax/minimax_bot.py
@@ -286,12 +286,13 @@ class MinimaxBot(Bot):
                 return self._handle_sync_response(request_body)
 
         except Exception as e:
+            error_msg = str(e)
             logger.error(f"[MINIMAX] call_with_tools error: {e}")
             import traceback
             logger.error(traceback.format_exc())
             
             def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+                yield {"error": True, "message": error_msg, "status_code": 500}
             return error_generator()
 
     def _convert_messages_to_openai_format(self, messages):

--- a/models/moonshot/moonshot_bot.py
+++ b/models/moonshot/moonshot_bot.py
@@ -311,12 +311,13 @@ class MoonshotBot(Bot):
                 return self._handle_sync_response(request_body)
 
         except Exception as e:
+            error_msg = str(e)
             logger.error(f"[MOONSHOT] call_with_tools error: {e}")
             import traceback
             logger.error(traceback.format_exc())
 
             def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+                yield {"error": True, "message": error_msg, "status_code": 500}
             return error_generator()
 
     # -------------------- streaming --------------------


### PR DESCRIPTION
## 问题

七个 bot 在 `call_with_tools` 的 `except Exception as e:` 里就地定义 `error_generator`，并在**生成器函数体内**引用 `str(e)`：

```python
except Exception as e:
    logger.error(f"[DEEPSEEK] call_with_tools error: {e}")
    def error_generator():
        yield {"error": True, "message": str(e), "status_code": 500}   # <-- 闭包引用 e
    return error_generator()
```

Python 3 在 `except ... as e` 处理器结束时会**隐式 `del e`**（PEP 3110）。`return error_generator()` 一执行，处理器就已经退出，闭包 cell 被清空；等到调用方真正迭代这个生成器时，第一个 `next()` 抛的是 `NameError`，而不是本该 yield 的错误分片。

调用点在 `bridge/agent_bridge.py:465-469`：

```python
stream = self.bot.call_with_tools(**kwargs)
for chunk in stream:              # <-- 处理器早已退出，这里才第一次 next()
    yield self._format_stream_chunk(chunk)
```

外层 `except` 只是 `logger.error(...)` 后 `raise`，所以**上游 API 一旦报错，用户看到的是一条误导性的 `NameError`，真正的错误信息（限流 / 鉴权失败 / 超时）被彻底丢掉**。

## 最小复现

```python
def broken():
    try:
        raise RuntimeError("upstream 429")
    except Exception as e:
        def error_generator():
            yield {"error": True, "message": str(e), "status_code": 500}
        return error_generator()

def fixed():
    try:
        raise RuntimeError("upstream 429")
    except Exception as e:
        error_msg = str(e)
        def error_generator():
            yield {"error": True, "message": error_msg, "status_code": 500}
        return error_generator()
```

```
broken -> NameError: cannot access free variable 'e' where it is not associated with a value in enclosing scope
fixed  -> {'error': True, 'message': 'upstream 429', 'status_code': 500}
```

## 修法（照抄仓内已有的正确写法）

仓里一共 14 处 `def error_generator`，其中 7 处**已经**是正确写法 —— 先在处理器里绑定 `error_msg = str(e)`，生成器只读这个局部变量。例如 `models/openai_compatible_bot.py:159` 和 `models/zhipuai/zhipuai_bot.py:293`：

```python
except Exception as e:
    error_msg = str(e)
    logger.error(f"[ZHIPU_AI] call_with_tools error: {error_msg}")
    if stream:
        def error_generator():
            yield {"error": True, "message": error_msg, "status_code": 500}
        return error_generator()
```

本 PR 把剩下 7 个（claudeapi / deepseek / doubao / linkai / mimo / minimax / moonshot）改成同样的形状。每个文件 +2/-1，共 +14/-7，无行为变更以外的改动。

已正确、未改动的 7 处：`openai_compatible_bot.py`、`zhipuai_bot.py`、`gemini/google_gemini_bot.py`(×2)、`dashscope_bot.py`、`modelscope_bot.py`(×2)。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
