### PR TITLE
fix(baidu): reply with an error instead of crashing on image-create

### DIFF
--- a/models/baidu/baidu_wenxin.py
+++ b/models/baidu/baidu_wenxin.py
@@ -66,12 +66,13 @@ class BaiduWenxinBot(Bot):
                         reply = Reply(ReplyType.TEXT, reply_content)
                 return reply
             elif context.type == ContextType.IMAGE_CREATE:
-                ok, retstring = self.create_img(query, 0)
-                reply = None
-                if ok:
-                    reply = Reply(ReplyType.IMAGE_URL, retstring)
-                else:
-                    reply = Reply(ReplyType.ERROR, retstring)
+                # The Wenxin API has no image-generation backend in this project,
+                # so this class has no create_img(). The image-create prefix used
+                # to call it anyway and raise AttributeError, which the channel
+                # worker logs and swallows -- the user got no reply at all.
+                # Answer with the same "unsupported type" error the other
+                # text-only bots return.
+                reply = Reply(ReplyType.ERROR, "Bot不支持处理{}类型的消息".format(context.type))
                 return reply
 
     def reply_text(self, session: BaiduWenxinSession, retry_count=0):

--- a/tests/test_baidu_wenxin_image_create.py
+++ b/tests/test_baidu_wenxin_image_create.py
@@ -1,0 +1,32 @@
+"""Regression tests for the image-create prefix on the Baidu Wenxin bot.
+
+`BaiduWenxinBot` only inherits the bare `Bot` base class, which defines no
+`create_img()`. The IMAGE_CREATE branch called `self.create_img(query, 0)`
+anyway, so an image-create prefix ("画图 ...") raised AttributeError inside the
+channel worker, which logs and swallows it -- the user got no reply at all.
+"""
+
+from bridge.context import Context, ContextType
+from bridge.reply import Reply, ReplyType
+from models.baidu.baidu_wenxin import BaiduWenxinBot
+
+
+def _bot():
+    # The IMAGE_CREATE branch touches nothing that __init__ builds, and __init__
+    # needs the session manager plus the Baidu config keys.
+    return BaiduWenxinBot.__new__(BaiduWenxinBot)
+
+
+def test_image_create_replies_with_error_instead_of_raising():
+    reply = _bot().reply("a cat", Context(ContextType.IMAGE_CREATE, "a cat"))
+
+    assert isinstance(reply, Reply)
+    assert reply.type == ReplyType.ERROR
+
+
+def test_image_create_error_matches_the_other_bots_wording():
+    # Same text every other bot without image generation returns, so the
+    # message a user sees does not depend on which model is configured.
+    reply = _bot().reply("a cat", Context(ContextType.IMAGE_CREATE, "a cat"))
+
+    assert reply.content == "Bot不支持处理{}类型的消息".format(ContextType.IMAGE_CREATE)


### PR DESCRIPTION
## What does this PR do?

`BaiduWenxinBot` answered the image-create prefix (`"画图 ..."`) with an `AttributeError` instead of a reply. This PR makes that branch return the same "unsupported type" error every other text-only bot returns, and adds a regression test for it.

## Problem

`BaiduWenxinBot` (`models/baidu/baidu_wenxin.py`) inherits the bare `Bot` base class, which defines no `create_img()`. The `IMAGE_CREATE` branch called it anyway:

```python
elif context.type == ContextType.IMAGE_CREATE:
    ok, retstring = self.create_img(query, 0)
```

So any message matching `image_create_prefix` raised inside `reply()`:

```
File "models/baidu/baidu_wenxin.py", line 69, in reply
    ok, retstring = self.create_img(query, 0)
AttributeError: 'BaiduWenxinBot' object has no attribute 'create_img'
```

`channel/chat_channel.py:171-174` sets `context.type = ContextType.IMAGE_CREATE` when the content matches `image_create_prefix`, and `channel/chat_channel.py:233` forwards that to `Bridge().fetch_reply_content()` → `bot.reply()`. Nothing on that path handles the exception, so it surfaces in the worker thread, where `channel/chat_channel.py:452` does `logger.exception(...)` and nothing else — **the user gets no reply at all**, just a traceback in the log.

