### PR TITLE
fix(linkai): classify media urls from the parsed url path

### DIFF
--- a/models/linkai/link_ai_bot.py
+++ b/models/linkai/link_ai_bot.py
@@ -18,6 +18,7 @@ import threading
 from common import memory, utils
 import base64
 import os
+from urllib.parse import urlparse
 
 
 def _linkai_base_url():
@@ -466,9 +467,10 @@ class LinkAIBot(Bot, OpenAICompatibleBot):
                 if max_send_num and i >= max_send_num:
                     continue
                 i += 1
-                if url.endswith(".mp4"):
+                url_path = urlparse(url).path.lower()
+                if url_path.endswith(".mp4"):
                     reply_type = ReplyType.VIDEO_URL
-                elif url.endswith(file_type):
+                elif url_path.endswith(file_type):
                     reply_type = ReplyType.FILE
                     url = _download_file(url)
                     if not url:
@@ -488,7 +490,7 @@ def _download_file(url: str):
         file_path = "tmp"
         if not os.path.exists(file_path):
             os.makedirs(file_path)
-        file_name = url.split("/")[-1]  # 获取文件名
+        file_name = os.path.basename(urlparse(url).path) or "download"  # 获取文件名
         file_path = os.path.join(file_path, file_name)
         response = requests.get(url)
         with open(file_path, "wb") as f:

--- a/tests/test_linkai_media_urls.py
+++ b/tests/test_linkai_media_urls.py
@@ -1,0 +1,56 @@
+# encoding:utf-8
+"""Regression tests for LinkAI media URL classification."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class _Channel:
+    def __init__(self):
+        self.sent = []
+
+    def send(self, reply, context):
+        self.sent.append(reply)
+
+
+def _send(monkeypatch, url):
+    from config import conf
+    from models.linkai import link_ai_bot
+    from models.linkai.link_ai_bot import LinkAIBot
+
+    monkeypatch.setitem(conf(), "max_media_send_count", 10)
+    monkeypatch.setitem(conf(), "media_send_interval", 0)
+    monkeypatch.setattr(link_ai_bot, "_download_file", lambda u: u)
+
+    channel = _Channel()
+    LinkAIBot._send_image(LinkAIBot.__new__(LinkAIBot), channel, None, [url])
+    return [r.type.name for r in channel.sent]
+
+
+def test_plain_image_url_is_sent_as_image(monkeypatch):
+    assert _send(monkeypatch, "https://cdn.example.com/pic.png") == ["IMAGE_URL"]
+
+
+def test_video_url_with_query_is_sent_as_video(monkeypatch):
+    assert _send(monkeypatch, "https://cdn.example.com/clip.mp4?token=abc") == ["VIDEO_URL"]
+
+
+def test_uppercase_extension_is_recognized(monkeypatch):
+    assert _send(monkeypatch, "https://cdn.example.com/clip.MP4") == ["VIDEO_URL"]
+
+
+def test_file_url_with_query_is_sent_as_file(monkeypatch):
+    assert _send(monkeypatch, "https://cdn.example.com/report.pdf?sig=xyz") == ["FILE"]
+
+
+def test_downloaded_file_name_excludes_query(monkeypatch, tmp_path):
+    from models.linkai import link_ai_bot
+
+    monkeypatch.setattr(
+        link_ai_bot.requests, "get", lambda url, **kw: type("R", (), {"content": b"x"})()
+    )
+    monkeypatch.chdir(tmp_path)
+    path = link_ai_bot._download_file("https://cdn.example.com/report.pdf?sig=1")
+    assert os.path.basename(path) == "report.pdf"


### PR DESCRIPTION
<!--
Thanks for your contribution! Please write this PR in English.
推荐使用英文填写，感谢 ❤️
-->

## What does this PR do?

Makes the LinkAI bot classify returned media URLs from their parsed URL path instead of the complete raw string.

`_send_image` chose the reply type with `url.endswith(".mp4")` / `url.endswith(file_type)`, and `_download_file` derived the saved file name with `url.split("/")[-1]`. Both read the whole string, so three cases were wrong:

- a media URL carrying query parameters never matched — `.../clip.mp4?token=abc` fell through to `IMAGE_URL`, so a returned video or document was sent as an image
- extension matching was case-sensitive — `.../clip.MP4` was sent as an image
- `.../download?name=report.pdf` did match `.pdf`, but produced the local file name `download?name=report.pdf`. On Windows `?` is not a legal file name character, so `open()` raised `OSError: [Errno 22] Invalid argument`; the exception is caught and logged, `_download_file` returns `None`, and the caller drops the file

The same pattern was applied to the keyword plugin in #3061.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): N/A

## Validation

Reproduced on unmodified `master` first, then re-ran the same script after the fix. `_send_image` was driven through `LinkAIBot.__new__` with a stub channel that records the reply type:

| input | before | after |
| --- | --- | --- |
| `https://cdn.example.com/pic.png` | `IMAGE_URL` | `IMAGE_URL` |
| `https://cdn.example.com/clip.mp4` | `VIDEO_URL` | `VIDEO_URL` |
| `https://cdn.example.com/clip.mp4?token=abc` | `IMAGE_URL` | `VIDEO_URL` |
| `https://cdn.example.com/clip.MP4` | `IMAGE_URL` | `VIDEO_URL` |
| `https://cdn.example.com/report.pdf?sig=xyz` | `IMAGE_URL` | `FILE` |

`_download_file("https://cdn.example.com/download?name=report.pdf")`:

- before: `OSError: [Errno 22] Invalid argument` on the local name containing `?`, so it returned `None` and the file was dropped
- after: saves the file as `download` under the `tmp` directory

Tests:

- `python -m pytest -q tests/test_linkai_media_urls.py` → `5 passed`
- `python -m pytest -q tests/test_linkai_media_urls.py tests/test_linkai_reasoning_effort.py` → `9 passed`
- the new file on unmodified `master`: `4 failed, 1 passed` — the four regression cases, while the plain-image happy path passes either way

Full suite: the failing set is unchanged from `master` in this environment (`fixed` minus `baseline` is empty). Those failures are pre-existing and environmental (Windows symlink permissions, missing optional dependencies, browser engines); none of them touch this module.

## Notes for Reviewer

- `models/linkai/link_ai_bot.py` was last touched by 55c5d1e0 (`error_generator` closure), which changed line 636 — about 140 lines below the 467–490 range this PR touches, so there is no overlap.
- None of the open PRs touch this file or `models/linkai/`.
- Scope is the two places that read the raw URL. The download flow, the exception handling and the surrounding logic are unchanged.
