### PR TITLE
fix(models): error_generator closes over the deleted exception variable (NameError on every streaming error)

### DIFF
--- a/models/claudeapi/claude_api_bot.py
+++ b/models/claudeapi/claude_api_bot.py
@@ -430,10 +430,10 @@ class ClaudeAPIBot(Bot, OpenAIImage):
             logger.error(f"Claude API call error: {e}")
             if stream:
                 # Return error generator for stream
-                def error_generator():
+                def error_generator(err=str(e)):
                     yield {
                         "error": True,
-                        "message": str(e),
+                        "message": err,
                         "status_code": 500
                     }
 

--- a/models/deepseek/deepseek_bot.py
+++ b/models/deepseek/deepseek_bot.py
@@ -299,8 +299,8 @@ class DeepSeekBot(Bot, OpenAICompatibleBot):
             import traceback
             logger.error(traceback.format_exc())
 
-            def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+            def error_generator(err=str(e)):
+                yield {"error": True, "message": err, "status_code": 500}
             return error_generator()
 
     # -------------------- streaming --------------------

--- a/models/doubao/doubao_bot.py
+++ b/models/doubao/doubao_bot.py
@@ -265,8 +265,8 @@ class DoubaoBot(Bot):
             import traceback
             logger.error(traceback.format_exc())
 
-            def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+            def error_generator(err=str(e)):
+                yield {"error": True, "message": err, "status_code": 500}
             return error_generator()
 
     # -------------------- streaming --------------------

--- a/models/linkai/link_ai_bot.py
+++ b/models/linkai/link_ai_bot.py
@@ -638,10 +638,10 @@ def _linkai_call_with_tools(self, messages, tools=None, stream=False, **kwargs):
     except Exception as e:
         logger.error(f"[LinkAI] call_with_tools error: {e}")
         if stream:
-            def error_generator():
+            def error_generator(err=str(e)):
                 yield {
                     "error": True,
-                    "message": str(e),
+                    "message": err,
                     "status_code": 500
                 }
             return error_generator()

--- a/models/mimo/mimo_bot.py
+++ b/models/mimo/mimo_bot.py
@@ -288,8 +288,8 @@ class MimoBot(Bot, OpenAICompatibleBot):
             import traceback
             logger.error(traceback.format_exc())
 
-            def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+            def error_generator(err=str(e)):
+                yield {"error": True, "message": err, "status_code": 500}
             return error_generator()
 
     # -------------------- streaming --------------------

--- a/models/minimax/minimax_bot.py
+++ b/models/minimax/minimax_bot.py
@@ -290,8 +290,8 @@ class MinimaxBot(Bot):
             import traceback
             logger.error(traceback.format_exc())
             
-            def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+            def error_generator(err=str(e)):
+                yield {"error": True, "message": err, "status_code": 500}
             return error_generator()
 
     def _convert_messages_to_openai_format(self, messages):

--- a/models/moonshot/moonshot_bot.py
+++ b/models/moonshot/moonshot_bot.py
@@ -315,8 +315,8 @@ class MoonshotBot(Bot):
             import traceback
             logger.error(traceback.format_exc())
 
-            def error_generator():
-                yield {"error": True, "message": str(e), "status_code": 500}
+            def error_generator(err=str(e)):
+                yield {"error": True, "message": err, "status_code": 500}
             return error_generator()
 
     # -------------------- streaming --------------------


### PR DESCRIPTION
## Problem

Seven model bots build a nested `error_generator` **inside** an
`except Exception as e:` handler and reference `str(e)` from that closure:

```python
except Exception as e:
    logger.error(f"[DEEPSEEK] call_with_tools error: {e}")
    def error_generator():
        yield {"error": True, "message": str(e), "status_code": 500}  # closes over e
    return error_generator()
```

In Python 3 the exception variable `e` is **implicitly deleted** when the
`except` block exits (equivalent to `del e`). But a generator body only runs
when the caller *iterates* it — long after the `except` block has exited. By
then `e` is gone, so the first `next()` on the returned generator raises:

```
NameError: cannot access free variable 'e' where it is not associated with a value in enclosing scope
```

The net effect: whenever one of these streaming calls hits an API error, the
user gets an opaque `NameError` instead of the intended error payload, and the
**real** error message is lost.

### Reproduction

```python
def call():
    try:
        raise ValueError("real API error")
    except Exception as e:
        def error_generator():
            yield {"error": True, "message": str(e), "status_code": 500}
        return error_generator()

list(call())
# -> NameError: cannot access free variable 'e' ...
```

`pyflakes` also flags each site as `undefined name 'e'`.

## Fix

Bind the message through a **default argument**, which is evaluated at `def`
time while `e` is still alive:

```python
def error_generator(err=str(e)):
    yield {"error": True, "message": err, "status_code": 500}
```

One line changed per generator, no behavioural change beyond restoring the
intended error message. After the fix the reproduction yields
`[{'error': True, 'message': 'real API error', 'status_code': 500}]` and
`pyflakes` reports no undefined names.

Affected files (streaming `call_with_tools` error path):

- `models/claudeapi/claude_api_bot.py`
- `models/deepseek/deepseek_bot.py`
- `models/doubao/doubao_bot.py`
- `models/linkai/link_ai_bot.py`
- `models/mimo/mimo_bot.py`
- `models/minimax/minimax_bot.py`
- `models/moonshot/moonshot_bot.py`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
