### PR TITLE
fix(translate): report the api error when every baidu retry fails

### DIFF
--- a/tests/test_baidu_translator.py
+++ b/tests/test_baidu_translator.py
@@ -1,0 +1,94 @@
+# encoding:utf-8
+"""
+Unit tests for the Baidu translator retry handling: when every retry of the
+transient error codes (52001/52002) fails, translate() must report the API
+error instead of a bare KeyError on the missing trans_result field.
+"""
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _mock_conf(**values):
+    """Build a callable that mimics config.conf() returning the provided dict."""
+    cfg = MagicMock()
+    cfg.get = MagicMock(side_effect=lambda key, default=None: values.get(key, default))
+    return MagicMock(return_value=cfg)
+
+
+def _response(payload):
+    response = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+def _make_translator():
+    with patch(
+        "translate.baidu.baidu_translate.conf",
+        _mock_conf(baidu_translate_app_id="appid123", baidu_translate_app_key="appkey456"),
+    ):
+        from translate.baidu.baidu_translate import BaiduTranslator
+
+        return BaiduTranslator()
+
+
+class TestBaiduTranslatorTranslate(unittest.TestCase):
+    def _post_returning(self, **kwargs):
+        return patch("translate.baidu.baidu_translate.requests.post", **kwargs)
+
+    def test_translate_success(self):
+        translator = _make_translator()
+        payload = {"trans_result": [{"src": "hello", "dst": "你好"}]}
+
+        with self._post_returning(return_value=_response(payload)) as mock_post:
+            result = translator.translate("hello", from_lang="en", to_lang="zh")
+
+        self.assertEqual(result, "你好")
+        mock_post.assert_called_once()
+        sent = mock_post.call_args.kwargs["params"]
+        self.assertEqual(sent["q"], "hello")
+        self.assertEqual(sent["from"], "en")
+        self.assertEqual(sent["to"], "zh")
+
+    def test_translate_retries_transient_error_then_succeeds(self):
+        translator = _make_translator()
+        responses = [
+            _response({"error_code": "52002", "error_msg": "系统错误"}),
+            _response({"trans_result": [{"dst": "你好"}]}),
+        ]
+
+        with self._post_returning(side_effect=responses) as mock_post:
+            result = translator.translate("hello")
+
+        self.assertEqual(result, "你好")
+        self.assertEqual(mock_post.call_count, 2)
+
+    def test_translate_non_retryable_error_raises_immediately(self):
+        translator = _make_translator()
+
+        with self._post_returning(
+            return_value=_response({"error_code": "54001", "error_msg": "Invalid Sign"})
+        ) as mock_post:
+            with self.assertRaises(Exception) as ctx:
+                translator.translate("hello")
+
+        self.assertIn("Invalid Sign", str(ctx.exception))
+        self.assertEqual(mock_post.call_count, 1)
+
+    def test_translate_retries_exhausted_raises_api_error(self):
+        """Every attempt hits a transient error: report it instead of a KeyError."""
+        translator = _make_translator()
+
+        with self._post_returning(
+            return_value=_response({"error_code": "52001", "error_msg": "请求超时"})
+        ) as mock_post:
+            with self.assertRaises(Exception) as ctx:
+                translator.translate("hello")
+
+        # 3 attempts, then a readable error rather than KeyError: 'trans_result'
+        self.assertEqual(mock_post.call_count, 3)
+        self.assertNotIsInstance(ctx.exception, KeyError)
+        self.assertIn("请求超时", str(ctx.exception))

--- a/translate/baidu/baidu_translate.py
+++ b/translate/baidu/baidu_translate.py
@@ -42,6 +42,11 @@ class BaiduTranslator(Translator):
                     raise Exception(result["error_msg"])
             else:
                 break
+        if retry_cnt == 0:
+            # every attempt hit a transient error (52001/52002), so the last
+            # response carries no trans_result: report the api error instead of
+            # letting the join below fail with a bare KeyError
+            raise Exception(result["error_msg"])
         text = "\n".join([item["dst"] for item in result["trans_result"]])
         return text
 


