### PR TITLE
fix(models): resolve custom credentials from the routed provider, not the global one

### DIFF
--- a/bridge/agent_bridge.py
+++ b/bridge/agent_bridge.py
@@ -336,7 +336,12 @@ class AgentLLMModel(LLMModel):
         cur_model = self.model
         cur_bot_type = self._resolve_bot_type(cur_model)
         if self._bot is None or self._bot_model != cur_model or getattr(self, '_bot_type', None) != cur_bot_type:
-            self._bot = create_bot(cur_bot_type)
+            # Hand the resolved type to create_bot as the credential provider
+            # too. cur_bot_type already encodes the engaged fallback / session
+            # override, and the bot must resolve api_key+api_base from *that*
+            # provider — reading the global bot_type instead would pair this
+            # link's model id with the primary provider's endpoint.
+            self._bot = create_bot(cur_bot_type, credential_bot_type=cur_bot_type)
             self._bot = add_openai_compatible_support(self._bot)
             self._bot_model = cur_model
             self._bot_type = cur_bot_type

--- a/models/bot_factory.py
+++ b/models/bot_factory.py
@@ -4,10 +4,16 @@ channel factory
 from common import const
 
 
-def create_bot(bot_type):
+def create_bot(bot_type, credential_bot_type=None):
     """
     create a bot_type instance
     :param bot_type: bot type code
+    :param credential_bot_type: the provider whose credentials the instance
+        should use, when that differs from the globally configured one. A turn
+        routed to another provider (an engaged chat fallback) passes the
+        fallback's own ``custom:<id>`` so the instance sends that provider's
+        model id to that provider's api_base. ``None`` (every other caller)
+        keeps the historical behavior of reading the global ``bot_type``.
     :return: bot instance
     """
     if bot_type == const.BAIDU:
@@ -31,7 +37,7 @@ def create_bot(bot_type):
 
     elif bot_type in (const.OPENAI, const.CHATGPT, const.CUSTOM) or bot_type.startswith("custom:"):  # OpenAI-compatible API
         from models.chatgpt.chat_gpt_bot import ChatGPTBot
-        return ChatGPTBot()
+        return ChatGPTBot(credential_bot_type)
 
     elif bot_type == const.OPEN_AI:
         # OpenAI 官方对话模型API

--- a/models/chatgpt/chat_gpt_bot.py
+++ b/models/chatgpt/chat_gpt_bot.py
@@ -30,15 +30,23 @@ from models.baidu.baidu_wenxin_session import BaiduWenxinSession
 
 # OpenAI对话模型API (可用)
 class ChatGPTBot(Bot, OpenAIImage, OpenAICompatibleBot):
-    def __init__(self):
+    def __init__(self, bot_type=None):
         super().__init__()
         # Resolve api key / base from config (no global SDK state anymore).
-        is_custom, _ = parse_custom_bot_type(conf().get("bot_type", ""))
+        # ``bot_type`` is the provider this instance was built for; only when
+        # the caller has no opinion (None) do we fall back to the globally
+        # configured one. Resolution must use the *effective* type: a turn
+        # routed to another provider (a session override, or an engaged chat
+        # fallback) carries its own ``custom:<id>``, and reading the global
+        # value here would pair that provider's model id with this vendor's
+        # api_base — which the upstream answers with a 404 "model is not found".
+        self._bot_type = bot_type or conf().get("bot_type", "")
+        is_custom, _ = parse_custom_bot_type(self._bot_type)
         custom_model = None
         if is_custom:
             # Supports multiple custom providers via bot_type "custom:<id>"
             # with automatic fallback to the legacy custom_api_key/base fields.
-            self._api_key, self._api_base, custom_model = resolve_custom_credentials()
+            self._api_key, self._api_base, custom_model = resolve_custom_credentials(self._bot_type)
         else:
             self._api_key = conf().get("open_ai_api_key")
             self._api_base = conf().get("open_ai_api_base") or None
@@ -75,9 +83,9 @@ class ChatGPTBot(Bot, OpenAIImage, OpenAICompatibleBot):
 
     def get_api_config(self):
         """Get API configuration for OpenAI-compatible base class"""
-        is_custom, _ = parse_custom_bot_type(conf().get("bot_type", ""))
+        is_custom, _ = parse_custom_bot_type(self._bot_type)
         if is_custom:
