### PR TITLE
fix(linkai): retry a failed midjourney reply by recursing into _send

### DIFF
--- a/plugins/linkai/midjourney.py
+++ b/plugins/linkai/midjourney.py
@@ -441,7 +441,7 @@ def _send(channel, reply: Reply, context, retry_cnt=0):
         logger.exception(e)
         if retry_cnt < 2:
             time.sleep(3 + 3 * retry_cnt)
-            channel.send(reply, context, retry_cnt + 1)
+            _send(channel, reply, context, retry_cnt + 1)
 
 
 def check_prefix(content, prefix_list):

--- a/tests/test_linkai_midjourney_send.py
+++ b/tests/test_linkai_midjourney_send.py
@@ -1,0 +1,57 @@
+"""Regression tests for the Midjourney plugin's channel-send retry.
+
+``plugins/linkai/midjourney.py::_send`` mirrors ``ChatChannel._send``
+(channel/chat_channel.py:437): on a transport failure it retries twice with a
+3s/6s backoff. The retry used to call ``channel.send`` with the retry counter
+as a third positional argument instead of recursing into ``_send``, so every
+real channel -- all of which declare ``send(self, reply, context)``
+(channel/channel.py:133) -- raised TypeError instead of retrying.
+"""
+
+from unittest.mock import patch
+
+import plugins
+from bridge.reply import Reply, ReplyType
+
+plugins.instance.current_plugin_path = "./plugins/linkai"
+import plugins.linkai.midjourney as midjourney  # noqa: E402,F401
+plugins.instance.current_plugin_path = None
+
+
+class _Channel:
+    """Fails the first ``fail_times`` sends, then accepts."""
+
+    def __init__(self, fail_times, exc=RuntimeError):
+        self.fail_times = fail_times
+        self.exc = exc
+        self.attempts = 0
+
+    def send(self, reply, context):
+        self.attempts += 1
+        if self.attempts <= self.fail_times:
+            raise self.exc("transport failure")
+
+
+def _run(fail_times, exc=RuntimeError):
+    channel = _Channel(fail_times, exc)
+    with patch.object(midjourney, "time") as clock:
+        midjourney._send(channel, Reply(ReplyType.INFO, "drawing done"), object())
+    return channel, clock
+
+
+def test_retries_until_the_send_succeeds():
+    channel, clock = _run(fail_times=2)
+    assert channel.attempts == 3
+    assert [c.args[0] for c in clock.sleep.call_args_list] == [3, 6]
+
+
+def test_gives_up_after_two_retries_without_raising():
+    channel, clock = _run(fail_times=99)
+    assert channel.attempts == 3
+    assert clock.sleep.call_count == 2
+
+
+def test_not_implemented_error_is_not_retried():
+    channel, clock = _run(fail_times=99, exc=NotImplementedError)
+    assert channel.attempts == 1
+    assert clock.sleep.call_count == 0


### PR DESCRIPTION
<!--
Thanks for your contribution! Please write this PR in English.
推荐使用英文填写，感谢 ❤️
-->

## What does this PR do?

Fixes the retry path in `plugins/linkai/midjourney.py::_send`.

`_send` is a copy of `ChatChannel._send` (`channel/chat_channel.py:437`), which
retries a failed send twice with a 3s/6s backoff by **recursing into itself**:

```python
self._send(reply, context, retry_cnt + 1)      # channel/chat_channel.py:447
```

The plugin copy forwarded the counter to `channel.send` instead:

```python
channel.send(reply, context, retry_cnt + 1)    # plugins/linkai/midjourney.py:444
```

Every channel declares `send(self, reply, context)` (`channel/channel.py:133`,
and that same two-argument signature in all 14 channel implementations), so the
third positional argument makes the retry raise

```
TypeError: send() takes 3 positional arguments but 4 were given
```

That `TypeError` is raised *inside* the `except` block, so it escapes `_send`
rather than being caught and retried. The message is therefore never retried at
all — the 3s/6s backoff sleeps and then fails to deliver — and because
`_send` is called from `_process_success_task` (`midjourney.py:319` and `:336`),
which runs on the task-polling thread started by `_do_check_task`, the exception
kills that thread: the generated image and the follow-up "drawing done" text are
both lost.

Forwarding the counter to `_send` restores both the retry and its bound. Because
the counter was never reaching `_send`, the recursion could never terminate on
its own either.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Refactor / chore

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/zhayujie/CowAgent/blob/master/CONTRIBUTING.md)
- [x] I tested this change locally
- [x] Code comments and docs are in English
- [x] Linked related issue (if any): closes #

## Changes

```diff
         if retry_cnt < 2:
             time.sleep(3 + 3 * retry_cnt)
-            channel.send(reply, context, retry_cnt + 1)
+            _send(channel, reply, context, retry_cnt + 1)
```

One line. No signature, config, or behaviour change beyond the retry actually
happening.

## Testing

The channel stub uses the real channel signature, so the wrong call is a
`TypeError` exactly as it is in production:

| | before | after |
| --- | --- | --- |
| `_send(...)` outcome | `RAISED TypeError: send() takes 3 positional arguments but 4 were given` | returns normally |
| `channel.send` attempts | **1** (retry never reached the channel) | **3** (1 + 2 retries) |
| sleeps | `[3]` | `[3, 6]` |

`tests/test_linkai_midjourney_send.py` (new, 3 cases):

- retry stops as soon as a send succeeds — asserts 3 attempts and the `[3, 6]` backoff schedule
- a permanently failing channel gives up after two retries without raising
- `NotImplementedError` is still not retried (one attempt, no sleep)

By reverting the one-hunk fix: `2 failed, 1 passed` — both retry cases fail with
`TypeError: _Channel.send() takes 3 positional arguments but 4 were given` at
`midjourney.py:444`. With the fix: `3 passed`.

`time.sleep` is patched in the tests, so the suite does not wait out the backoff.

## Notes for Reviewer

- Scope: 1 source line + 1 new test file. No new dependency, no architecture change.
- The plugin had no test coverage at all for `_send`; `tests/test_linkai_midjourney_send.py` follows the layout of the existing plugin tests (`tests/test_keyword_attachment_urls.py`) for loading a plugin module.
- Conflict risk is 0: `plugins/linkai/midjourney.py` is last touched by `04ef0907` (2024-10-31), is not in the last 60 days of commits, and no open PR touches `plugins/`. None of my earlier PRs (#3072, #3133, #3134, #3137, #3144, #3147, #3149, #3150) modify this file — note that `plugins/linkai/` (this change) and `models/linkai/` (#3150) are different subsystems.
- I deliberately left two unrelated nits alone to keep this one change: the log line above still says `[WX] sendMsg error` (copied from the WeChat channel), and `_send`'s retry does not skip `NotImplementedError` before logging a full traceback. Say the word if you want either in a follow-up.
