### PR TITLE
fix(voice): decode silk into its own wav before re-encoding to mp3

### DIFF
--- a/tests/test_audio_convert.py
+++ b/tests/test_audio_convert.py
@@ -1,0 +1,85 @@
+# encoding:utf-8
+"""Regression tests for the silk branch of voice.audio_convert.any_to_mp3.
+
+It used to decode onto the caller's own file and then re-encode from a path that
+had not been written yet: the conversion always failed, and the voice file the
+caller fell back to had already been overwritten with wav bytes.
+"""
+import os
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import voice.audio_convert as audio_convert
+
+
+class _FakeSegment:
+    """Minimal stand-in for pydub's AudioSegment."""
+
+    def export(self, out_path, format=None):
+        with open(out_path, "wb") as f:
+            f.write(b"mp3-bytes")
+
+
+class TestAnyToMp3Silk(unittest.TestCase):
+    SILK_BYTES = b"SILK" + b"\x02\x00" * 8
+    DECODED_WAV = b"RIFF" + b"\x00" * 44
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory(prefix="audio-convert-")
+        self.addCleanup(self._tmp.cleanup)
+        self.src = os.path.join(self._tmp.name, "wx_1.silk")
+        self.dst = os.path.join(self._tmp.name, "wx_1.mp3")
+        with open(self.src, "wb") as f:
+            f.write(self.SILK_BYTES)
+        # pydub is an optional extra (requirements-optional.txt).
+        guard = patch.object(audio_convert, "_pydub_available", True)
+        guard.start()
+        self.addCleanup(guard.stop)
+
+    def _convert(self):
+        """Convert and report what AudioSegment.from_file was handed.
+
+        Each entry is (path, existed): a reader can only open a path that is
+        already on disk. pysilk is an optional native dependency, so its
+        decoder is stubbed -- sil_to_wav itself still does real file I/O.
+        """
+        reads = []
+
+        def from_file(path, *args, **kwargs):
+            reads.append((path, os.path.exists(path)))
+            if not os.path.exists(path):
+                raise FileNotFoundError(path)
+            return _FakeSegment()
+
+        pysilk = SimpleNamespace(
+            decode_file=lambda path, to_wav=False, sample_rate=None: self.DECODED_WAV
+        )
+        segment = SimpleNamespace(from_file=from_file)
+        with patch.object(audio_convert, "pysilk", pysilk, create=True), patch.object(
+            audio_convert, "AudioSegment", segment
+        ):
+            audio_convert.any_to_mp3(self.src, self.dst)
+        return reads
+
+    def test_source_voice_file_is_left_untouched(self):
+        self._convert()
+        with open(self.src, "rb") as f:
+            self.assertEqual(f.read(), self.SILK_BYTES)
+
+    def test_decoded_audio_is_read_from_a_file_that_exists(self):
+        reads = self._convert()
+        self.assertEqual(len(reads), 1)
+        path, existed = reads[0]
+        self.assertTrue(existed, f"{path} was read before it existed")
+        self.assertTrue(path.endswith(".wav"), path)
+
+    def test_mp3_is_written_and_the_scratch_wav_is_removed(self):
+        reads = self._convert()
+        with open(self.dst, "rb") as f:
+            self.assertEqual(f.read(), b"mp3-bytes")
+        self.assertFalse(os.path.exists(reads[0][0]), "scratch wav left behind")

--- a/voice/audio_convert.py
+++ b/voice/audio_convert.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import wave
 
@@ -55,11 +56,20 @@ def any_to_mp3(any_path, mp3_path):
     if any_path.endswith(".mp3"):
         shutil.copy2(any_path, mp3_path)
         return
+    sil_wav_path = None
     if any_path.endswith(".sil") or any_path.endswith(".silk") or any_path.endswith(".slk"):
-        sil_to_wav(any_path, any_path)
-        any_path = mp3_path
-    audio = AudioSegment.from_file(any_path)
-    audio.export(mp3_path, format="mp3")
+        # pysilk decodes silk into wav only, so the audio needs a wav file of
+        # its own: decoding onto any_path overwrote the caller's voice file and
+        # then left nothing at mp3_path to read.
+        sil_wav_path = os.path.splitext(any_path)[0] + ".silk.wav"
+        sil_to_wav(any_path, sil_wav_path)
+        any_path = sil_wav_path
+    try:
+        audio = AudioSegment.from_file(any_path)
+        audio.export(mp3_path, format="mp3")
+    finally:
+        if sil_wav_path and os.path.exists(sil_wav_path):
+            os.remove(sil_wav_path)
 
 
 def any_to_wav(any_path, wav_path):


### PR DESCRIPTION
## Problem

`any_to_mp3` never worked for silk input, and it damaged the caller's file while failing:

```python
if any_path.endswith(".sil") or any_path.endswith(".silk") or any_path.endswith(".slk"):
    sil_to_wav(any_path, any_path)   # decodes onto the caller's own file
    any_path = mp3_path              # then reads a file that was never written
audio = AudioSegment.from_file(any_path)
audio.export(mp3_path, format="mp3")
```

Two defects on that branch:

1. **The source is overwritten.** `sil_to_wav(any_path, any_path)` decodes the silk
   bytes and writes them straight back over the caller's voice file.
2. **The conversion always fails.** `any_path` is then repointed at `mp3_path`, which
   has not been created yet, so the read raises.