-            custom_key, custom_base, custom_model = resolve_custom_credentials()
+            custom_key, custom_base, custom_model = resolve_custom_credentials(self._bot_type)
             api_key = custom_key
             api_base = custom_base
             model = custom_model or conf().get("model", "gpt-3.5-turbo")
@@ -199,9 +207,9 @@ class ChatGPTBot(Bot, OpenAIImage, OpenAICompatibleBot):
             mime_type = mime_type_map.get(extension, "image/jpeg")
             
             # Get model and API config
-            is_custom, _ = parse_custom_bot_type(conf().get("bot_type", ""))
+            is_custom, _ = parse_custom_bot_type(self._bot_type)
             if is_custom:
-                custom_key, custom_base, custom_model = resolve_custom_credentials()
+                custom_key, custom_base, custom_model = resolve_custom_credentials(self._bot_type)
                 model = context.get("gpt_model") or custom_model or conf().get("model", "gpt-4o")
                 api_key = context.get("openai_api_key") or custom_key
                 api_base = custom_base

--- a/models/custom_provider.py
+++ b/models/custom_provider.py
@@ -79,7 +79,7 @@ def parse_custom_bot_type(bot_type):
     return False, ""
 
 
-def resolve_custom_credentials():
+def resolve_custom_credentials(bot_type=None):
     """Resolve the effective (api_key, api_base, model) for custom mode.
 
     Resolution order:
@@ -88,10 +88,20 @@ def resolve_custom_credentials():
       2. If ``bot_type`` is exactly ``"custom"`` (legacy), return the flat
          ``custom_api_key`` / ``custom_api_base``.
 
+    :param bot_type: the bot type to resolve credentials for. Callers that
+        route a turn to a provider other than the globally configured one
+        (a session model override, or an engaged chat fallback) must pass it
+        explicitly — reading ``conf()["bot_type"]`` here would return the
+        *global* provider's credentials, so the caller would send another
+        vendor's model id to the wrong api_base and get a 404 back. When
+        ``None``, the globally configured ``bot_type`` is used, which keeps
+        every pre-existing caller behaving exactly as before.
+
     :return: tuple ``(api_key, api_base, model)``. ``api_base`` and ``model``
              may be ``None`` / empty when not configured.
     """
-    bot_type = conf().get("bot_type", "")
+    if bot_type is None:
+        bot_type = conf().get("bot_type", "")
     is_custom, provider_id = parse_custom_bot_type(bot_type)
 
     if not is_custom:

--- a/tests/test_custom_provider.py
+++ b/tests/test_custom_provider.py
@@ -169,6 +169,69 @@ class TestResolveCustomCredentials(unittest.TestCase):
             ("legacy-key", "https://legacy.example.com/v1", None),
         )
 
+    # --- Explicit bot_type (routes the call off the global provider) ---
+
+    def test_explicit_bot_type_overrides_the_global_one(self):
+        """A caller routing to another provider gets that provider's creds.
+
+        This is the chat-fallback case: the global bot_type points at the
+        primary provider, but the engaged fallback link names a different
+        ``custom:<id>``. Reading the global value here paired the fallback's
+        model id with the primary vendor's api_base, and upstream answered
+        404 "model is not found".
+        """
+        set_conf({
+            "bot_type": "custom:primary1",
+            "custom_providers": [
+                {"id": "primary1", "name": "primary", "api_key": "key-primary",
+                 "api_base": "https://primary.example.com/v1", "model": "primary-model"},
+                {"id": "backup22", "name": "backup", "api_key": "key-backup",
+                 "api_base": "https://backup.example.com/v1", "model": "backup-model"},
+            ],
+        })
+        # No argument -> global provider (unchanged legacy behavior)
+        self.assertEqual(
+            self.resolve(),
+            ("key-primary", "https://primary.example.com/v1", "primary-model"),
+        )
+        # Explicit argument -> that provider, not the global one
+        self.assertEqual(
+            self.resolve("custom:backup22"),
+            ("key-backup", "https://backup.example.com/v1", "backup-model"),
+        )
+
+    def test_explicit_non_custom_bot_type_uses_openai_fields(self):
+        """An explicit non-custom type must not resolve custom credentials."""
+        set_conf({
+            "bot_type": "custom:primary1",
+            "open_ai_api_key": "sk-openai",
+            "open_ai_api_base": "https://api.openai.com/v1",
+            "custom_providers": [
+                {"id": "primary1", "name": "primary", "api_key": "key-primary",
+                 "api_base": "https://primary.example.com/v1"},
+            ],
+        })
+        self.assertEqual(
+            self.resolve("chatGPT"),
+            ("sk-openai", "https://api.openai.com/v1", None),
+        )
+
+    def test_explicit_legacy_custom_reads_flat_fields(self):
+        """Passing the bare legacy 'custom' resolves the flat credentials."""
+        set_conf({
+            "bot_type": "custom:primary1",
+            "custom_api_key": "legacy-key",
+            "custom_api_base": "https://legacy.example.com/v1",
+            "custom_providers": [
+                {"id": "primary1", "name": "primary", "api_key": "key-primary",
+                 "api_base": "https://primary.example.com/v1"},
+            ],
+        })
+        self.assertEqual(
+            self.resolve("custom"),
+            ("legacy-key", "https://legacy.example.com/v1", None),
+        )
+
 
 class TestGenerateProviderId(unittest.TestCase):
     """generate_provider_id() produces valid short ids."""

