### PR TITLE
test(models): align stale Claude/Dashscope provider tests with current behaviour

### DIFF
--- a/tests/test_claude_thinking.py
+++ b/tests/test_claude_thinking.py
@@ -64,8 +64,19 @@ def test_legacy_budget_is_capped(monkeypatch):
     assert captured["request"]["thinking"]["budget_tokens"] == 16000
 
 
-def test_thinking_disabled_is_sent_through(monkeypatch):
+def test_adaptive_model_omits_disabled_thinking(monkeypatch):
+    # Adaptive-only models reject ``thinking.type: disabled`` (verified against
+    # the live API in 1e08c97c), so the field is dropped and the API falls back
+    # to adaptive rather than failing the request.
     bot, captured = _bot_with_capture(monkeypatch, "claude-sonnet-5")
+
+    _call(bot, thinking={"type": "disabled"})
+
+    assert "thinking" not in captured["request"]
+
+
+def test_legacy_model_disabled_thinking_is_sent_through(monkeypatch):
+    bot, captured = _bot_with_capture(monkeypatch, "claude-sonnet-4-5")
 
     _call(bot, thinking={"type": "disabled"})
 

--- a/tests/test_dashscope_provider.py
+++ b/tests/test_dashscope_provider.py
@@ -24,7 +24,13 @@ class TestDashscopeConst(unittest.TestCase):
             len(qwen_models),
             1,
         )
-        self.assertEqual(qwen_models[0], "qwen3.7-plus")
+        # The list is ordered by release, so a newer model (e.g. qwen3.8-flash)
+        # can legitimately sit ahead of qwen3.7-plus; what must hold is that
+        # plus is offered before max.
+        self.assertLess(
+            qwen_models.index(const.QWEN37_PLUS),
+            qwen_models.index(const.QWEN37_MAX),
+        )
 
 
 class TestDashscopeBotDefaultModel(unittest.TestCase):


### PR DESCRIPTION
Two tests in `tests/` are currently **red on `master`**, deterministically and independently of the platform. Both are stale assertions left behind by deliberate changes; this PR brings them back in line with the behaviour those changes introduced, and pins the half of the contract that had no coverage.

No production code is touched.

## Problem

**1. `tests/test_claude_thinking.py::test_thinking_disabled_is_sent_through` — `KeyError: 'thinking'`**

`1e08c97c` (2026-09-03, "feat: add claude-fable-5-1 model to Claude provider") changed `_thinking_params()` so adaptive-only models no longer send `thinking.type: "disabled"`. From the commit message:

> Also fix adaptive-only Claude models rejecting `thinking.type=disabled` by omitting the field so the API falls back to adaptive mode.

The test still asserted the old contract, so it now fails — the field is gone from the request.

**2. `tests/test_dashscope_provider.py::TestDashscopeConst::test_qwen37_plus_before_qwen37_max_in_model_list` — `'qwen3.8-flash' != 'qwen3.7-plus'`**

`33b20da8` ("feat(models): add qwen3.8-flash and glm-5.3-flash") added `qwen3.8-flash` at the head of `const.MODEL_LIST` (it is the new recommended default). The test asserted `qwen_models[0] == "qwen3.7-plus"`, i.e. an absolute position, which is what broke — not the ordering guarantee its own name promises.

## Solution

Update the two assertions to the current contract, and keep the assertions honest about *what* is actually guaranteed:

- Claude: adaptive model → `thinking` omitted (API falls back to adaptive); budget-generation model → `{"type": "disabled"}` still sent. The second case had no coverage at all before, so the `disabled` path is now pinned on both sides instead of only one.
- Dashscope: assert `index(QWEN37_PLUS) < index(QWEN37_MAX)` — the invariant the test name states — instead of "plus is the very first qwen entry".

Both edits are deliberately conservative: they do not relax anything that is still true, and they do not touch provider code. If Anthropic later accepts `type: "disabled"` for adaptive models, `test_adaptive_model_omits_disabled_thinking` is the single place to flip, and the PR/commit that reverts it will have to say so explicitly.

## Changes

- `tests/test_claude_thinking.py` — rename `test_thinking_disabled_is_sent_through` → `test_adaptive_model_omits_disabled_thinking` (asserts the field is dropped, with the reasoning in a comment) and add `test_legacy_model_disabled_thinking_is_sent_through` for a budget-generation model.
- `tests/test_dashscope_provider.py` — replace the absolute-position assertion with the relative-order one.

2 files, +19 −2, no new dependencies.

## Testing

- Before: `pytest tests/test_claude_thinking.py tests/test_dashscope_provider.py` → **2 failed**, 15 passed.
- After: **17 passed**.
- Wider subset (`-k "claude or dashscope or qwen or thinking or model_list or const"`) → **58 passed**, 0 failed.
- Verified the two failures reproduce from a clean `master` checkout on Python 3.13.12 / Windows, and that both are platform-independent (no paths, no network, no DNS).

## Notes for Reviewer

- **Test-only.** No production behaviour changes, so the merge risk is limited to the two assertions.
- **Low conflict risk.** Neither file is touched by any open PR; both have very low churn (1–2 commits in the last two months) and neither is among the recent hot files (`channel/web/web_channel.py`, `console.js`, `i18n.ts`, …). No overlap with my earlier PRs #3072 / #3133.
- Happy to go the other way on either case if the intent was different — in particular, if adaptive models should once again receive `thinking: {"type": "disabled"}`, that is a one-line change in `_thinking_params()` and I can flip this PR into that code fix instead.
