### PR TITLE
fix(skills): ignore empty b64_json/url when saving generated images

### DIFF
--- a/skills/image-generation/scripts/generate.py
+++ b/skills/image-generation/scripts/generate.py
@@ -124,6 +124,26 @@ def _load_image(source: str) -> bytes:
         return resp.read()
 
 
+def _decode_image_item(item: dict, *, url_first: bool = False) -> bytes | None:
+    """Return the image bytes carried by an OpenAI-compatible result item.
+
+    Some backends send both keys even when only one of them holds a value —
+    e.g. an empty ``b64_json`` next to a usable ``url`` in URL output mode.
+    Branching on key presence would decode the empty string into a 0-byte
+    file, so branch on the value instead and fall through to the other key.
+    Returns None when neither field carries a value.
+    """
+    keys = ("url", "b64_json") if url_first else ("b64_json", "url")
+    for key in keys:
+        value = item.get(key)
+        if not value:
+            continue
+        if key == "b64_json":
+            return base64.b64decode(value)
+        return _load_image(value)
+    return None
+
+
 def _compress_image(data: bytes, max_bytes: int = 4 * 1024 * 1024, max_edge: int = 4096) -> bytes:
     """Compress image to fit size/dimension limits. Requires Pillow only when needed."""
     if len(data) <= max_bytes:
@@ -383,11 +403,8 @@ class OpenAIProvider(ImageProvider):
     def _save_results(result: dict, output_dir: str) -> list[str]:
         paths = []
         for item in result.get("data", []):
-            if "b64_json" in item:
-                raw = base64.b64decode(item["b64_json"])
-                paths.append(_save_image(raw, output_dir))
-            elif "url" in item:
-                raw = _load_image(item["url"])
+            raw = _decode_image_item(item)
+            if raw:
                 paths.append(_save_image(raw, output_dir))
         return paths
 
@@ -472,11 +489,8 @@ class LinkAIProvider(ImageProvider):
 
         paths = []
         for item in result.get("data", []):
-            if "url" in item:
-                raw = _load_image(item["url"])
-                paths.append(_save_image(raw, output_dir))
-            elif "b64_json" in item:
-                raw = base64.b64decode(item["b64_json"])
+            raw = _decode_image_item(item, url_first=True)
+            if raw:
                 paths.append(_save_image(raw, output_dir))
         return paths
 

--- a/tests/test_image_generation_empty_b64.py
+++ b/tests/test_image_generation_empty_b64.py
@@ -1,0 +1,71 @@
+import base64
+import importlib.util
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "skills"
+    / "image-generation"
+    / "scripts"
+    / "generate.py"
+)
+SPEC = importlib.util.spec_from_file_location("image_generation_script", SCRIPT_PATH)
+image_generation = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(image_generation)
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\nfake-image-payload"
+IMAGE_URL = "https://images.example.com/a.png"
+
+
+def _block_load(source):  # pragma: no cover - must not be reached
+    raise AssertionError(f"unexpected download of {source}")
+
+
+def test_empty_b64_json_falls_back_to_url(tmp_path, monkeypatch):
+    loaded = []
+    monkeypatch.setattr(
+        image_generation,
+        "_load_image",
+        lambda source: loaded.append(source) or PNG_BYTES,
+    )
+
+    paths = image_generation.OpenAIProvider._save_results(
+        {"data": [{"b64_json": "", "url": IMAGE_URL}]},
+        str(tmp_path),
+    )
+
+    assert loaded == [IMAGE_URL]
+    assert Path(paths[0]).read_bytes() == PNG_BYTES
+
+
+def test_non_empty_b64_json_is_still_preferred(tmp_path, monkeypatch):
+    monkeypatch.setattr(image_generation, "_load_image", _block_load)
+    b64 = base64.b64encode(PNG_BYTES).decode()
+
+    paths = image_generation.OpenAIProvider._save_results(
+        {"data": [{"b64_json": b64, "url": IMAGE_URL}]},
+        str(tmp_path),
+    )
+
+    assert len(paths) == 1
+    assert Path(paths[0]).read_bytes() == PNG_BYTES
+
+
+def test_item_without_usable_payload_writes_nothing(tmp_path, monkeypatch):
+    monkeypatch.setattr(image_generation, "_load_image", _block_load)
+
+    paths = image_generation.OpenAIProvider._save_results(
+        {"data": [{"b64_json": "", "url": ""}]},
+        str(tmp_path),
+    )
+
+    assert paths == []
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_linkai_order_skips_empty_url():
+    b64 = base64.b64encode(PNG_BYTES).decode()
+
+    raw = image_generation._decode_image_item({"url": "", "b64_json": b64}, url_first=True)
+
+    assert raw == PNG_BYTES