`BaiduWenxinBot` is the only bot routed through `IMAGE_CREATE` without an image backend:

| bot | `IMAGE_CREATE` handling |
|---|---|
| `ChatGPTBot`, `OpenAIBot` | `create_img()` from the `OpenAIImage` mixin |
| `ClaudeAPIBot` | `create_img()` from the `OpenAIImage` mixin |
| `ZHIPUAIBot` | `create_img()` from the `ZhipuAIImage` mixin |
| `LinkAIBot` | `create_img()`, guarded by the `text_to_image` switch |
| `ModelScopeBot` | own `create_img()` |
| `BaiduWenxinBot` | **calls a `create_img()` that does not exist** |

## Solution

The Wenxin API has no image-generation backend in this project — `skills/image-generation` ships providers for OpenAI, LinkAI, Gemini, Seedream, Qwen and MiniMax, and none of them covers Wenxin — so there is nothing to delegate to. The branch now returns the wording the other text-only bots already use for an unsupported context type (shared by 13 files under `models/`, e.g. `models/deepseek/deepseek_bot.py:168`, `models/modelscope/modelscope_bot.py:108`):

```python
reply = Reply(ReplyType.ERROR, "Bot不支持处理{}类型的消息".format(context.type))
```

This makes the failure visible to the user instead of silent, keeps the message consistent no matter which model is configured, and removes the call to a method the class never had. Wiring up a real Wenxin image backend is a separate feature and deliberately out of scope here.

## Changes

- `models/baidu/baidu_wenxin.py` — the `IMAGE_CREATE` branch returns the shared unsupported-type `Reply` instead of calling the missing `create_img()` (+7 / −6).
- `tests/test_baidu_wenxin_image_create.py` — new regression test (32 lines).

No new dependencies, no API or signature changes.

## Testing

```
$ python -m pytest tests/test_baidu_wenxin_image_create.py -v
tests/test_baidu_wenxin_image_create.py::test_image_create_replies_with_error_instead_of_raising PASSED
tests/test_baidu_wenxin_image_create.py::test_image_create_error_matches_the_other_bots_wording PASSED
2 passed
```

Before / after for the same call (the bot is built with `__new__`, so no config or session state is involved):

```
# before
AttributeError: 'BaiduWenxinBot' object has no attribute 'create_img'

# after
Reply(type=ERROR, content=Bot不支持处理IMAGE_CREATE类型的消息)
```

Also ran the neighbouring model/provider test files (`test_agent_model_defaults`, `test_custom_provider`, `test_custom_provider_handlers`, `test_models_handler`, `test_dashscope_provider`, `test_qianfan_provider`, `test_minimax_provider`) — 114 passed.

Full-suite run: 1328 passed / 51 failed / 29 skipped, against 1313 passed / 47 failed / 30 skipped before the change. Every pre-existing failure is environmental on this machine (Windows symlink privileges, missing `pypdf`, browser engine not installed). The four failures that differed between the two runs are all in `tests/test_evolution_safety.py` and `tests/test_security_read_env_bypass.py` — files this PR does not touch — and they pass when those files are run on their own, so they are order/environment dependent here rather than caused by this change.

## Notes for Reviewer

Conflict check against my earlier PRs in this repo, all merged:

- #3137 — `agent/tools/utils/truncate.py`, `tests/test_tool_output_truncation.py`
- #3134 — `tests/test_claude_thinking.py`, `tests/test_dashscope_provider.py`
- #3133 — `skills/image-generation/scripts/generate.py`, `tests/test_image_generation_empty_b64.py`
- #3072 — `docs/ja/README.md`

Neither file in this PR appears in any of them, nor in any currently open PR, so there is no file overlap.

There is no issue for this one: at the time of writing the repo has no open issue labelled `good first issue`, `help wanted`, `bug` or `documentation`. Happy to open one if you would rather have it tracked.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [ ] Linked related issue (if any): closes #
