### PR TITLE
fix: allow clearing the max context token field in desktop settings

### DIFF
--- a/desktop/src/renderer/src/pages/settings/BasicSettings.tsx
+++ b/desktop/src/renderer/src/pages/settings/BasicSettings.tsx
@@ -16,6 +16,17 @@ const showManagedApiKey = product.models?.showManagedApiKey === true
 const ModelFieldLink = product.models?.ModelFieldLink
 const ApiKeyFieldLink = product.models?.ApiKeyFieldLink
 
+// Numeric settings are kept as raw text while editing so an emptied field stays
+// empty instead of snapping back to a digit the user then cannot delete. Only
+// on save is the text turned into a number, falling back to `fallback` when the
+// field was left blank.
+const digitsOnly = (text: string): string => text.replace(/\D/g, '').replace(/^0+(?=\d)/, '')
+
+const toInt = (text: string, fallback: number): number => {
+  const n = parseInt(text, 10)
+  return Number.isFinite(n) && n >= 0 ? n : fallback
+}
+
 interface BasicSettingsProps {
   baseUrl: string
   onLangChange?: () => void
@@ -102,9 +113,9 @@ const BasicSettings: React.FC<BasicSettingsProps> = ({ baseUrl, onLangChange, on
   // agent card
   // Manual cap on the input budget (compact once reached, to control cost);
   // 0 disables the cap and follows the model window.
-  const [maxTokens, setMaxTokens] = useState(64000)
-  const [maxTurns, setMaxTurns] = useState(20)
-  const [maxSteps, setMaxSteps] = useState(20)
+  const [maxTokens, setMaxTokens] = useState('64000')
+  const [maxTurns, setMaxTurns] = useState('20')
+  const [maxSteps, setMaxSteps] = useState('20')
   const [thinking, setThinking] = useState(false)
   const [reasoningEffort, setReasoningEffort] = useState('high')
   const [subagent, setSubagent] = useState(true)
@@ -163,9 +174,9 @@ const BasicSettings: React.FC<BasicSettingsProps> = ({ baseUrl, onLangChange, on
       const data = await apiClient.getConfig()
       setConfig(data)
       setModel(data.model || '')
-      setMaxTokens(data.agent_max_context_tokens ?? 64000)
-      setMaxTurns(data.agent_max_context_turns ?? 20)
-      setMaxSteps(data.agent_max_steps ?? 20)
+      setMaxTokens(String(data.agent_max_context_tokens ?? 64000))
+      setMaxTurns(String(data.agent_max_context_turns ?? 20))
+      setMaxSteps(String(data.agent_max_steps ?? 20))
       setThinking(!!data.enable_thinking)
       setReasoningEffort(data.reasoning_effort || 'high')
       setSubagent(data.subagent_enabled !== false)
@@ -321,10 +332,15 @@ const BasicSettings: React.FC<BasicSettingsProps> = ({ baseUrl, onLangChange, on
       // value the user set for a different model. Merge with the existing map so
       // other models' saved efforts are not overwritten by the flat config save.
       const effortKey = currentModelKey()
+      // A field left blank keeps whatever is already persisted rather than
+      // silently saving 0, which would drop the context cap or turn limit.
+      const nextMaxTokens = toInt(maxTokens, config?.agent_max_context_tokens ?? 64000)
+      const nextMaxTurns = toInt(maxTurns, config?.agent_max_context_turns ?? 20)
+      const nextMaxSteps = toInt(maxSteps, config?.agent_max_steps ?? 20)
       await apiClient.updateConfig({
-        agent_max_context_tokens: maxTokens,
-        agent_max_context_turns: maxTurns,
-        agent_max_steps: maxSteps,
+        agent_max_context_tokens: nextMaxTokens,
+        agent_max_context_turns: nextMaxTurns,
+        agent_max_steps: nextMaxSteps,
         enable_thinking: thinking,
         reasoning_effort_by_model: {
           ...(config?.reasoning_effort_by_model || {}),
@@ -337,6 +353,10 @@ const BasicSettings: React.FC<BasicSettingsProps> = ({ baseUrl, onLangChange, on
       // otherwise switching model and back would show/submit a stale value.
       const fresh = await apiClient.getConfig()
       setConfig(fresh)
+      // Show what was actually saved, so a field left blank doesn't stay blank.
+      setMaxTokens(String(nextMaxTokens))
+      setMaxTurns(String(nextMaxTurns))
+      setMaxSteps(String(nextMaxSteps))
       setAgentStatus(t('config_saved'))
     } catch {
       setAgentStatus(t('config_save_error'))
@@ -552,7 +572,7 @@ const BasicSettings: React.FC<BasicSettingsProps> = ({ baseUrl, onLangChange, on
                 highlightBudget ? 'ring-2 ring-accent/50 border-accent' : ''
               }`}
               value={maxTokens}
-              onChange={(e) => setMaxTokens(parseInt(e.target.value) || 0)}
+              onChange={(e) => setMaxTokens(digitsOnly(e.target.value))}
             />
           </Field>
           <Field label={t('config_max_turns')} hint={t('config_max_turns_hint')}>
@@ -560,7 +580,7 @@ const BasicSettings: React.FC<BasicSettingsProps> = ({ baseUrl, onLangChange, on
               type="number"
               className="font-mono"
               value={maxTurns}
-              onChange={(e) => setMaxTurns(parseInt(e.target.value) || 0)}
+              onChange={(e) => setMaxTurns(digitsOnly(e.target.value))}
             />
           </Field>
           <Field label={t('config_max_steps')} hint={t('config_max_steps_hint')}>
@@ -568,7 +588,7 @@ const BasicSettings: React.FC<BasicSettingsProps> = ({ baseUrl, onLangChange, on
               type="number"
               className="font-mono"
               value={maxSteps}
-              onChange={(e) => setMaxSteps(parseInt(e.target.value) || 0)}
+              onChange={(e) => setMaxSteps(digitsOnly(e.target.value))}
             />
           </Field>
           <div className="flex items-center justify-between py-1">


### PR DESCRIPTION
## Problem

In the desktop app, under **Settings → Agent**, the *Max context tokens* field could not be emptied: deleting its contents immediately put a `0` back, and that leading `0` could never be deleted. Typing after it also produced values like `06400`.

The same bug affected the two sibling fields, *Max context turns* and *Max steps*.

## Cause

The three inputs were controlled by numeric state with `onChange={(e) => setMaxTokens(parseInt(e.target.value) || 0)}`. Clearing the field makes `parseInt('')` return `NaN`, which `|| 0` turns into `0`, and that `0` is written straight back into the input.

## Fix

In `desktop/src/renderer/src/pages/settings/BasicSettings.tsx`:

- Keep the three fields as raw text while editing, so an emptied field stays empty.
- Sanitize input to digits only and strip leading zeros as the user types.
- Convert to a number only on save. A field left blank keeps the already persisted value instead of saving `0`, which would otherwise disable the context cap or set the turn/step limit to zero; after saving, the inputs are refilled with the values that were actually stored.

## Testing

- `tsc --noEmit` reports no new errors for the touched file (only two pre-existing `product.models` typing errors remain).
- Manually verified in the desktop settings that the field can be cleared, retyped, and saved, and that a blank field falls back to the stored value.