### PR DESCRIPTION
Closes #3131

## Problem

`skills/image-generation/scripts/generate.py` parsed OpenAI-compatible results with a **key-presence** check:

```python
if "b64_json" in item:
    raw = base64.b64decode(item["b64_json"])
elif "url" in item:
    raw = _load_image(item["url"])
```

Some backends (reported for Agnes `agnes-image-2.5-flash`) return `b64_json` even in **URL output mode**, with an empty string as the value next to a valid `url`. The check matched on the key, so `base64.b64decode("")` produced 0 bytes, the script wrote a 0-byte file and reported success — the failure only surfaced later when the client tried to send the empty image. No error was logged anywhere in between.

`LinkAIProvider` had the mirror-image problem: it checks `url` first, so an empty `url` next to a valid `b64_json` would have been sent to the downloader.

## Solution

Branch on the **value** instead of the key, falling through to the other field when one is empty. Both providers already had opposite field priorities (OpenAI: base64 first, LinkAI: url first), so the shared helper takes a `url_first` flag rather than reordering either one — behaviour for well-formed responses is unchanged.

Items with no usable payload are now skipped instead of being written as an empty file, so `OpenAIProvider.generate` raises `provider returned no image (empty data)` instead of handing a 0-byte path back to the agent.

No new dependencies, no interface changes, no refactor beyond extracting the two parsing loops into one helper.

## Changes

- `skills/image-generation/scripts/generate.py`
  - New `_decode_image_item(item, *, url_first=False)` helper: returns bytes from the first non-empty of `b64_json` / `url`, or `None`.
  - `OpenAIProvider._save_results` and `LinkAIProvider.generate` now use it and skip empty payloads.
- `tests/test_image_generation_empty_b64.py` (new, follows the importlib loading style of `tests/test_image_generation_custom_provider.py`).

## Testing

`python -m pytest tests/test_image_generation_empty_b64.py tests/test_image_generation_custom_provider.py` → **7 passed** (Python 3.13.12 / Windows).

Covered cases:

| case | expectation |
| --- | --- |
| `b64_json=""` + valid `url` | downloads from `url`, file has real bytes (the reported bug; fails before this PR) |
| valid `b64_json` + `url` | uses base64, **no** network call (base64 mode unchanged) |
| `b64_json=""` + `url=""` | writes nothing, no 0-byte file (was: silent 0-byte file) |
| LinkAI order with `url=""` + valid `b64_json` | decodes base64 (was: `MissingSchema: Invalid URL ''`) |

Verified as a real regression guard: reverting only `generate.py` makes 3 of the 4 new tests fail.

Full suite on this machine: 851 passed / 44 failed / 27 skipped; all 44 failures are pre-existing and in unrelated areas (feishu cards, evolution write guards, credential guards, browser SSRF, PDF window, SQLite recovery) — none import the image-generation script.

## Notes for Reviewer

- **No overlap with my previous PR.** My only earlier contribution here is #3072 (`docs/ja/README.md`); this PR touches Python source only.
- **Low conflict risk.** No open PR touches `skills/image-generation/`. The file's last change was 2026-08-25 (`5816dc74`); it is not among the high-traffic files of the last two months (`channel/web/web_channel.py`, `console.js`, `i18n.ts`, …).
- Scope kept to 2 files / +95 −10 lines, in two commits (fix, then tests).