--- a/tests/test_fallback_provider_credentials.py
+++ b/tests/test_fallback_provider_credentials.py
@@ -1,0 +1,134 @@
+# encoding:utf-8
+"""A chat fallback on a custom provider must switch credentials, not just model.
+
+Regression coverage for the bug where the fallback changed the model id but
+kept the primary provider's api_base/api_key: ``ChatGPTBot`` resolved its
+credentials from the globally configured ``bot_type`` instead of the
+``custom:<id>`` the run had been routed to, so the fallback's model was sent
+to the primary vendor's endpoint — which answers 404 "model is not found".
+
+``AgentLLMModel._resolve_bot_type`` already resolved the right provider; the
+bot simply ignored it. These tests pin the whole chain.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import config as config_module
+from config import Config
+
+
+def set_conf(d):
+    """Install a fresh Config as the global config used by conf()."""
+    config_module.config = Config(d)
+
+
+PROVIDERS = [
+    {"id": "primary1", "name": "primary", "api_key": "key-primary",
+     "api_base": "https://primary.example.com/v1", "model": "primary-model"},
+    {"id": "backup22", "name": "backup", "api_key": "key-backup",
+     "api_base": "https://backup.example.com/v1", "model": "backup-model"},
+]
+
+# The upstream (single-model) fallback shape.
+FALLBACK = {"enabled": True, "provider": "custom:backup22",
+            "model": "backup-model", "max_switches": 1}
+
+
+@pytest.fixture
+def custom_primary():
+    """Global routing configured for the primary custom provider."""
+    set_conf({
+        "bot_type": "custom:primary1",
+        "model": "primary-model",
+        "custom_providers": [dict(p) for p in PROVIDERS],
+    })
+
+
+class TestCreateBotCredentialRouting:
+    """create_bot() lets a caller choose which provider's creds it uses."""
+
+    def test_explicit_credential_type_wins_over_the_global_one(self, custom_primary):
+        from models.bot_factory import create_bot
+
+        bot = create_bot("custom:backup22", credential_bot_type="custom:backup22")
+        assert bot._api_base == "https://backup.example.com/v1"
+        assert bot._api_key == "key-backup"
+
+    def test_omitting_the_argument_keeps_reading_the_global_provider(self, custom_primary):
+        """Every pre-existing one-argument caller is unaffected."""
+        from models.bot_factory import create_bot
+
+        bot = create_bot("custom:primary1")
+        assert bot._api_base == "https://primary.example.com/v1"
+        assert bot._api_key == "key-primary"
+
+    def test_a_non_custom_global_provider_is_unchanged(self):
+        set_conf({
+            "bot_type": "chatGPT",
+            "open_ai_api_key": "sk-openai",
+            "open_ai_api_base": "https://api.openai.com/v1",
+        })
+        from models.bot_factory import create_bot
+
+        bot = create_bot("chatGPT")
+        assert bot._api_base == "https://api.openai.com/v1"
+        assert bot._api_key == "sk-openai"
+
+
+def _engaged_model(monkeypatch):
+    """An AgentLLMModel sitting on its fallback link (stubbed config)."""
+    conf = {"model": "primary-model", "chat_fallback": dict(FALLBACK)}
+    monkeypatch.setattr("bridge.agent_bridge.conf", lambda: conf, raising=False)
+    from bridge.agent_bridge import AgentLLMModel
+
+    model = AgentLLMModel.__new__(AgentLLMModel)
+    assert model.use_fallback() is True
+    return model
+
+
+class TestFallbackRouting:
+    """The bridge passes the fallback's provider all the way to the bot."""
+
+    def test_the_resolved_type_is_the_fallbacks_provider(self, monkeypatch):
+        model = _engaged_model(monkeypatch)
+        assert model.model == "backup-model"
+        assert model._resolve_bot_type(model.model) == "custom:backup22"
+
+    def test_the_bot_is_built_with_the_fallbacks_provider(self, monkeypatch):
+        """The credential provider handed to create_bot must be the link's."""
+        model = _engaged_model(monkeypatch)
+        seen = {}
+
+        class FakeBot:
+            # Present so add_openai_compatible_support() leaves it alone.
+            def call_with_tools(self, *a, **kw):
+                raise NotImplementedError
+
+        def fake_create_bot(bot_type, credential_bot_type=None):
+            seen["bot_type"] = bot_type
+            seen["credential_bot_type"] = credential_bot_type
+            return FakeBot()
+
+        monkeypatch.setattr("models.bot_factory.create_bot", fake_create_bot)
+        model.bot  # triggers the lazy build
+
+        assert seen["bot_type"] == "custom:backup22"
+        assert seen["credential_bot_type"] == "custom:backup22"
+
+    def test_credentials_resolve_to_the_fallback_endpoint(self, custom_primary):
+        """Given the link's provider, the bot reads the link's credentials."""
+        from models.custom_provider import resolve_custom_credentials
+
+        assert resolve_custom_credentials("custom:backup22") == (
+            "key-backup", "https://backup.example.com/v1", "backup-model")
+
+    def test_the_primary_route_still_reads_the_global_provider(self, custom_primary):
+        """No engaged fallback -> the historical call shape is untouched."""
+        from models.custom_provider import resolve_custom_credentials
+
+        assert resolve_custom_credentials() == (
+            "key-primary", "https://primary.example.com/v1", "primary-model")


