### PR TITLE
fix(tools): report byte truncation when the kept line is partial

### DIFF
--- a/agent/tools/utils/truncate.py
+++ b/agent/tools/utils/truncate.py
@@ -236,8 +236,10 @@ def truncate_tail(content: str, max_lines: Optional[int] = None, max_bytes: Opti
         output_lines_arr.insert(0, line)
         output_bytes_count += line_bytes
     
-    # If exited due to line limit
-    if len(output_lines_arr) >= max_lines and output_bytes_count <= max_bytes:
+    # If exited due to line limit. A partially kept line means the byte limit
+    # was what actually cut the output, even when it also fills max_lines, so
+    # leave truncated_by as "bytes" in that case.
+    if not last_line_partial and len(output_lines_arr) >= max_lines and output_bytes_count <= max_bytes:
         truncated_by = "lines"
     
     output_content = '\n'.join(output_lines_arr)

--- a/tests/test_tool_output_truncation.py
+++ b/tests/test_tool_output_truncation.py
@@ -1,0 +1,44 @@
+"""Truncation metadata for oversized tool output.
+
+`truncate_tail` relabelled a byte cut as `"lines"` whenever the kept output
+happened to fill `max_lines`, so one over-long line reported
+`truncated_by == "lines"` while also reporting `last_line_partial=True` and
+`output_bytes == max_bytes`. Callers pick their notice off `truncated_by`
+(agent/tools/bash/bash.py), so the model was told "showing lines X-Y" for
+output that had actually been cut in the middle of a line.
+"""
+
+from agent.tools.utils.truncate import truncate_tail
+
+
+def test_a_partial_line_filling_max_lines_is_reported_as_byte_truncation():
+    result = truncate_tail("first\n" + "x" * 300, max_lines=1, max_bytes=100)
+
+    assert result.truncated_by == "bytes"
+    assert result.last_line_partial is True
+    assert result.output_lines == 1
+    assert result.output_bytes == 100
+
+
+def test_byte_limit_across_whole_lines_is_reported_as_byte_truncation():
+    result = truncate_tail("ab\ncd\nef", max_lines=10, max_bytes=4)
+
+    assert result.truncated_by == "bytes"
+    assert result.last_line_partial is False
+    assert result.output_lines == 1
+
+
+def test_the_line_limit_is_still_reported_as_line_truncation():
+    result = truncate_tail("\n".join(str(i) for i in range(10)), max_lines=3)
+
+    assert result.truncated_by == "lines"
+    assert result.last_line_partial is False
+    assert result.output_lines == 3
+
+
+def test_a_whole_line_filling_max_lines_is_reported_as_line_truncation():
+    result = truncate_tail("first\nsecond", max_lines=1, max_bytes=100)
+
+    assert result.truncated_by == "lines"
+    assert result.last_line_partial is False
+    assert result.content == "second"


### PR DESCRIPTION
## Problem

`truncate_tail` (agent/tools/utils/truncate.py) reports *why* output was cut through `TruncationResult.truncated_by`, and callers branch on that field — `agent/tools/bash/bash.py` picks the notice shown to the model:

```python
if truncation.last_line_partial:
    ...  # "line is <size>"
elif truncation.truncated_by == "lines":
    ...  # "Showing lines X-Y of N"
else:
    ...  # "Showing lines X-Y of N (50KB limit)"
```

The post-loop relabel

```python
if len(output_lines_arr) >= max_lines and output_bytes_count <= max_bytes:
    truncated_by = "lines"
```

also fires in the single-over-long-line case. There the loop breaks on the **byte** limit, keeps a partial line (`last_line_partial=True`, `output_bytes == max_bytes`), and the one partial line happens to fill `max_lines`, so the reason is rewritten to `"lines"`.

Result: the same content reports `"bytes"` with `max_lines=5` but `"lines"` with `max_lines=1`:

```
truncate_tail("first\n" + "x" * 300, max_lines=1, max_bytes=100)
  -> truncated_by='lines', last_line_partial=True, output_bytes=100   # wrong
truncate_tail("first\n" + "x" * 300, max_lines=5, max_bytes=100)
  -> truncated_by='bytes', last_line_partial=True, output_bytes=100   # right
```

`truncated_by="lines"` and `last_line_partial=True` cannot both be true, so the two fields contradicted each other.

## Solution

Skip the relabel when the last line is partial. `last_line_partial` is set only on the byte-limit path, so it is exactly the signal for "the byte limit is what cut this", regardless of how many lines the output ended up filling. The relabel keeps its original meaning — the line limit stopped us — for every other case.

`truncate_head` needs no change: it can only keep whole lines, so when it breaks on the byte limit `len(output_lines_arr) < max_lines` and the relabel never fires.

## Changes

- `agent/tools/utils/truncate.py` (+4 / −2): guard the post-loop `"lines"` relabel with `not last_line_partial`, plus a comment on why the two cases differ.
- `tests/test_tool_output_truncation.py` (+44): new file covering all four ways `truncate_tail` can stop.

## Testing

```
pytest tests/test_tool_output_truncation.py                 -> 4 passed
pytest tests/test_tool_args_truncation.py \
       tests/test_bash_output_encoding.py \
       tests/test_bash_streaming.py \
       tests/test_bash_windows_guidance.py                  -> 24 passed, 5 skipped
```

- **Regression guard verified**: reverting only `truncate.py` makes `test_a_partial_line_filling_max_lines_is_reported_as_byte_truncation` fail with `assert 'lines' == 'bytes'`; with the fix all 4 pass.
- The 4 cases are: a partial line that alone fills `max_lines` (must be `"bytes"`), a byte cut across whole lines (`"bytes"`, not partial), the plain line limit (`"lines"`), and a whole line that alone fills `max_lines` (`"lines"`) — the last one pins the boundary so the fix cannot over-correct into reporting `"bytes"` for ordinary line truncation.

## Notes for Reviewer

- No behavioural change for current callers: `bash.py` calls `truncate_tail(output)` with the default `max_lines=2000`, where the mislabel could not trigger. This fixes the shared helper's metadata contract (`truncated_by` is part of `to_dict()` and is surfaced in tool result details), not a path that is currently reachable in production.
- Scope: 2 files, +48 / −2, no new dependencies, no refactor.
- No overlap with my earlier PRs in this repo (#3072 touched `docs/ja/README.md`, #3133 touched `skills/image-generation/scripts/generate.py`, #3134 touched `tests/test_claude_thinking.py` and `tests/test_dashscope_provider.py`), nor with any of the 8 currently open PRs, nor with the recent hot zones (`channel/web/web_channel.py`, `console.js`, `i18n.ts`). `agent/tools/utils/truncate.py` was added on 2026-08-12 and has not been modified since, so this should apply cleanly.
