### PR TITLE
fix(desktop): bump client version to 2.1.8

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cowagent-desktop",
-  "version": "2.1.5",
+  "version": "2.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cowagent-desktop",
-      "version": "2.1.5",
+      "version": "2.1.8",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cowagent-desktop",
-  "version": "2.1.6",
+  "version": "2.1.8",
   "description": "CowAgent Desktop Client - AI Agent on your desktop",
   "main": "dist/main/index.js",
   "author": "CowAgent",

--- a/desktop/src/renderer/src/layout/NavRail.tsx
+++ b/desktop/src/renderer/src/layout/NavRail.tsx
@@ -41,7 +41,7 @@ import { product } from '@product'
 // Fallback shown when app.getVersion() is unavailable (dev/web preview). Keep
 // in sync with desktop/package.json "version"; the packaged app overrides this
 // with the real value via IPC, so it only matters outside a packaged build.
-const FALLBACK_VERSION = '2.1.5'
+const FALLBACK_VERSION = '2.1.8'
 
 // External links opened in the user's default browser. The window-open handler
 // in the main process routes window.open() through shell.openExternal.


### PR DESCRIPTION
## Problem

The desktop client still reports version **2.1.6** in local runs, long after 2.1.7 and 2.1.8 shipped. Running the client from source shows a version number that no longer matches the project.

## Root cause

Three places carry a client version, and they had drifted apart:

| Source | Value | Used by |
| --- | --- | --- |
| `cli/VERSION` | 2.1.8 | backend `cli.__version__`, served via `/api/version` |
| `desktop/package.json` | **2.1.6** | `app.getVersion()` — what the client shows in dev |
| `desktop/package-lock.json` | **2.1.5** | npm/lockfile metadata |
| `NavRail.tsx` `FALLBACK_VERSION` | **2.1.5** | dev / web-preview label when IPC is unavailable |

Release builds rewrite `package.json` with `npm version` before packaging (`release.yml`, `release-overlay.yml`), so packaged installers were always correct — only unpackaged/dev runs surfaced the stale number. That is why it went unnoticed.

## Changes

- `desktop/package.json`: `2.1.6` → `2.1.8`
- `desktop/package-lock.json`: `2.1.5` → `2.1.8`
- `NavRail.tsx` `FALLBACK_VERSION`: `2.1.5` → `2.1.8`

All three now match `cli/VERSION` (2.1.8), the version the backend already reports.

## Verification

- Consistency check across all four version sources: **all match 2.1.8**
- `package.json` / `package-lock.json` parse as valid JSON
- `git diff --check`: no whitespace errors; diff is 3 files, +4/-4, no unrelated changes
- Version bump applied with `npm version --no-git-tag-version`, the same command used in the release workflow

## Notes

`node_modules` is not installed in this environment, so `tsc` was not run. The only source change is a single string literal in a `const`, which cannot affect type checking.