### PR TITLE
feat(image-generation): support gpt-image-2.5-flare and gpt-image-2.5-sunburst

### DIFF
--- a/channel/web/web_channel.py
+++ b/channel/web/web_channel.py
@@ -3526,7 +3526,7 @@ class ModelsHandler:
     # The skill itself maps either form to the real vendor endpoint, so the
     # hint is purely cosmetic.
     _IMAGE_PROVIDER_MODELS = {
-        "openai":    ["gpt-image-2", "gpt-image-1"],
+        "openai":    ["gpt-image-2.5-flare", "gpt-image-2.5-sunburst", "gpt-image-2", "gpt-image-1"],
         "gemini": [
             {"value": "gemini-3.1-flash-image-preview", "hint": "Nano Banana 2"},
             {"value": "gemini-3-pro-image-preview",     "hint": "Nano Banana Pro"},
@@ -3536,6 +3536,8 @@ class ModelsHandler:
         "dashscope": ["qwen-image-2.0-pro", "qwen-image-2.0"],
         "minimax":   ["image-01"],
         "linkai": [
+            "gpt-image-2.5-flare",
+            "gpt-image-2.5-sunburst",
             "gpt-image-2",
             {"value": "gemini-3.1-flash-image-preview", "hint": "Nano Banana 2"},
             {"value": "gemini-3-pro-image-preview",     "hint": "Nano Banana Pro"},
@@ -4127,12 +4129,12 @@ class ModelsHandler:
     # provider-card id to the script's per-provider DEFAULT_MODEL so the
     # hint matches what the runtime would actually request.
     _IMAGE_AUTO_ORDER = [
-        ("openai",    "gpt-image-2"),
+        ("openai",    "gpt-image-2.5-flare"),
         ("gemini",    "gemini-3.1-flash-image-preview"),  # nano-banana-2
         ("doubao",    "seedream-5.0-lite"),
         ("dashscope", "qwen-image-2.0"),
         ("minimax",   "image-01"),
-        ("linkai",    "gpt-image-2"),
+        ("linkai",    "gpt-image-2.5-flare"),
     ]
 
     @classmethod

--- a/docs/ja/models/linkai.mdx
+++ b/docs/ja/models/linkai.mdx
@@ -48,7 +48,7 @@ description: LinkAI プラットフォーム経由でテキスト、ビジョン
 {
   "skills": {
     "image-generation": {
-      "model": "gpt-image-2"
+      "model": "gpt-image-2.5-flare"
     }
   }
 }
@@ -56,6 +56,8 @@ description: LinkAI プラットフォーム経由でテキスト、ビジョン
 
 | モデル ID | エイリアス |
 | --- | --- |
+| `gpt-image-2.5-flare` | OpenAI |
+| `gpt-image-2.5-sunburst` | OpenAI |
 | `gpt-image-2` | OpenAI |
 | `gemini-3.1-flash-image-preview` | Nano Banana 2 |
 | `gemini-3-pro-image-preview` | Nano Banana Pro |

--- a/docs/ja/models/openai.mdx
+++ b/docs/ja/models/openai.mdx
@@ -51,13 +51,13 @@ OpenAI は最も広範な機能をカバーするベンダーで、テキスト�
 {
   "skills": {
     "image-generation": {
-      "model": "gpt-image-2"
+      "model": "gpt-image-2.5-flare"
     }
   }
 }
 ```
 
-サポートする画像生成モデル：`gpt-image-2`、`gpt-image-1`。
+サポートする画像生成モデル：`gpt-image-2.5-flare`（推奨デフォルト）、`gpt-image-2.5-sunburst`、`gpt-image-2`、`gpt-image-1`。
 
 ## 音声認識
 

--- a/docs/ja/skills/image-generation.mdx
+++ b/docs/ja/skills/image-generation.mdx
@@ -9,7 +9,7 @@ description: テキストから画像生成 / 画像編集 / 複数画像融合�
 
 | プロバイダー | モデル / エイリアス | 特徴 |
 | --- | --- | --- |
-| OpenAI | `gpt-image-2`、`gpt-image-1` | 汎用テキスト→画像、高品質、`quality` で画質制御に対応 |
+| OpenAI | `gpt-image-2.5-flare`、`gpt-image-2.5-sunburst`、`gpt-image-2`、`gpt-image-1` | 汎用テキスト→画像、高品質、`quality` で画質制御に対応 |
 | Gemini Nano Banana | `nano-banana-2`、`nano-banana-pro`、`nano-banana` | `gemini-3.1-flash`、`gemini-3-pro`、`gemini-2.5-flash` の画像バージョン |
 | Seedream（Volcengine Ark） | `seedream-5.0-lite`、`seedream-4.5` | ネイティブ 2K–4K、最大 14 枚の画像融合 |
 | Qwen（DashScope） | `qwen-image-2.0`、`qwen-image-2.0-pro` | 中国語のレイアウトや画像とテキストの融合に強い |

--- a/docs/models/linkai.mdx
+++ b/docs/models/linkai.mdx
@@ -48,7 +48,7 @@ Available models: `gpt-4.1-mini`, `gpt-5.4-mini`, `qwen3.8-flash`, `qwen3.7-plus
 {
   "skills": {
     "image-generation": {
-      "model": "gpt-image-2"
+      "model": "gpt-image-2.5-flare"
     }
   }
 }
@@ -56,6 +56,8 @@ Available models: `gpt-4.1-mini`, `gpt-5.4-mini`, `qwen3.8-flash`, `qwen3.7-plus
 
 | Model ID | Alias |
 | --- | --- |
+| `gpt-image-2.5-flare` | OpenAI |
+| `gpt-image-2.5-sunburst` | OpenAI |
 | `gpt-image-2` | OpenAI |
 | `gemini-3.1-flash-image-preview` | Nano Banana 2 |
 | `gemini-3-pro-image-preview` | Nano Banana Pro |

--- a/docs/models/openai.mdx
+++ b/docs/models/openai.mdx
@@ -51,13 +51,13 @@ Specify the image generation model in the configuration file; the Agent automati
 {
   "skills": {
     "image-generation": {
-      "model": "gpt-image-2"
+      "model": "gpt-image-2.5-flare"
     }
   }
 }
 ```
 
-Supported image generation models: `gpt-image-2`, `gpt-image-1`.
+Supported image generation models: `gpt-image-2.5-flare` (recommended default), `gpt-image-2.5-sunburst`, `gpt-image-2`, `gpt-image-1`.
 
 ## Speech-to-Text (ASR)
 

--- a/docs/skills/image-generation.mdx
+++ b/docs/skills/image-generation.mdx
@@ -9,7 +9,7 @@ A general-purpose image generation and editing skill supporting six providers: O
 
 | Provider | Models / Aliases | Notes |
 | --- | --- | --- |
-| OpenAI | `gpt-image-2`, `gpt-image-1` | General-purpose, high quality, supports `quality` parameter |
+| OpenAI | `gpt-image-2.5-flare`, `gpt-image-2.5-sunburst`, `gpt-image-2`, `gpt-image-1` | General-purpose, high quality, supports `quality` parameter |
 | Gemini Nano Banana | `nano-banana-2`, `nano-banana-pro`, `nano-banana` | Corresponds to the image variants of `gemini-3.1-flash`, `gemini-3-pro`, `gemini-2.5-flash` |
 | Seedream (Volcengine Ark) | `seedream-5.0-lite`, `seedream-4.5` | Native 2K–4K, up to 14 reference images for fusion |
 | Qwen (DashScope) | `qwen-image-2.0`, `qwen-image-2.0-pro` | Strong with Chinese text rendering and text-image layouts |

--- a/docs/zh/models/linkai.mdx
+++ b/docs/zh/models/linkai.mdx
@@ -48,7 +48,7 @@ description: 通过 LinkAI 平台统一接入文本、视觉、图像、语音�
 {
   "skills": {
     "image-generation": {
-      "model": "gpt-image-2"
+      "model": "gpt-image-2.5-flare"
     }
   }
 }
@@ -56,6 +56,8 @@ description: 通过 LinkAI 平台统一接入文本、视觉、图像、语音�
 
 | 模型 ID | 别名 |
 | --- | --- |
+| `gpt-image-2.5-flare` | OpenAI |
+| `gpt-image-2.5-sunburst` | OpenAI |
 | `gpt-image-2` | OpenAI |
 | `gemini-3.1-flash-image-preview` | Nano Banana 2 |
 | `gemini-3-pro-image-preview` | Nano Banana Pro |

--- a/docs/zh/models/openai.mdx
+++ b/docs/zh/models/openai.mdx
@@ -51,13 +51,13 @@ OpenAI 是覆盖最完整的厂商，可同时承担文本对话、视觉理解�
 {
   "skills": {
     "image-generation": {
-      "model": "gpt-image-2"
+      "model": "gpt-image-2.5-flare"
     }
   }
 }
 ```
 
-支持的图像生成模型：`gpt-image-2`、`gpt-image-1`。
+支持的图像生成模型：`gpt-image-2.5-flare`（推荐默认）、`gpt-image-2.5-sunburst`、`gpt-image-2`、`gpt-image-1`。
 
 ## 语音识别
 

--- a/docs/zh/skills/image-generation.mdx
+++ b/docs/zh/skills/image-generation.mdx
@@ -9,7 +9,7 @@ description: 文生图 / 图生图 / 多图融合，支持多家厂商自动路�
 
 | 厂商 | 模型 / 别名 | 特点 |
 | --- | --- | --- |
-| OpenAI | `gpt-image-2`、`gpt-image-1` | 通用文生图，高质量，支持 `quality` 控制画质 |
+| OpenAI | `gpt-image-2.5-flare`、`gpt-image-2.5-sunburst`、`gpt-image-2`、`gpt-image-1` | 通用文生图，高质量，支持 `quality` 控制画质 |
 | Gemini Nano Banana | `nano-banana-2`、`nano-banana-pro`、`nano-banana` | 对应 `gemini-3.1-flash`、`gemini-3-pro`、`gemini-2.5-flash` 的图像版本 |
 | Seedream（火山方舟） | `seedream-5.0-lite`、`seedream-4.5` | 原生 2K–4K，最多 14 张图融合 |
 | Qwen（百炼） | `qwen-image-2.0`、`qwen-image-2.0-pro` | 擅长中文排版和图文融合 |

--- a/skills/image-generation/SKILL.md
+++ b/skills/image-generation/SKILL.md
@@ -19,7 +19,7 @@ Generate and edit images using AI models. The script automatically picks a backe
 
 Supported models (passed via `model` only when the user asks for a specific one):
 
-- **OpenAI** — `gpt-image-2`, `gpt-image-1`
+- **OpenAI** — `gpt-image-2.5-flare` (recommended default: best quality/latency trade-off), `gpt-image-2.5-sunburst` (highest editing precision), `gpt-image-2`, `gpt-image-1`
 - **Gemini Nano Banana** — `nano-banana-2`, `nano-banana-pro`, `nano-banana`
 - **Seedream (Volcengine Ark)** — `seedream-5.0-lite`, `seedream-4.5`
 - **Qwen (DashScope)** — `qwen-image-2.0`, `qwen-image-2.0-pro`

--- a/skills/image-generation/scripts/generate.py
+++ b/skills/image-generation/scripts/generate.py
@@ -10,6 +10,7 @@ OpenAI → Gemini → Seedream → Qwen → MiniMax → LinkAI; missing API keys
 are skipped, and the provider that natively owns the requested model is
 promoted to the front of the queue):
 
+    - gpt-image-2.5-flare / gpt-image-2.5-sunburst → OpenAI
     - gpt-image-2 / gpt-image-1                    → OpenAI
     - nano-banana / gemini-*-image-*               → Gemini
     - doubao-seedream-* / seedream-*               → Seedream (Volcengine Ark)
@@ -253,13 +254,14 @@ class ImageProvider(ABC):
 
 
 # ---------------------------------------------------------------------------
-# OpenAI-compatible provider (gpt-image-2, gpt-image-1)
+# OpenAI-compatible provider
+# (gpt-image-2.5-flare, gpt-image-2.5-sunburst, gpt-image-2, gpt-image-1)
 # ---------------------------------------------------------------------------
 
 class OpenAIProvider(ImageProvider):
     """Provider for OpenAI Image API (generations + edits)."""
 
-    DEFAULT_MODEL = "gpt-image-2"
+    DEFAULT_MODEL = "gpt-image-2.5-flare"
 
     def __init__(self, api_key: str, api_base: str, model: str):
         self.api_key = api_key
@@ -416,7 +418,7 @@ class OpenAIProvider(ImageProvider):
 class LinkAIProvider(ImageProvider):
     """Provider for LinkAI unified image generation API."""
 
-    DEFAULT_MODEL = "gpt-image-2"
+    DEFAULT_MODEL = "gpt-image-2.5-flare"
 
     def __init__(self, api_key: str, api_base: str, model: str):
         self.api_key = api_key
@@ -1061,6 +1063,7 @@ class MinimaxProvider(ImageProvider):
 # When the requested model matches a prefix, that provider is promoted to the
 # front of the queue. All other configured providers still run as fallbacks.
 _MODEL_PREFERRED_PROVIDER: list[tuple[tuple[str, ...], str]] = [
+    (("gpt-image-2.5",), "OpenAI"),
     (("gpt-image",), "OpenAI"),
     (("nano-banana", "gemini-"), "Gemini"),
     (("seedream", "doubao-seedream"), "Seedream"),

--- a/tests/test_image_generation_model_routing.py
+++ b/tests/test_image_generation_model_routing.py
@@ -1,0 +1,70 @@
+"""Routing and default-model tests for the image-generation skill.
+
+Covers the gpt-image-2.5 family: the new ids must resolve to the OpenAI
+provider, and the recommended default must be gpt-image-2.5-flare on both
+the OpenAI and LinkAI backends.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).parents[1]
+    / "skills"
+    / "image-generation"
+    / "scripts"
+    / "generate.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "image_generation_routing_script",
+    SCRIPT_PATH,
+)
+image_generation = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(image_generation)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-image-2.5-flare",
+        "gpt-image-2.5-sunburst",
+        "gpt-image-2.5-flare-2026-09-09",
+        "GPT-Image-2.5-Flare",
+        "gpt-image-2",
+        "gpt-image-1",
+    ],
+)
+def test_gpt_image_models_route_to_openai(model):
+    assert image_generation._preferred_provider(model) == "OpenAI"
+
+
+def test_unknown_prefix_has_no_preferred_provider():
+    assert image_generation._preferred_provider("some-other-model") is None
+
+
+def test_openai_default_model_is_recommended_flare():
+    assert image_generation.OpenAIProvider.DEFAULT_MODEL == "gpt-image-2.5-flare"
+
+
+def test_linkai_default_model_is_recommended_flare():
+    assert image_generation.LinkAIProvider.DEFAULT_MODEL == "gpt-image-2.5-flare"
+
+
+def test_explicit_model_overrides_default():
+    provider = image_generation.OpenAIProvider(
+        api_key="k",
+        api_base="https://api.openai.com/v1",
+        model="gpt-image-2.5-sunburst",
+    )
+    assert provider.model == "gpt-image-2.5-sunburst"
+
+
+def test_empty_model_falls_back_to_default():
+    provider = image_generation.OpenAIProvider(
+        api_key="k",
+        api_base="https://api.openai.com/v1",
+        model="",
+    )
+    assert provider.model == "gpt-image-2.5-flare"


### PR DESCRIPTION
Closes #3139

Adds support for the two new OpenAI image models and makes `gpt-image-2.5-flare` the recommended default.

## Why

OpenAI shipped the GPT-Image 2.5 family: `gpt-image-2.5-flare` is the mainstream model (same quality as 2.0 with up to 50% lower latency) and `gpt-image-2.5-sunburst` targets high-precision editing workflows. CowAgent only knew about `gpt-image-2` / `gpt-image-1`, so the new ids were neither documented nor selectable.

## Changes

| File | Change |
| --- | --- |
| `skills/image-generation/scripts/generate.py` | List both ids in the provider docstring; promote the `gpt-image-2.5` prefix in `_MODEL_PREFERRED_PROVIDER`; set `OpenAIProvider.DEFAULT_MODEL` and `LinkAIProvider.DEFAULT_MODEL` to `gpt-image-2.5-flare` |
| `channel/web/web_channel.py` | Expose both ids in `_IMAGE_PROVIDER_MODELS["openai"]` and `["linkai"]`; update `_IMAGE_AUTO_ORDER` so the predicted default matches the runtime |
| `skills/image-generation/SKILL.md` | Document the new models and mark Flare as the recommended default |
| `docs/**/models/openai.mdx`, `docs/**/models/linkai.mdx`, `docs/**/skills/image-generation.mdx` (en/zh/ja) | Same, in all three languages |
| `tests/test_image_generation_model_routing.py` | New regression test for prefix routing and defaults |

`gpt-image-2` and `gpt-image-1` remain fully supported; the prefix entry for `gpt-image-2.5` is listed before `gpt-image` purely for explicitness (the existing `gpt-image` prefix already matched it).

## Verification

- `pytest tests/test_image_generation_model_routing.py` — 11 passed.
- All image-generation related suites (`test_image_generation_model_routing.py`, `test_image_generation_empty_b64.py`, `test_image_generation_custom_provider.py`, `test_custom_provider_handlers.py`) — 43 passed.
- Manual routing check: `_build_providers` resolves `gpt-image-2.5-flare` / `gpt-image-2.5-sunburst` to the OpenAI provider while preserving the requested model id; an empty model falls back to `gpt-image-2.5-flare`.
- Web UI lists verified: `ModelsHandler._IMAGE_PROVIDER_MODELS["openai"]` and `["linkai"]` now include both ids, and `_IMAGE_AUTO_ORDER` points at `gpt-image-2.5-flare`.
- Full `pytest tests/` shows the same 29 pre-existing failures on `master` and on this branch (unrelated to image generation), so no regression is introduced.