This is on a live path, not a dead branch. Incoming WeChat voice messages are persisted
with a `.silk` extension (`channel/weixin/weixin_message.py:154`, `:190`), and both ASR
providers route `.silk`/`.slk` into `any_to_mp3` before uploading:

- `voice/dashscope/dashscope_voice.py:144` → `:147`
- `voice/zhipuai/zhipuai_voice.py:169`

Both callers swallow the exception, log `mp3 convert failed` and return the **original**
path — which now holds wav bytes under a `.silk` name. So every WeChat voice message
transcribed through DashScope or ZhipuAI fails, and the locally cached voice file is
left corrupted for any later retry.

### Reproduction

No network, and neither `pysilk` nor `ffmpeg` is needed:

```python
import os, sys, types
sys.path.insert(0, "<repo>")
fake = types.ModuleType("pysilk")
fake.decode_file = lambda path, to_wav=False, sample_rate=None: b"RIFF" + b"\x00" * 44
sys.modules["pysilk"] = fake          # optional native dep; only decode_file is used
import voice.audio_convert as ac

# sil_to_wav runs for real; AudioSegment records the path it is handed
ac.AudioSegment = types.SimpleNamespace(from_file=lambda p, *a, **k: print(p, os.path.exists(p)))
ac.any_to_mp3("wx_1234.silk", "wx_1234.mp3")
```

| | before | after |
| --- | --- | --- |
| path handed to `AudioSegment` | `wx_1234.mp3`, **not on disk** | `wx_1234.silk.wav`, on disk |
| outcome | `FileNotFoundError` | mp3 written |
| source file | `SILK…` → `RIFF…` (corrupted) | unchanged |
| mp3 produced | no | yes |

## Solution

Decode the silk bytes into a wav file of their own, re-encode from that file, and remove
it afterwards:

```python
sil_wav_path = None
if any_path.endswith(".sil") or ... :
    sil_wav_path = os.path.splitext(any_path)[0] + ".silk.wav"
    sil_to_wav(any_path, sil_wav_path)
    any_path = sil_wav_path
try:
    audio = AudioSegment.from_file(any_path)
    audio.export(mp3_path, format="mp3")
finally:
    if sil_wav_path and os.path.exists(sil_wav_path):
        os.remove(sil_wav_path)
```

The scratch file is deliberately **named `.wav`**: pydub decides by extension whether it
can read a file with the stdlib `wave` module, and only falls back to ffprobe/ffmpeg for
anything else. Measured on this machine (pydub 0.25.1, no ffmpeg installed):

```
real wav written: 4844 bytes
from_file(..wav) OK, ms = 100 (no ffmpeg needed)
from_file(..mp3 holding wav) FAILED: FileNotFoundError [WinError 2]
```

So decoding into a `.wav` file keeps the read side ffmpeg-free; writing the same bytes
into a `.mp3` path would push them through ffprobe for no reason. Any other branch of
`any_to_mp3` is untouched, and the signature is unchanged.

## Changes

| file | change |
| --- | --- |
| `voice/audio_convert.py` | `any_to_mp3` silk branch decodes to a scratch `.wav`, re-encodes from it, deletes it in a `finally`; add the `os` import |
| `tests/test_audio_convert.py` | new — the silk branch had no coverage |

## Testing

`voice/audio_convert.py` had no tests at all. The new file is 3 focused cases, all on the
regression:

- the source voice file is byte-identical after the call
- the path handed to `AudioSegment.from_file` exists and ends in `.wav`
- the mp3 is written, and the scratch wav is gone

Verified both directions:

| | `pytest tests/test_audio_convert.py` |
| --- | --- |
| this branch | **3 passed** |
| same tests against the unmodified module (fix reverted) | **3 failed** — `FileNotFoundError: …/wx_1.mp3` |

`pysilk` is an optional native dependency and is not installed here, so its decoder is
stubbed; `sil_to_wav` still performs real file I/O. `_pydub_available` is patched so the
suite does not depend on the optional `pydub` extra being present. `ffmpeg` is not
installed on this machine either, so the final `export` is exercised against a stub
`AudioSegment` rather than a real encoder — the regression is about *which path is read*,
which is what the assertions pin down.

Full suite (`pytest tests -q`): failing set unchanged from `master` — no test outside the
new file references `voice.audio_convert`, so nothing existing can regress. (The repo
already carries ~40 environment-dependent failures on Windows: symlink permissions,
missing `pypdf`, browser engines, Linux-only paths.)

## Notes for Reviewer

- Scope: 2 files, +15/−4 in the module and one new test file, no new dependencies, no
  signature or behaviour change on any other branch.
- Cold spot: `voice/audio_convert.py` last changed 2026-05-05 (`b80c3fe5`) and is not in
  the last 60 days of commits; no open PR touches it.
- Conflict risk with my earlier PRs is nil — they live in other subsystems
  (#3147 `translate/baidu/`, #3144 `models/baidu/`, #3137 `agent/tools/utils/`,
  #3134/#3133 tests and `skills/image-generation/`, #3072 `docs/ja/`).
- Two adjacent issues I noticed but deliberately did **not** touch, to keep this one
  change: `any_to_wav` passes `parameters=["-nostdin"]` to keep a background ffmpeg from
  inheriting stdin, while `any_to_mp3` passes none; and `get_pcm_from_wav` never closes
  the `wave` handle it opens. Happy to send those as separate PRs if useful.