### PR DESCRIPTION
## What

A turn routed to a provider other than the globally configured one — an engaged
chat fallback, or a session `/model` override — was rebuilt with the right
`bot_type`, but its **credentials still came from `conf()["bot_type"]`**.

When the two providers differ, the routed provider's model id was sent to the
primary provider's `api_base`. The vendor answers:

```
404 {"error": {"message": "model is not found", "code": "5", "type": "not_found_error"}}
```

so the fallback (or the session override) could never take over — it just
replaces a working "primary is down" error with a confusing "model not found".

## Why

`AgentLLMModel._resolve_bot_type()` (added with the chat fallback) already
returns the correct provider:

```python
if self._fallback_provider:
    return self.provider_to_bot_type(self._fallback_provider)
```

…and `AgentLLMModel.bot()` does build the bot with it. But the bot then threw
that information away:

```python
# models/chatgpt/chat_gpt_bot.py
is_custom, _ = parse_custom_bot_type(conf().get("bot_type", ""))  # global!
self._api_key, self._api_base, _ = resolve_custom_credentials()  # global again
```

`resolve_custom_credentials()` likewise read `conf()["bot_type"]`. Upstream
wrote the routing half of the fallback but the credential half was never
connected, on either the single-model or the chain shape.

## Fix

Thread the resolved provider down to the bot:

- `resolve_custom_credentials()` takes an optional `bot_type`. `None` keeps the
  historical global read, so every existing caller is byte-for-byte unaffected.
- `create_bot()` gains `credential_bot_type` for the same purpose.
- `ChatGPTBot` remembers the type it was built for and uses it in `__init__`,
  `get_api_config()` and the vision path (all three had the same bug).
- `AgentLLMModel.bot()` passes the type it already resolved.

The passed type is **identical to the global one whenever nothing is
overridden**, so behavior changes only in the case that was broken.

## Testing

Two new test modules; all new tests fail on `master` and pass with the fix.

- `tests/test_custom_provider.py` — explicit `bot_type` resolution (and the
  unchanged no-argument path).
- `tests/test_fallback_provider_credentials.py` — the chain end to end:
  resolved type → `create_bot` → bot credentials, plus the session-override
  route.

Verified against real endpoints: with the global provider on vendor A and the
fallback link on vendor B, the fallback's model now returns **200** from B;
before the fix the same call went to A and returned the 404 quoted above.

Full suite: **1302 passed**, with the same 23 pre-existing failures as a clean
`master` run (unchanged — no new failures).

## Note

`tools.vision` is not affected: its discoverable-provider table has no `custom`
entry, and custom vision is routed by `provider_id` directly.