### PR DESCRIPTION
## Problem

`BaiduTranslator.translate` retries the transient Baidu error codes `52001` (request timeout) and `52002` (system error) up to three times:

```python
retry_cnt = 3
while retry_cnt:
    r = requests.post(self.url, params=payload, headers=headers)
    result = r.json()
    errcode = result.get("error_code", "52000")
    if errcode != "52000":
        if errcode == "52001" or errcode == "52002":
            retry_cnt -= 1
            continue
        else:
            raise Exception(result["error_msg"])
    else:
        break
text = "\n".join([item["dst"] for item in result["trans_result"]])
```

When the third attempt is also transient, the counter reaches `0` and the loop exits without `break`, so `result` still holds the *error* payload. The line after the loop then reads `result["trans_result"]` — a field an error response does not contain — and the caller gets `KeyError: 'trans_result'` instead of the reason the request failed. The retry budget is spent exactly on the case that reports the least useful error.

Reproduction (no network needed):

```python
# mock conf() so BaiduTranslator() can be constructed, then:
with patch("translate.baidu.baidu_translate.requests.post",
           return_value=response({"error_code": "52001", "error_msg": "请求超时"})):
    translator.translate("hello")
# master: KeyError('trans_result')   <- masks the api error, 3 requests wasted
```

## Solution

Raise the api error message once the retry counter is exhausted, so the third transient failure reports what actually went wrong. The success path, the transient-then-success path and the non-retryable path (`raise Exception(result["error_msg"])`, no retry) keep their current behaviour. No new dependency, no public interface change.

## Changes

- `translate/baidu/baidu_translate.py`: after the retry loop, if `retry_cnt` reached `0`, raise the api error instead of falling through to the missing `trans_result` field. +5 lines, the existing branches untouched.
- `tests/test_baidu_translator.py` (new): the baidu translator had no tests. Covers the retry loop's behaviour, following the layout of the existing `tests/test_youdao_translator.py`.

## Testing

```
python -m pytest tests/test_baidu_translator.py -q
4 passed
```

| Case | master | this PR |
| --- | --- | --- |
| success response | ok | ok |
| `52002` then success | retries, ok | retries, ok |
| non-retryable `54001` | raises api error, 1 request | unchanged |
| all three attempts `52001` | `KeyError: 'trans_result'` | `Exception: 请求超时` |

The last case is the regression test: it fails against `master` with `KeyError('trans_result')` and passes with the patch (verified locally by reverting the one-hunk fix and re-running).

Existing suite: `tests/test_youdao_translator.py` (17 passed, the sibling translator) and the full `tests/` run (1470 tests) show no new failures. The pre-existing failures reported on this machine are in unrelated, environment-dependent areas (`test_security_ssrf_browser_navigate`, `test_memory_global_config`, `test_agent_admin`, `test_shared_db_recovery`, ...); none of those files import `translate` at all, and re-running the same files with and without the patch produces an identical failure set.

## Notes for Reviewer

- Scope: 2 files, 99 added lines (5 in the module, 94 of tests), no new dependency, no refactor, branch `fix-baidu-translate-retry-exhausted`.
- `translate/` has had no changes in the last 60 days and no open PR touches it, so the conflict risk here is zero.
- My earlier PRs in this repo — #3144, #3137, #3134, #3133, #3072 — touch `models/baidu/baidu_wenxin.py`, `agent/tools/utils/truncate.py`, `skills/image-generation/scripts/generate.py`, `docs/ja/README.md` and their tests. None of those files overlap with this PR: different subsystem (`models/` vs `translate/`), no conflict expected.
- Deliberately not touched, to keep the patch focused: the adjacent `raise Exception(result["error_msg"])` would also `KeyError` if a response ever carried an `error_code` without `error_msg`. Happy to extend the patch if you want that hardened too.
